### PR TITLE
Cache Airtable data in server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
   integration:
     docker:
       # the Docker image with Cypress dependencies
-      - image: cypress/base:6
+      - image: cypress/base:10
         environment:
           ## this enables colors in the output
           TERM: xterm

--- a/__tests__/pages/A_test.js
+++ b/__tests__/pages/A_test.js
@@ -155,4 +155,35 @@ describe("A", () => {
     expect(AInstance.sectionToDisplay("A3").props.id).toEqual("A3");
     expect(AInstance.sectionToDisplay("B3").props.id).toEqual("B3");
   });
+
+  it("componantDidMount hydrates Redux with fixtures if use_testdata set", () => {
+    props.url = {
+      query: {
+        use_testdata: "true"
+      }
+    };
+    const expectedArgs = {
+      benefitTypes: benefitTypesFixture,
+      patronTypes: patronTypesFixture,
+      benefits: benefitsFixture,
+      corporaEn: corporaEnFixture,
+      corporaFr: corporaFrFixture
+    };
+    expect(mountedA().instance().props.loadDataStore).toBeCalledWith(
+      expectedArgs
+    );
+  });
+
+  it("componantDidMount hydrates Redux with cached data if passed", () => {
+    props.data = {
+      benefitTypes: 1,
+      patronTypes: 2,
+      benefits: 3,
+      corporaEn: 4,
+      corporaFr: 5
+    };
+    expect(mountedA().instance().props.loadDataStore).toBeCalledWith(
+      props.data
+    );
+  });
 });

--- a/__tests__/pages/A_test.js
+++ b/__tests__/pages/A_test.js
@@ -45,21 +45,6 @@ describe("A", () => {
     _mountedA = undefined;
   });
 
