### PR TITLE
Added lang attribute to html

### DIFF
--- a/pages/A1.js
+++ b/pages/A1.js
@@ -9,7 +9,6 @@ import { initStore, loadDataStore } from "../store";
 
 import { withI18next } from "../lib/withI18next";
 import Layout from "../components/layout";
-import { logEvent } from "../utils/analytics";
 import Link from "next/link";
 import SelectButton from "../components/select_button";
 import { fetchFromAirtable } from "../utils/airtable";
@@ -32,11 +31,6 @@ export class App extends Component<Props> {
       selectedOptions: []
     };
   }
-
-  changeLanguage = () => {
-    this.props.i18n.changeLanguage(this.props.t("other-language-code"));
-    logEvent("Language change", this.props.t("other-language"));
-  };
 
   throwError = () => {
     throw new Error("test");

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -6,12 +6,14 @@ import flush from "styled-jsx/server";
 import getPageContext from "../lib/pageContext";
 import { MuiThemeProvider } from "material-ui/styles";
 
+import { withI18next } from "../lib/withI18next";
+
 const bodyStyling = {
   fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
   margin: 0
 };
 
-export default class MyDocument extends Document {
+class MyDocument extends Document {
   static getInitialProps(ctx) {
     const pageContext = getPageContext();
     //eslint-disable-next-line react/display-name
@@ -61,7 +63,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <html>
+      <html lang={this.props.t("current-language-code")}>
         <Head>
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
         </Head>
@@ -73,3 +75,5 @@ export default class MyDocument extends Document {
     );
   }
 }
+
+export default withI18next()(MyDocument);


### PR DESCRIPTION
HTML requires a lang attribute. The app will now add either `en` or `fr` depending on the initial browser language. 