### PR TITLE
Made child benefits collapsable

### DIFF
--- a/__tests__/components/benefit_card_test.js
+++ b/__tests__/components/benefit_card_test.js
@@ -1,9 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
-import {
-  EmbeddedBenefitCard,
-  BenefitCard
-} from "../../components/benefit_cards";
+import EmbeddedBenefitCard from "../../components/embedded_benefit_card";
+import { BenefitCard } from "../../components/benefit_cards";
 import benefitsFixture from "../fixtures/benefits";
 
 describe("EmbeddedBenefitCard", () => {
@@ -24,14 +22,17 @@ describe("EmbeddedBenefitCard", () => {
     _mountedEmbeddedBenefitCard = undefined;
   });
 
-  it("contains a SelectButton", () => {
-    expect(mountedEmbeddedBenefitCard().find("SelectButton").length).toEqual(1);
+  it("contains a ExpansionPanel", () => {
+    expect(mountedEmbeddedBenefitCard().find("ExpansionPanel").length).toEqual(
+      1
+    );
   });
 
   it("has a blank target", () => {
     expect(
       mountedEmbeddedBenefitCard()
-        .find("SelectButton")
+        .find("ExpansionPanelActions")
+        .find("Button")
         .prop("target")
     ).toEqual("_blank");
   });
@@ -39,12 +40,14 @@ describe("EmbeddedBenefitCard", () => {
   it("has expected English text and href", () => {
     expect(
       mountedEmbeddedBenefitCard()
-        .find("SelectButton")
+        .find("ExpansionPanelSummary")
+        .find("Typography")
         .text()
     ).toEqual(benefitsFixture[0].vacNameEn);
     expect(
       mountedEmbeddedBenefitCard()
-        .find("SelectButton")
+        .find("ExpansionPanelActions")
+        .find("Button")
         .prop("href")
     ).toEqual(benefitsFixture[0].benefitPageEn);
   });
@@ -57,12 +60,14 @@ describe("EmbeddedBenefitCard", () => {
     it("has expected French text and href", () => {
       expect(
         mountedEmbeddedBenefitCard()
-          .find("SelectButton")
+          .find("ExpansionPanelSummary")
+          .find("Typography")
           .text()
       ).toEqual(benefitsFixture[0].vacNameFr);
       expect(
         mountedEmbeddedBenefitCard()
-          .find("SelectButton")
+          .find("ExpansionPanelActions")
+          .find("Button")
           .prop("href")
       ).toEqual(benefitsFixture[0].benefitPageFr);
     });

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -14,6 +14,9 @@ export class BenefitCard extends Component<Props> {
 
   render() {
     const benefit = this.props.benefit;
+    const style = {
+      padding: "30px 0px"
+    };
 
     const childBenefits = benefit.childBenefits
       ? this.props.allBenefits.filter(
@@ -37,20 +40,23 @@ export class BenefitCard extends Component<Props> {
             >
               {"Benefit Description"}
             </Typography>
-
             <Grid container spacing={24}>
-              <div width="100%">
-                {childBenefits.map((cb, i) => (
-                  <EmbeddedBenefitCard
-                    id={"cb" + i}
-                    className="BenefitCards"
-                    benefit={cb}
-                    allBenefits={this.props.allBenefits}
-                    t={this.props.t}
-                    key={i}
-                  />
-                ))}
-              </div>
+              {childBenefits.length > 0 ? (
+                <div width="100%" style={style}>
+                  {childBenefits.map((cb, i) => (
+                    <EmbeddedBenefitCard
+                      id={"cb" + i}
+                      className="BenefitCards"
+                      benefit={cb}
+                      allBenefits={this.props.allBenefits}
+                      t={this.props.t}
+                      key={i}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div />
+              )}
             </Grid>
           </CardContent>
           <CardActions>

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -38,7 +38,7 @@ export class BenefitCard extends Component<Props> {
               {"Benefit Description"}
             </Typography>
 
-            <Grid container spacing={24} padding-top="20em">
+            <Grid container spacing={24}>
               {childBenefits.map((cb, i) => (
                 <EmbeddedBenefitCard
                   id={"cb" + i}

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -1,40 +1,13 @@
 import React, { Component } from "react";
 import Card, { CardContent, CardActions } from "material-ui/Card";
 import { Grid, Typography, Button } from "material-ui";
-import SelectButton from "./select_button";
+import EmbeddedBenefitCard from "./embedded_benefit_card";
 
 type Props = {
   benefit: mixed,
   allBenefits: mixed,
   t: mixed
 };
-
-export class EmbeddedBenefitCard extends Component<Props> {
-  props: Props;
-
-  render() {
-    const benefit = this.props.benefit;
-    return (
-      <Grid item xs={12}>
-        <SelectButton
-          target="_blank"
-          text={
-            this.props.t("current-language-code") === "en"
-              ? benefit.vacNameEn
-              : benefit.vacNameFr
-          }
-          href={
-            this.props.t("current-language-code") === "en"
-              ? benefit.benefitPageEn
-              : benefit.benefitPageFr
-          }
-          isDown={false}
-          id="title"
-        />
-      </Grid>
-    );
-  }
-}
 
 export class BenefitCard extends Component<Props> {
   props: Props;
@@ -65,7 +38,7 @@ export class BenefitCard extends Component<Props> {
               {"Benefit Description"}
             </Typography>
 
-            <Grid container spacing={24}>
+            <Grid container spacing={24} padding-top="20em">
               {childBenefits.map((cb, i) => (
                 <EmbeddedBenefitCard
                   id={"cb" + i}

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -39,16 +39,18 @@ export class BenefitCard extends Component<Props> {
             </Typography>
 
             <Grid container spacing={24}>
-              {childBenefits.map((cb, i) => (
-                <EmbeddedBenefitCard
-                  id={"cb" + i}
-                  className="BenefitCards"
-                  benefit={cb}
-                  allBenefits={this.props.allBenefits}
-                  t={this.props.t}
-                  key={i}
-                />
-              ))}
+              <div width="100%">
+                {childBenefits.map((cb, i) => (
+                  <EmbeddedBenefitCard
+                    id={"cb" + i}
+                    className="BenefitCards"
+                    benefit={cb}
+                    allBenefits={this.props.allBenefits}
+                    t={this.props.t}
+                    key={i}
+                  />
+                ))}
+              </div>
             </Grid>
           </CardContent>
           <CardActions>

--- a/components/embedded_benefit_card.js
+++ b/components/embedded_benefit_card.js
@@ -1,10 +1,11 @@
 import React, { Component } from "react";
-import { Typography } from "material-ui";
+import { Typography, Button } from "material-ui";
 import classnames from "classnames";
 import { withStyles } from "material-ui/styles";
 import ExpansionPanel from "material-ui/ExpansionPanel/ExpansionPanel";
 import ExpansionPanelSummary from "material-ui/ExpansionPanel/ExpansionPanelSummary";
 import ExpansionPanelDetails from "material-ui/ExpansionPanel/ExpansionPanelDetails";
+import ExpansionPanelActions from "material-ui/ExpansionPanel/ExpansionPanelActions";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 import PropTypes from "prop-types";
@@ -31,25 +32,36 @@ export class EmbeddedBenefitCard extends Component<Props> {
   render() {
     const { t, classes, benefit } = this.props;
     return (
-      <div className={classes.root}>
-        <ExpansionPanel>
-          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography className={classnames(classes.heading)}>
-              {" "}
-              {t("current-language-code") === "en"
-                ? benefit.vacNameEn
-                : benefit.vacNameFr}
-            </Typography>
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              Suspendisse malesuada lacus ex, sit amet blandit leo lobortis
-              eget.
-            </Typography>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
-      </div>
+      //   <div className={classes.root}>
+      <ExpansionPanel>
+        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography className={classnames(classes.heading)}>
+            {t("current-language-code") === "en"
+              ? benefit.vacNameEn
+              : benefit.vacNameFr}
+          </Typography>
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanelDetails>
+        <ExpansionPanelActions>
+          <Button
+            size="small"
+            target="_blank"
+            href={
+              this.props.t("current-language-code") === "en"
+                ? benefit.benefitPageEn
+                : benefit.benefitPageFr
+            }
+          >
+            View Details
+          </Button>
+        </ExpansionPanelActions>
+      </ExpansionPanel>
+      //   </div>
     );
   }
 }

--- a/components/embedded_benefit_card.js
+++ b/components/embedded_benefit_card.js
@@ -1,0 +1,59 @@
+import React, { Component } from "react";
+import { Typography } from "material-ui";
+import classnames from "classnames";
+import { withStyles } from "material-ui/styles";
+import ExpansionPanel from "material-ui/ExpansionPanel/ExpansionPanel";
+import ExpansionPanelSummary from "material-ui/ExpansionPanel/ExpansionPanelSummary";
+import ExpansionPanelDetails from "material-ui/ExpansionPanel/ExpansionPanelDetails";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+
+import PropTypes from "prop-types";
+
+type Props = {
+  benefit: mixed,
+  t: mixed,
+  classes: mixed
+};
+
+const styles = theme => ({
+  root: {
+    width: "100%"
+  },
+  heading: {
+    fontSize: theme.typography.pxToRem(15),
+    fontWeight: theme.typography.fontWeightRegular
+  }
+});
+
+export class EmbeddedBenefitCard extends Component<Props> {
+  props: Props;
+
+  render() {
+    const { t, classes, benefit } = this.props;
+    return (
+      <div className={classes.root}>
+        <ExpansionPanel>
+          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography className={classnames(classes.heading)}>
+              {" "}
+              {t("current-language-code") === "en"
+                ? benefit.vacNameEn
+                : benefit.vacNameFr}
+            </Typography>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            <Typography>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              Suspendisse malesuada lacus ex, sit amet blandit leo lobortis
+              eget.
+            </Typography>
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
+      </div>
+    );
+  }
+}
+EmbeddedBenefitCard.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+export default withStyles(styles)(EmbeddedBenefitCard);


### PR DESCRIPTION
Put EmbeddedBenefitCard component in its own file. Switched the component to a material-ui ExpansionPanel.

@sastels @maxneuvians The child cards overlap their parents' content and I'm not sure how to fix it.