### PR TITLE
Deploy to AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,6 @@ workflows:
      - build
      - integration
      - update_ecs:
-        filters:
-          branches:
-            only:
-              - deploy   
         requires:
          - deploy
      - deploy:
@@ -125,4 +121,4 @@ workflows:
         filters:
           branches:
             only:
-              - deploy
+              - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,23 @@ jobs:
               docker push "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:latest"
           name: "Build and Deploy API Docker Image"
     working_directory: ~/repo
+  update_ecs: 
+    docker: 
+      - 
+        image: "cdssnc/ecs-cli:latest"
+    steps: 
+      - 
+        name: "Update ECS Task"
+      - 
+        checkout: 
+          path: ~/repo
+      - setup_remote_docker
+      - 
+        run: 
+         command: |
+              cd deploy
+              command: "ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE\n"
+    working_directory: ~/repo
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,8 @@ workflows:
           branches:
             only:
               - deploy   
+        requires:
+         - deploy
      - deploy:
         requires:
          - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,9 @@ jobs:
         run: 
          command: |
               cd deploy
-              command: "ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE\n"
+              command: "ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE"
     working_directory: ~/repo
+
 
 workflows:
   version: 2
@@ -112,6 +113,11 @@ workflows:
    jobs:
      - build
      - integration
+     - update_ecs:
+        filters:
+          branches:
+            only:
+              - deploy   
      - deploy:
         requires:
          - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,6 @@ jobs:
         image: "cdssnc/ecs-cli:latest"
     steps: 
       - 
-        name: "Update ECS Task"
-      - 
         checkout: 
           path: ~/repo
       - setup_remote_docker
@@ -104,8 +102,8 @@ jobs:
          command: |
               cd deploy
               command: "ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE"
+         name: "Update ECS Task"
     working_directory: ~/repo
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
         run: 
          command: |
               cd deploy
-              command: "ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE"
+              /usr/local/bin/ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE"
          name: "Update ECS Task"
     working_directory: ~/repo
 
@@ -123,4 +123,4 @@ workflows:
         filters:
           branches:
             only:
-              - master
+              - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
         run: 
          command: |
               cd deploy
-              command: "ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE"
+              ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE
          name: "Update ECS Task"
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,15 +90,12 @@ jobs:
     working_directory: ~/repo
   update_ecs: 
     docker: 
-      - 
-        image: "cdssnc/ecs-cli:latest"
+      - image: "cdssnc/ecs-cli:latest"
     steps: 
-      - 
-        checkout: 
+      - checkout: 
           path: ~/repo
       - setup_remote_docker
-      - 
-        run: 
+      - run: 
          command: |
               cd deploy
               ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml --cluster staging-ecs-cluster --project-name staging-vac-poc  service up --launch-type FARGATE

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: docker.io/cdssnc/vac-poc:latest
     ports:
       - "3000:3000"
+      - "3002:3002"
     logging:
       driver: awslogs
       options:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,10 +6,9 @@ services:
     image: docker.io/cdssnc/vac-poc:latest
     ports:
       - "3000:3000"
-      - "3002:3002"
     logging:
       driver: awslogs
       options:
         awslogs-group: ecs-logs
         awslogs-region: us-east-1
-        awslogs-stream-prefix: nrcan-poc
+        awslogs-stream-prefix: vac-poc

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+
+services:
+
+   vac:
+    image: docker.io/cdssnc/vac-poc:latest
+    ports:
+      - "3000:3000"
+    logging:
+      driver: awslogs
+      options:
+        awslogs-group: ecs-logs
+        awslogs-region: us-east-1
+        awslogs-stream-prefix: nrcan-poc

--- a/deploy/ecs-params.yml
+++ b/deploy/ecs-params.yml
@@ -1,7 +1,7 @@
 version: 1
 task_definition:
   task_execution_role: ecs_task_execution_role-vac-poc
-  task_role_arn: arn:aws:iam::241785157803:role/ecs_task_execution_role-ircc-rescheduler
+  task_role_arn: arn:aws:iam::241785157803:role/ecs_task_execution_role-vac-poc
   ecs_network_mode: awsvpc
   task_size:
     mem_limit: 0.5GB

--- a/deploy/ecs-params.yml
+++ b/deploy/ecs-params.yml
@@ -1,0 +1,21 @@
+version: 1
+task_definition:
+  task_execution_role: ecs_task_execution_role-vac-poc
+  task_role_arn: arn:aws:iam::241785157803:role/ecs_task_execution_role-ircc-rescheduler
+  ecs_network_mode: awsvpc
+  task_size:
+    mem_limit: 0.5GB
+    cpu_limit: 256
+  launch-type: FARGATE
+  services:
+    vac:
+     essential: true
+run_params:
+  network_configuration:
+    awsvpc_configuration:
+      subnets:
+        - "subnet-1000f777"
+        - "subnet-40e8f31d"
+      security_groups:
+        - "sg-cc9ed885"
+      assign_public_ip: ENABLED

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,6 +1,6 @@
 {
   "home": {
-    "poc-description": "This is a Proof of Concept for the VAC project"
+    "poc-description": "Test: This is a Proof of Concept for the VAC project"
   },
 
   "A1": {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,6 +1,6 @@
 {
   "home": {
-    "poc-description": "Test: This is a Proof of Concept for the VAC project"
+    "poc-description": "This is a Proof of Concept for the VAC project"
   },
 
   "A1": {


### PR DESCRIPTION
This PR will deploy the VAC project to Amazon's Elastic Container Service. It does a rolling update of the application for a zero downtime deployment.

I'm leaving the Azure deploy in for the time being until we're comfortable with ECS.
