### PR TITLE
remove core-js and raf

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@cdssnc/gcui": "^0.0.16",
     "@zeit/next-sass": "^0.1.2",
-    "core-js": "^2.5.4",
     "express": "4.16.2",
     "i18next": "10.4.1",
     "i18next-browser-languagedetector": "2.1.0",
@@ -22,7 +21,6 @@
     "i18next-xhr-backend": "1.5.1",
     "next": "^5.1.0",
     "node-sass": "^4.8.3",
-    "raf": "^3.4.0",
     "raven-js": "^3.24.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,5 @@
 // @flow
 
-// for IE 9 and 10 compatibility
-import "core-js/es6/map";
-import "core-js/es6/set";
-import "raf/polyfill";
-
 import React, { Component } from "react";
 import {
   Container,


### PR DESCRIPTION
fixes #20 

We don't need this code since we don't need to support IE < 11 (and we couldn't get it to work anyway)
