### PR TITLE
Inject SENTRY_DSN and GA_UA into Docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           command: |
               docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-              docker build  -t "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}" -t "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:latest" .
+              docker build  -t "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}" -t "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:latest" --build-arg SENTRY_DSN="${SENTRY_DSN}" --build-arg GA_UA="${GA_UA}" .
               docker push "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
               docker push "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:latest"
           name: "Build and Deploy API Docker Image"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ LABEL Description="Government of Canada VAC Proof of Concept" Vendor="Canadian D
 WORKDIR /app
 ADD . .
 
+ARG SENTRY_DSN
+ENV SENTRY_DSN ${SENTRY_DSN}
+
+ARG GA_UA
+ENV GA_UA ${GA_UA}
+
 RUN yarn install && yarn build
 USER node
 


### PR DESCRIPTION
@szinck1 Could you take a look just to make sure if this makes sense? Both SENTRY_DSN and GA_UA are configured in Circle_CI. The idea is that they get passed to the node build process and then get written into the compiled code instead of their placeholders.