### PR TITLE
Fix BenefitCard

### DIFF
--- a/__tests__/components/benefit_card_test.js
+++ b/__tests__/components/benefit_card_test.js
@@ -10,12 +10,20 @@ const benefitsFixture = [
   {
     vac_name_en: "Disability Award",
     vac_name_fr: "Prix ​​d'invalidité",
+    benefitTypeEn: "BT EN 1",
+    benefitTypeFr: "BT FR 1",
+    descriptionEn: "Money compensation for a service related injury",
+    descriptionFr: "Compensation monétaire pour une blessure liée au service",
     linkEn: "English link",
     linkFr: "French link"
   },
   {
     vac_name_en: "Disability Pension",
     vac_name_fr: "Pension d'invalidité",
+    benefitTypeEn: "BT EN 2",
+    benefitTypeFr: "BT FR 2",
+    descriptionEn: "A pension compensating service related injuries",
+    descriptionFr: "Une blessure compensant les blessures liées au service",
     linkEn: "English link",
     linkFr: "French link"
   }
@@ -40,44 +48,31 @@ describe("Test Benefit Cards", () => {
   });
 
   it("BenefitCard", () => {
-    const test_props = {
-      type: "test type",
-      title: "test title",
-      description: "test description"
-    };
+    const test_props = benefitsFixture[0];
     const card = mount(<BenefitCard t={key => key} benefit={test_props} />);
     expect(card.find("CardHeader").text()).toEqual(
-      test_props.type.toUpperCase()
+      test_props.benefitTypeFr.toUpperCase()
     );
-    expect(card.find("Typography#title").text()).toEqual(test_props.title);
+    expect(card.find("Typography#title").text()).toEqual(
+      test_props.vac_name_fr
+    );
     expect(card.find("Typography#description").text()).toEqual(
-      test_props.description
+      test_props.descriptionFr
     );
     expect(card.find("Button").text()).toEqual("View Details");
   });
 
   it("BenefitCardList", () => {
-    const test_props = [
-      {
-        type: "test type1",
-        title: "test title1",
-        description: "test description1"
-      },
-      {
-        type: "test type2",
-        title: "test title2",
-        description: "test description2"
-      }
-    ];
+    const test_props = benefitsFixture;
 
     const cardList = mount(
-      <BenefitCardList t={key => key} benefitList={test_props} />
+      <BenefitCardList t={key => key} benefits={test_props} />
     );
     for (let i = 0; i < 2; i++) {
       const expected =
-        test_props[i].type.toUpperCase() +
-        test_props[i].title +
-        test_props[i].description +
+        test_props[i].benefitTypeFr.toUpperCase() +
+        test_props[i].vac_name_fr +
+        test_props[i].descriptionFr +
         "View Details";
       expect(cardList.find("#bc" + i).text()).toEqual(expected);
     }

--- a/__tests__/pages/all-benefits_test.js
+++ b/__tests__/pages/all-benefits_test.js
@@ -4,7 +4,7 @@ import { mount } from "enzyme";
 import React from "react";
 
 import { AllBenefits } from "../../pages/all-benefits";
-import { BenefitTitleCardList } from "../../components/benefit_cards";
+import { BenefitCardList } from "../../components/benefit_cards";
 
 const tMocked = key => key;
 const i18nFixture = { language: "en-US" };
@@ -27,6 +27,7 @@ const benefitsFixture = [
 ];
 const corporaEnFixture = [];
 const corporaFrFixture = [];
+const benefitTypesFixture = [];
 
 jest.mock("react-ga");
 
@@ -40,9 +41,10 @@ describe("All benefits page", () => {
         benefits={benefitsFixture}
         corporaEn={corporaEnFixture}
         corporaFr={corporaFrFixture}
+        benefitTypes={benefitTypesFixture}
       />
     );
-    expect(app.find(BenefitTitleCardList).length).toEqual(1);
-    expect(app.find(".BenefitCard").length).toEqual(2);
+    expect(app.find(BenefitCardList).length).toEqual(1);
+    expect(app.find("Card").length).toEqual(2);
   });
 });

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -16,7 +16,6 @@ export class BenefitTitleCard extends Component<CardProps> {
     return (
       <Grid item xs={12} sm={4}>
         <SelectButton
-          className="BenefitCard"
           target="_blank"
           text={
             this.props.t("current-language-code") === "en"
@@ -68,17 +67,35 @@ export class BenefitCard extends Component<CardProps> {
     return (
       <Grid item xs={12} lg={6}>
         <Card>
-          <CardHeader title={this.props.t(benefit.type).toUpperCase()} />
+          <CardHeader
+            title={(this.props.t("current-language-code") === "en"
+              ? benefit.benefitTypeEn
+              : benefit.benefitTypeFr
+            ).toUpperCase()}
+          />
           <CardContent>
             <Typography id="title" variant="title" gutterBottom>
-              {this.props.t(benefit.title)}
+              {this.props.t("current-language-code") === "en"
+                ? benefit.vac_name_en
+                : benefit.vac_name_fr}
             </Typography>
             <Typography id="description" variant="body1" gutterBottom>
-              {this.props.t(benefit.description)}
+              {this.props.t("current-language-code") === "en"
+                ? benefit.descriptionEn
+                : benefit.descriptionFr}
             </Typography>
           </CardContent>
           <CardActions>
-            <Button>{this.props.t("View Details")}</Button>
+            <Button
+              target="_blank"
+              href={
+                this.props.t("current-language-code") === "en"
+                  ? benefit.linkEn
+                  : benefit.linkFr
+              }
+            >
+              {this.props.t("View Details")}
+            </Button>
           </CardActions>
         </Card>
       </Grid>
@@ -87,19 +104,15 @@ export class BenefitCard extends Component<CardProps> {
 }
 
 type CardListProps = {
-  benefitList: mixed,
+  benefits: mixed,
   t: mixed
 };
 
-class BenefitCardList extends Component<CardListProps> {
+export class BenefitCardList extends Component<CardListProps> {
   props: CardListProps;
 
-  state = {
-    benefits: this.props.benefitList
-  };
-
   render() {
-    return this.state.benefits.map((benefit, i) => (
+    return this.props.benefits.map((benefit, i) => (
       <BenefitCard id={"bc" + i} benefit={benefit} t={this.props.t} key={i} />
     ));
   }

--- a/components/footer.js
+++ b/components/footer.js
@@ -9,7 +9,7 @@ type Props = {
 
 const Div = styled("div")`
   width: 100%;
-  height: 66px;
+  height: 65px;
   background-color: #ddd;
   color: #000;
   text-align: center;

--- a/pages/all-benefits.js
+++ b/pages/all-benefits.js
@@ -9,7 +9,7 @@ import { initStore, loadDataStore } from "../store";
 
 import { withI18next } from "../lib/withI18next";
 import Layout from "../components/layout";
-import { BenefitTitleCardList } from "../components/benefit_cards";
+import { BenefitCardList } from "../components/benefit_cards";
 import { bindActionCreators } from "redux";
 import { fetchFromAirtable } from "../utils/airtable";
 
@@ -21,7 +21,8 @@ type Props = {
   t: mixed,
   url: mixed,
   corporaEn: mixed,
-  corporaFr: mixed
+  corporaFr: mixed,
+  benefitTypes: mixed
 };
 
 export class AllBenefits extends Component<Props> {
@@ -38,18 +39,33 @@ export class AllBenefits extends Component<Props> {
 
     let benefits = this.props.benefits;
 
-    // add links to benefits
+    // add links and descriptions to benefits
     benefits = benefits.map(benefit => {
-      let links = this.props.corporaEn.filter(corp =>
+      let corporas = this.props.corporaEn.filter(corp =>
         corp.benefits.includes(benefit.id)
       );
       benefit.linkEn =
-        links.length > 0 ? links[0].full_description_link : undefined;
-      links = this.props.corporaFr.filter(corp =>
+        corporas.length > 0 ? corporas[0].full_description_link : undefined;
+      benefit.descriptionEn =
+        corporas.length > 0 ? corporas[0].one_line_description : undefined;
+
+      corporas = this.props.corporaFr.filter(corp =>
         corp.benefits.includes(benefit.id)
       );
       benefit.linkFr =
-        links.length > 0 ? links[0].full_description_link : undefined;
+        corporas.length > 0 ? corporas[0].full_description_link : undefined;
+      benefit.descriptionFr =
+        corporas.length > 0 ? corporas[0].one_line_description : undefined;
+      return benefit;
+    });
+
+    // add benefit types
+    benefits = benefits.map(benefit => {
+      let bts = this.props.benefitTypes.filter(bt =>
+        bt.benefits.includes(benefit.id)
+      );
+      benefit.benefitTypeEn = bts.length > 0 ? bts[0].name_en : "";
+      benefit.benefitTypeFr = bts.length > 0 ? bts[0].name_fr : "";
       return benefit;
     });
 
@@ -60,7 +76,7 @@ export class AllBenefits extends Component<Props> {
           <Grid container spacing={24}>
             <Grid item xs={12}>
               <Grid container spacing={24}>
-                <BenefitTitleCardList benefits={benefits} t={t} />
+                <BenefitCardList benefits={benefits} t={t} />
               </Grid>
             </Grid>
           </Grid>
@@ -80,7 +96,8 @@ const mapStateToProps = state => {
   return {
     benefits: state.benefits,
     corporaEn: state.corporaEn,
-    corporaFr: state.corporaFr
+    corporaFr: state.corporaFr,
+    benefitTypes: state.benefitTypes
   };
 };
 


### PR DESCRIPTION
fixes #124 

The `BenefitCard` that contains the one line description broke when we switched to using the Airtable schema in our datastore. This fixes that and uses those cards on the `all-benefits` page.

Also minor fixes to the header and footer (eliminates unnecessary scroll bars)
