### PR TITLE
Added fallback pages for IE < 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # testing
 /coverage
+/cypress/screenshots
 
 # production
 /build

--- a/cypress/integration/fallback_spec.js
+++ b/cypress/integration/fallback_spec.js
@@ -1,0 +1,13 @@
+describe("Fallback tests", function() {
+  if (
+    Cypress.config("userAgent") ==
+    "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"
+  ) {
+    it("Visits the page with an incompatible browser (ex. IE < 11)", function() {
+      cy.visit("");
+      cy.contains(
+        "Your current version of this browser is not supported. Please update to the latest version."
+      );
+    });
+  }
+});

--- a/fallback-pages/browser-incompatible.html
+++ b/fallback-pages/browser-incompatible.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Your browser is not supported | Ton navigateur n'est pas supporté</title>
+    <link href="//cdn.muicss.com/mui-0.9.39-rc1/css/mui.min.css" rel="stylesheet" type="text/css"/>
+    <style>
+      /**
+       * Body CSS
+       */
+html,
+body {
+  height: 100%;
+}
+html,
+body
+{
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.004);
+}
+/**
+ * Content CSS
+ */
+#content-wrapper {
+  min-height: 100%;
+}
+</style>
+</head>
+<body>
+  <div id="content-wrapper" class="mui--text-center">
+    <br/>
+    <br/>
+    <p>
+      Your current version of this browser is not supported. Please update to the latest version.      
+    </p>
+    <p>
+      Votre version actuelle de ce navigateur n'est pas supportée. S'il vous plaît mettre à jour à la dernière version.
+    </p>
+  </div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint": "node_modules/eslint/bin/eslint.js pages components __tests__",
     "precommit": "pretty-quick --staged",
     "cypress:wait": "wait-on http://localhost:3000",
+    "cypress:fallback":
+      "cypress run -s cypress/integration/fallback_spec.js --config 'userAgent=Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run"
   },
@@ -18,6 +20,7 @@
     "@material-ui/icons": "^1.0.0-beta.42",
     "babel-plugin-emotion": "^9.1.0",
     "babel-plugin-transform-inline-environment-variables": "^0.3.0",
+    "detect-browser": "^2.3.0",
     "emotion": "^9.1.1",
     "emotion-server": "^9.1.2",
     "express": "4.16.2",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ const express = require("express");
 const path = require("path");
 const next = require("next");
 
+const { parseUserAgent } = require("detect-browser");
+
 const dev = process.env.NODE_ENV !== "production";
 const app = next({ dev });
 const handle = app.getRequestHandler();
@@ -46,7 +48,19 @@ i18nInstance
         );
 
         // use next.js
-        server.get("*", (req, res) => handle(req, res));
+        server.get("*", (req, res) => {
+          // Check if browse is less than IE 11
+          const ua = req.headers["user-agent"];
+          const browser = parseUserAgent(ua);
+
+          if (browser.name === "ie" && parseInt(browser.version) < 11) {
+            res.sendFile("fallback-pages/browser-incompatible.html", {
+              root: __dirname
+            });
+          } else {
+            handle(req, res);
+          }
+        });
 
         server.listen(3000, err => {
           if (err) throw err;

--- a/server.js
+++ b/server.js
@@ -53,7 +53,11 @@ i18nInstance
           const ua = req.headers["user-agent"];
           const browser = parseUserAgent(ua);
 
-          if (browser.name === "ie" && parseInt(browser.version) < 11) {
+          if (
+            browser &&
+            browser.name === "ie" &&
+            parseInt(browser.version) < 11
+          ) {
             res.sendFile("fallback-pages/browser-incompatible.html", {
               root: __dirname
             });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,6 +2243,10 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+detect-browser@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-2.3.0.tgz#559be80688725b437500ec7c04b618b43dea6e76"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"


### PR DESCRIPTION
Added a fall back page when the server encounters a IE browser less than IE < 11. Instead a static html page is sent back to the browser. Added another yarn option to specifically test cypress with a IE 10 user agent string.