-  it("componentWillMount does not run hydrateFromAirtable if storeHydrated = true", () => {
-    let airtable = require("../../utils/airtable");
-    airtable.hydrateFromAirtable = jest.fn();
-    mountedA();
-    expect(airtable.hydrateFromAirtable).not.toBeCalled();
-  });
-
-  it("componentWillMount does run hydrateFromAirtable if storeHydrated = false", () => {
-    props.storeHydrated = false;
-    let airtable = require("../../utils/airtable");
-    airtable.hydrateFromAirtable = jest.fn();
-    mountedA();
-    expect(airtable.hydrateFromAirtable).toBeCalled();
-  });
-
   it("componentWillMount sets state correctly from empty url", () => {
     const expectedState = {
       section: "A1",

--- a/__tests__/pages/all-benefits_test.js
+++ b/__tests__/pages/all-benefits_test.js
@@ -35,21 +35,6 @@ describe("AllBenefits", () => {
     _mountedAllBenefits = undefined;
   });
 
-  it("componentWillMount does not run hydrateFromAirtable if storeHydrated = true", () => {
-    let airtable = require("../../utils/airtable");
-    airtable.hydrateFromAirtable = jest.fn();
-    mountedAllBenefits();
-    expect(airtable.hydrateFromAirtable).not.toBeCalled();
-  });
-
-  it("componentWillMount does run hydrateFromAirtable if storeHydrated = false", () => {
-    props.storeHydrated = false;
-    let airtable = require("../../utils/airtable");
-    airtable.hydrateFromAirtable = jest.fn();
-    mountedAllBenefits();
-    expect(airtable.hydrateFromAirtable).toBeCalled();
-  });
-
   it("has a correct enrichBenefit function", () => {
     let expectedBenefit = Object.assign({}, benefitsFixture[0]);
     expectedBenefit.linkEn = corporaEnFixture[0].full_description_link;

--- a/components/A2.js
+++ b/components/A2.js
@@ -7,7 +7,6 @@ import SelectButton from "../components/select_button";
 type Props = {
   id: string,
   t: mixed,
-  storeHydrated: boolean,
   patronTypes: mixed,
   url: mixed,
   selectedPatronTypes: mixed,

--- a/cypress/integration/typical_story_spec.js
+++ b/cypress/integration/typical_story_spec.js
@@ -7,7 +7,7 @@ describe("Wireframe A example story", () => {
     cy.contains("Military Service-Person").click();
     cy.contains("See Results").click();
     cy.contains("Disability Award");
-    cy.contains("Disability Pension").should("not.exist");
+    cy.get("Disability Pension").should("not.exist");
     cy.get("#userStatusesCard").within(() => {
       cy.get("#ChangeButton").click();
     });

--- a/fallback-pages/browser-incompatible.html
+++ b/fallback-pages/browser-incompatible.html
@@ -35,9 +35,11 @@ body
     <br/>
     <p>
       Your current version of this browser is not supported. Please update to the latest version.      
+      To see a list of all benefits click <a href='/all-benefits'>here</a>.
     </p>
     <p>
       Votre version actuelle de ce navigateur n'est pas supportée. S'il vous plaît mettre à jour à la dernière version.
+      Pour voir la liste complète des avantages, cliquez <a href='/all-benefits'>ici</a>.
     </p>
   </div>
 </body>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "i18next-node-fs-backend": "1.0.0",
     "i18next-xhr-backend": "1.5.1",
     "isomorphic-unfetch": "^2.0.0",
-    "lru-cache": "^4.1.3",
     "material-ui": "next",
     "next": "^5.1.0",
     "next-redux-wrapper": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "i18next-node-fs-backend": "1.0.0",
     "i18next-xhr-backend": "1.5.1",
     "isomorphic-unfetch": "^2.0.0",
+    "lru-cache": "^4.1.3",
     "material-ui": "next",
     "next": "^5.1.0",
     "next-redux-wrapper": "^1.3.5",

--- a/pages/A.js
+++ b/pages/A.js
@@ -8,7 +8,6 @@ import { initStore, loadDataStore } from "../store";
 import { withI18next } from "../lib/withI18next";
 import Layout from "../components/layout";
 import { bindActionCreators } from "redux";
-import { hydrateFromAirtable } from "../utils/airtable";
 import { hydrateFromFixtures } from "../utils/hydrate_from_fixtures";
 
 import A1 from "../components/A1";
@@ -26,7 +25,8 @@ type Props = {
   patronTypes: mixed,
   benefits: mixed,
   corporaEn: mixed,
-  corporaFr: mixed
+  corporaFr: mixed,
+  data: mixed
 };
 
 export class A extends Component<Props> {
@@ -63,8 +63,6 @@ export class A extends Component<Props> {
 
     if (this.props.url.query.use_testdata) {
       hydrateFromFixtures(this.props.loadDataStore);
-    } else if (!this.props.storeHydrated) {
-      hydrateFromAirtable(this.props.loadDataStore);
     }
     const newState = {
       section: this.props.url.query.section || "A1",
@@ -76,6 +74,24 @@ export class A extends Component<Props> {
         : []
     };
     this.setState(newState);
+  }
+
+  componentDidMount() {
+    if (typeof this.props.data !== "undefined") {
+      this.props.loadDataStore({
+        benefitTypes: this.props.data.benefitTypes,
+        patronTypes: this.props.data.patronTypes,
+        benefits: this.props.data.benefits,
+        corporaEn: this.props.data.corporaEn,
+        corporaFr: this.props.data.corporaFr
+      });
+    }
+  }
+
+  static getInitialProps(ctx) {
+    if (typeof ctx.req !== "undefined") {
+      return { data: ctx.req.data };
+    }
   }
 
   switchSection = (newSection, data) => {
@@ -125,7 +141,6 @@ export class A extends Component<Props> {
           <A1
             id="A1"
             t={this.props.t}
-            storeHydrated={this.props.storeHydrated}
             benefitTypes={this.props.benefitTypes}
             selectedBenefitTypes={this.state.selectedBenefitTypes}
             switchSection={this.switchSection}
@@ -136,7 +151,6 @@ export class A extends Component<Props> {
           <A2
             id="A2"
             t={this.props.t}
-            storeHydrated={this.props.storeHydrated}
             patronTypes={this.props.patronTypes}
             switchSection={this.switchSection}
             selectedPatronTypes={this.state.selectedPatronTypes}
@@ -147,7 +161,6 @@ export class A extends Component<Props> {
           <A3
             id="A3"
             t={this.props.t}
-            storeHydrated={this.props.storeHydrated}
             benefitTypes={this.props.benefitTypes}
             patronTypes={this.props.patronTypes}
             benefits={this.props.benefits}
@@ -163,7 +176,6 @@ export class A extends Component<Props> {
           <B3
             id="B3"
             t={this.props.t}
-            storeHydrated={this.props.storeHydrated}
             benefitTypes={this.props.benefitTypes}
             patronTypes={this.props.patronTypes}
             benefits={this.props.benefits}

--- a/pages/A.js
+++ b/pages/A.js
@@ -61,9 +61,6 @@ export class A extends Component<Props> {
       this.setState(newState);
     };
 
-    if (this.props.url.query.use_testdata) {
-      hydrateFromFixtures(this.props.loadDataStore);
-    }
     const newState = {
       section: this.props.url.query.section || "A1",
       selectedBenefitTypes: this.props.url.query.selectedBenefitTypes
@@ -77,7 +74,9 @@ export class A extends Component<Props> {
   }
 
   componentDidMount() {
-    if (typeof this.props.data !== "undefined") {
+    if (this.props.url.query.use_testdata) {
+      hydrateFromFixtures(this.props.loadDataStore);
+    } else if (typeof this.props.data !== "undefined") {
       this.props.loadDataStore({
         benefitTypes: this.props.data.benefitTypes,
         patronTypes: this.props.data.patronTypes,
@@ -192,11 +191,13 @@ export class A extends Component<Props> {
   };
 
   render() {
-    return (
-      <Layout i18n={this.props.i18n} t={this.props.t}>
-        {this.sectionToDisplay(this.state.section)}
-      </Layout>
-    );
+    if (this.props.benefitTypes !== []) {
+      return (
+        <Layout i18n={this.props.i18n} t={this.props.t}>
+          {this.sectionToDisplay(this.state.section)}
+        </Layout>
+      );
+    }
   }
 }
 

--- a/pages/A.js
+++ b/pages/A.js
@@ -191,13 +191,11 @@ export class A extends Component<Props> {
   };
 
   render() {
-    if (this.props.benefitTypes !== []) {
-      return (
-        <Layout i18n={this.props.i18n} t={this.props.t}>
-          {this.sectionToDisplay(this.state.section)}
-        </Layout>
-      );
-    }
+    return (
+      <Layout i18n={this.props.i18n} t={this.props.t}>
+        {this.sectionToDisplay(this.state.section)}
+      </Layout>
+    );
   }
 }
 

--- a/pages/all-benefits.js
+++ b/pages/all-benefits.js
@@ -27,9 +27,13 @@ type Props = {
 export class AllBenefits extends Component<Props> {
   props: Props;
 
+  static getInitialProps(ctx) {
+    return { cache: ctx.req.ssCache };
+  }
+
   componentWillMount() {
     if (!this.props.storeHydrated) {
-      hydrateFromAirtable(this.props.loadDataStore);
+      hydrateFromAirtable(this.props.loadDataStore, this.props.cache);
     }
   }
 

--- a/pages/all-benefits.js
+++ b/pages/all-benefits.js
@@ -4,14 +4,9 @@ import React, { Component } from "react";
 
 import { Grid } from "material-ui";
 
-import withRedux from "next-redux-wrapper";
-import { initStore, loadDataStore } from "../store";
-
 import { withI18next } from "../lib/withI18next";
 import Layout from "../components/layout";
 import { BenefitCard } from "../components/benefit_cards";
-import { bindActionCreators } from "redux";
-import { hydrateFromAirtable } from "../utils/airtable";
 
 type Props = {
   benefits: mixed,
@@ -28,13 +23,14 @@ export class AllBenefits extends Component<Props> {
   props: Props;
 
   static getInitialProps(ctx) {
-    return { cache: ctx.req.ssCache };
-  }
-
-  componentWillMount() {
-    if (!this.props.storeHydrated) {
-      hydrateFromAirtable(this.props.loadDataStore, this.props.cache);
-    }
+    let data = ctx.req.data;
+    return {
+      benefitTypes: data.benefitTypes,
+      patronTypes: data.patronTypes,
+      benefits: data.benefits,
+      corporaEn: data.corporaEn,
+      corporaFr: data.corporaFr
+    };
   }
 
   enrichBenefit = (benefit, benefitTypes, corporaEn, corporaFr) => {
@@ -92,21 +88,4 @@ export class AllBenefits extends Component<Props> {
   }
 }
 
-const mapDispatchToProps = dispatch => {
-  return {
-    loadDataStore: bindActionCreators(loadDataStore, dispatch)
-  };
-};
-
-const mapStateToProps = state => {
-  return {
-    benefits: state.benefits,
-    corporaEn: state.corporaEn,
-    corporaFr: state.corporaFr,
-    benefitTypes: state.benefitTypes
-  };
-};
-
-export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(
-  withI18next()(AllBenefits)
-);
+export default withI18next()(AllBenefits);

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const path = require("path");
 const next = require("next");
-const LRUCache = require("lru-cache");
 
 const { parseUserAgent } = require("detect-browser");
 
@@ -13,71 +12,75 @@ const i18nextMiddleware = require("i18next-express-middleware");
 const Backend = require("i18next-node-fs-backend");
 const { i18nInstance } = require("./i18n");
 
-const ssCache = new LRUCache({
-  max: 100,
-  maxAge: 1000 * 60 * 60
-});
+const airTable = require("./utils/airtable_es2015");
+Promise.resolve(airTable.hydrateFromAirtable()).then(data => {
+  // init i18next with serverside settings
+  // using i18next-express-middleware
+  i18nInstance
+    .use(Backend)
+    .use(i18nextMiddleware.LanguageDetector)
+    .init(
+      {
+        fallbackLng: "en",
+        preload: ["en", "de"], // preload all langages
+        ns: ["common", "home", "page2"], // need to preload all the namespaces
+        backend: {
+          loadPath: path.join(__dirname, "/locales/{{lng}}/{{ns}}.json"),
+          addPath: path.join(__dirname, "/locales/{{lng}}/{{ns}}.missing.json")
+        }
+      },
+      () => {
+        // loaded translations we can bootstrap our routes
+        app.prepare().then(() => {
+          const server = express();
 
-// init i18next with serverside settings
-// using i18next-express-middleware
-i18nInstance
-  .use(Backend)
-  .use(i18nextMiddleware.LanguageDetector)
-  .init(
-    {
-      fallbackLng: "en",
-      preload: ["en", "de"], // preload all langages
-      ns: ["common", "home", "page2"], // need to preload all the namespaces
-      backend: {
-        loadPath: path.join(__dirname, "/locales/{{lng}}/{{ns}}.json"),
-        addPath: path.join(__dirname, "/locales/{{lng}}/{{ns}}.missing.json")
+          // enable middleware for i18next
+          server.use(i18nextMiddleware.handle(i18nInstance));
+
+          // serve locales for client
+          server.use(
+            "/locales",
+            express.static(path.join(__dirname, "/locales"))
+          );
+
+          // missing keys
+          server.post(
+            "/locales/add/:lng/:ns",
+            i18nextMiddleware.missingKeyHandler(i18nInstance)
+          );
+
+          // use next.js
+          server.get("*", (req, res) => {
+            // Check if browse is less than IE 11
+            const ua = req.headers["user-agent"];
+            const browser = parseUserAgent(ua);
+
+            setTimeout(function() {
+              Promise.resolve(airTable.hydrateFromAirtable()).then(newData => {
+                data = newData;
+              });
+            }, 1000 * 60 * 60);
+
+            req.data = data;
+
+            if (
+              browser &&
+              browser.name === "ie" &&
+              parseInt(browser.version) < 11
+            ) {
+              res.sendFile("fallback-pages/browser-incompatible.html", {
+                root: __dirname
+              });
+            } else {
+              handle(req, res);
+            }
+          });
+          const port = process.env.PORT || 3000;
+          server.listen(port, err => {
+            if (err) throw err;
+            console.log("> Ready on http://localhost:" + port);
+          });
+        });
       }
-    },
-    () => {
-      // loaded translations we can bootstrap our routes
-      app.prepare().then(() => {
-        const server = express();
-
-        // enable middleware for i18next
-        server.use(i18nextMiddleware.handle(i18nInstance));
-
-        // serve locales for client
-        server.use(
-          "/locales",
-          express.static(path.join(__dirname, "/locales"))
-        );
-
-        // missing keys
-        server.post(
-          "/locales/add/:lng/:ns",
-          i18nextMiddleware.missingKeyHandler(i18nInstance)
-        );
-
-        // use next.js
-        server.get("*", (req, res) => {
-          // Check if browse is less than IE 11
-          const ua = req.headers["user-agent"];
-          const browser = parseUserAgent(ua);
-
-          req.ssCache = ssCache;
-
-          if (
-            browser &&
-            browser.name === "ie" &&
-            parseInt(browser.version) < 11
-          ) {
-            res.sendFile("fallback-pages/browser-incompatible.html", {
-              root: __dirname
-            });
-          } else {
-            handle(req, res);
-          }
-        });
-        const port = process.env.PORT || 3000;
-        server.listen(port, err => {
-          if (err) throw err;
-          console.log("> Ready on http://localhost:" + port);
-        });
-      });
-    }
-  );
+    );
+});

--- a/server.js
+++ b/server.js
@@ -22,8 +22,8 @@ Promise.resolve(airTable.hydrateFromAirtable()).then(data => {
     .init(
       {
         fallbackLng: "en",
-        preload: ["en", "de"], // preload all langages
-        ns: ["common", "home", "page2"], // need to preload all the namespaces
+        preload: ["en", "fr"],
+        ns: ["common"],
         backend: {
           loadPath: path.join(__dirname, "/locales/{{lng}}/{{ns}}.json"),
           addPath: path.join(__dirname, "/locales/{{lng}}/{{ns}}.missing.json")

--- a/server.js
+++ b/server.js
@@ -62,11 +62,11 @@ Promise.resolve(airTable.hydrateFromAirtable()).then(data => {
             }, 1000 * 60 * 60);
 
             req.data = data;
-
             if (
               browser &&
               browser.name === "ie" &&
-              parseInt(browser.version) < 11
+              parseInt(browser.version) < 11 &&
+              !req.url.includes("all-benefits")
             ) {
               res.sendFile("fallback-pages/browser-incompatible.html", {
                 root: __dirname

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const path = require("path");
 const next = require("next");
+const LRUCache = require("lru-cache");
 
 const { parseUserAgent } = require("detect-browser");
 
@@ -11,6 +12,11 @@ const handle = app.getRequestHandler();
 const i18nextMiddleware = require("i18next-express-middleware");
 const Backend = require("i18next-node-fs-backend");
 const { i18nInstance } = require("./i18n");
+
+const ssCache = new LRUCache({
+  max: 100,
+  maxAge: 1000 * 60 * 60
+});
 
 // init i18next with serverside settings
 // using i18next-express-middleware
@@ -52,6 +58,8 @@ i18nInstance
           // Check if browse is less than IE 11
           const ua = req.headers["user-agent"];
           const browser = parseUserAgent(ua);
+
+          req.ssCache = ssCache;
 
           if (
             browser &&

--- a/utils/airtable.js
+++ b/utils/airtable.js
@@ -2,14 +2,18 @@ import fetch from "isomorphic-unfetch";
 
 const key = "keySzaXvONeLwsBm4"; // Read access only API key
 
-const fetchTableFromAirtable = async table => {
+const fetchTableFromAirtable = async (table, cache) => {
+  let result = cache.get(table);
+  if (typeof result !== "undefined") {
+    return result;
+  }
   let url =
-    "https://api.airtable.com/v0/appIjjOxIa2utbHGH/" +
+    "https://api.airtable.com/v0/appijjoxia2utbhgh/" +
     table +
-    "?maxRecords=100&view=Grid%20view";
+    "?maxrecords=100&view=grid%20view";
   let resp = await fetch(url, {
     headers: {
-      Authorization: `Bearer ${key}`
+      authorization: `bearer ${key}`
     }
   });
   let json = await resp.json();
@@ -18,12 +22,18 @@ const fetchTableFromAirtable = async table => {
   });
 };
 
-export const hydrateFromAirtable = async loadDataStore => {
+export const hydrateFromAirtable = async (loadDataStore, cache) => {
   loadDataStore({
-    benefitTypes: await fetchTableFromAirtable("benefit_types")
+    benefitTypes: await fetchTableFromAirtable("benefit_types", cache)
   });
-  loadDataStore({ patronTypes: await fetchTableFromAirtable("patron_types") });
-  loadDataStore({ benefits: await fetchTableFromAirtable("benefits") });
-  loadDataStore({ corporaEn: await fetchTableFromAirtable("corpora_en") });
-  loadDataStore({ corporaFr: await fetchTableFromAirtable("corpora_fr") });
+  loadDataStore({
+    patronTypes: await fetchTableFromAirtable("patron_types", cache)
+  });
+  loadDataStore({ benefits: await fetchTableFromAirtable("benefits", cache) });
+  loadDataStore({
+    corporaEn: await fetchTableFromAirtable("corpora_en", cache)
+  });
+  loadDataStore({
+    corporaFr: await fetchTableFromAirtable("corpora_fr", cache)
+  });
 };

--- a/utils/airtable.js
+++ b/utils/airtable.js
@@ -2,18 +2,14 @@ import fetch from "isomorphic-unfetch";
 
 const key = "keySzaXvONeLwsBm4"; // Read access only API key
 
-const fetchTableFromAirtable = async (table, cache) => {
-  let result = cache.get(table);
-  if (typeof result !== "undefined") {
-    return result;
-  }
+const fetchTableFromAirtable = async table => {
   let url =
-    "https://api.airtable.com/v0/appijjoxia2utbhgh/" +
+    "https://api.airtable.com/v0/appIjjOxIa2utbHGH/" +
     table +
-    "?maxrecords=100&view=grid%20view";
+    "?maxRecords=100&view=Grid%20view";
   let resp = await fetch(url, {
     headers: {
-      authorization: `bearer ${key}`
+      Authorization: `Bearer ${key}`
     }
   });
   let json = await resp.json();
@@ -23,17 +19,51 @@ const fetchTableFromAirtable = async (table, cache) => {
 };
 
 export const hydrateFromAirtable = async (loadDataStore, cache) => {
-  loadDataStore({
-    benefitTypes: await fetchTableFromAirtable("benefit_types", cache)
-  });
-  loadDataStore({
-    patronTypes: await fetchTableFromAirtable("patron_types", cache)
-  });
-  loadDataStore({ benefits: await fetchTableFromAirtable("benefits", cache) });
-  loadDataStore({
-    corporaEn: await fetchTableFromAirtable("corpora_en", cache)
-  });
-  loadDataStore({
-    corporaFr: await fetchTableFromAirtable("corpora_fr", cache)
-  });
+  console.log("+++ Cache hydrateFromAirtable:", cache);
+
+  let benefit_types, patron_types, benefits, corpora_en, corpora_fr;
+
+  if (0) {
+    loadDataStore({
+      benefitTypes: await fetchTableFromAirtable("benefit_types")
+    });
+    loadDataStore({
+      patronTypes: await fetchTableFromAirtable("patron_types")
+    });
+    loadDataStore({ benefits: await fetchTableFromAirtable("benefits") });
+    loadDataStore({ corporaEn: await fetchTableFromAirtable("corpora_en") });
+    loadDataStore({ corporaFr: await fetchTableFromAirtable("corpora_fr") });
+  } else {
+    if (typeof cache.get("benefit_types") !== "undefined") {
+      benefit_types = cache.get("benefit_types");
+      patron_types = cache.get("patron_types");
+      benefits = cache.get("benefits");
+      corpora_en = cache.get("corpora_en");
+      corpora_fr = cache.get("corpora_fr");
+    } else {
+      benefit_types = await fetchTableFromAirtable("benefit_types");
+      patron_types = await fetchTableFromAirtable("patron_types");
+      benefits = await fetchTableFromAirtable("benefits");
+      corpora_en = await fetchTableFromAirtable("corpora_en");
+      corpora_fr = await fetchTableFromAirtable("corpora_fr");
+
+      cache.set("benefit_types", benefit_types);
+      cache.set("patron_types", patron_types);
+      cache.set("benefits", benefits);
+      cache.set("corpora_en", corpora_en);
+      cache.set("corpora_fr", corpora_fr);
+    }
+
+    console.log("benefit_types", benefit_types);
+    console.log("patron_types", patron_types);
+    console.log("benefits", benefits);
+    console.log("corpora_en", corpora_en);
+    console.log("corpora_fr", corpora_fr);
+
+    loadDataStore({ benefitTypes: benefit_types });
+    loadDataStore({ patronTypes: patron_types });
+    loadDataStore({ benefits: benefits });
+    loadDataStore({ corporaEn: corpora_en });
+    loadDataStore({ corporaFr: corpora_fr });
+  }
 };

--- a/utils/airtable.js
+++ b/utils/airtable.js
@@ -18,52 +18,14 @@ const fetchTableFromAirtable = async table => {
   });
 };
 
-export const hydrateFromAirtable = async (loadDataStore, cache) => {
-  console.log("+++ Cache hydrateFromAirtable:", cache);
-
-  let benefit_types, patron_types, benefits, corpora_en, corpora_fr;
-
-  if (0) {
-    loadDataStore({
-      benefitTypes: await fetchTableFromAirtable("benefit_types")
-    });
-    loadDataStore({
-      patronTypes: await fetchTableFromAirtable("patron_types")
-    });
-    loadDataStore({ benefits: await fetchTableFromAirtable("benefits") });
-    loadDataStore({ corporaEn: await fetchTableFromAirtable("corpora_en") });
-    loadDataStore({ corporaFr: await fetchTableFromAirtable("corpora_fr") });
-  } else {
-    if (typeof cache.get("benefit_types") !== "undefined") {
-      benefit_types = cache.get("benefit_types");
-      patron_types = cache.get("patron_types");
-      benefits = cache.get("benefits");
-      corpora_en = cache.get("corpora_en");
-      corpora_fr = cache.get("corpora_fr");
-    } else {
-      benefit_types = await fetchTableFromAirtable("benefit_types");
-      patron_types = await fetchTableFromAirtable("patron_types");
-      benefits = await fetchTableFromAirtable("benefits");
-      corpora_en = await fetchTableFromAirtable("corpora_en");
-      corpora_fr = await fetchTableFromAirtable("corpora_fr");
-
-      cache.set("benefit_types", benefit_types);
-      cache.set("patron_types", patron_types);
-      cache.set("benefits", benefits);
-      cache.set("corpora_en", corpora_en);
-      cache.set("corpora_fr", corpora_fr);
-    }
-
-    console.log("benefit_types", benefit_types);
-    console.log("patron_types", patron_types);
-    console.log("benefits", benefits);
-    console.log("corpora_en", corpora_en);
-    console.log("corpora_fr", corpora_fr);
-
-    loadDataStore({ benefitTypes: benefit_types });
-    loadDataStore({ patronTypes: patron_types });
-    loadDataStore({ benefits: benefits });
-    loadDataStore({ corporaEn: corpora_en });
-    loadDataStore({ corporaFr: corpora_fr });
-  }
+export const hydrateFromAirtable = async loadDataStore => {
+  loadDataStore({
+    benefitTypes: await fetchTableFromAirtable("benefit_types")
+  });
+  loadDataStore({
+    patronTypes: await fetchTableFromAirtable("patron_types")
+  });
+  loadDataStore({ benefits: await fetchTableFromAirtable("benefits") });
+  loadDataStore({ corporaEn: await fetchTableFromAirtable("corpora_en") });
+  loadDataStore({ corporaFr: await fetchTableFromAirtable("corpora_fr") });
 };

--- a/utils/airtable_es2015.js
+++ b/utils/airtable_es2015.js
@@ -1,0 +1,43 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.hydrateFromAirtable = undefined;
+
+var _isomorphicUnfetch = require("isomorphic-unfetch");
+
+var _isomorphicUnfetch2 = _interopRequireDefault(_isomorphicUnfetch);
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
+
+var key = "keySzaXvONeLwsBm4"; // Read access only API key
+
+var fetchTableFromAirtable = async function fetchTableFromAirtable(table) {
+  var url =
+    "https://api.airtable.com/v0/appIjjOxIa2utbHGH/" +
+    table +
+    "?maxRecords=100&view=Grid%20view";
+  var resp = await (0, _isomorphicUnfetch2.default)(url, {
+    headers: {
+      Authorization: "Bearer " + key
+    }
+  });
+  var json = await resp.json();
+  return json.records.map(function(item) {
+    return item.fields;
+  });
+};
+
+var hydrateFromAirtable = (exports.hydrateFromAirtable = async function hydrateFromAirtable() {
+  let dataStore = {};
+  dataStore.benefitTypes = await fetchTableFromAirtable("benefit_types");
+  dataStore.patronTypes = await fetchTableFromAirtable("patron_types");
+  dataStore.benefits = await fetchTableFromAirtable("benefits");
+  dataStore.corporaEn = await fetchTableFromAirtable("corpora_en");
+  dataStore.corporaFr = await fetchTableFromAirtable("corpora_fr");
+  dataStore.timestamp = await Date.now();
+  return dataStore;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4925,6 +4925,13 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 make-dir@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.2.0.tgz#6d6a49eead4aae296c53bbf3a1a008bd6c89469b"


### PR DESCRIPTION
Cache the AirTable data on the server, refreshing it every hour. Serve this data to the client on page request. (So now the clients never hit AirTable)

in page A, the page gets rerendered when we push changes to the url (just rerendered, not reloaded from the server). To keep the data around between rerenderings we store it in Redux. This causes the same flicker on initial load as we say when the browsers were hitting airtable themselves, unfortunately.
