### PR TITLE
Don't show main cards for benefits that need a gateway

### DIFF
--- a/__tests__/components/BB_test.js
+++ b/__tests__/components/BB_test.js
@@ -37,10 +37,10 @@ describe("BB", () => {
       selectedNeeds: {},
       needs: [],
       selectedEligibility: {
-        serviceType: { CAF: 1 },
-        serviceStatus: { released: 1 },
-        patronType: { ["service-person"]: 1 },
-        servicePersonVitalStatus: { alive: 1 }
+        serviceType: {},
+        serviceStatus: {},
+        patronType: {},
+        servicePersonVitalStatus: {}
       },
       toggleSelectedEligibility: jest.fn(),
       classes: {
@@ -56,6 +56,12 @@ describe("BB", () => {
   });
 
   it("has a correct filteredBenefits function", () => {
+    props.selectedEligibility = {
+      serviceType: { CAF: 1 },
+      serviceStatus: { released: 1 },
+      patronType: { ["service-person"]: 1 },
+      servicePersonVitalStatus: { alive: 1 }
+    };
     let BBInstance = shallow_BB().instance();
     expect(
       BBInstance.filteredBenefits(
@@ -65,7 +71,7 @@ describe("BB", () => {
         needsFixture,
         props.selectedNeeds
       )
-    ).toEqual([benefitsFixture[0]]);
+    ).toEqual([benefitsFixture[1]]);
   });
 
   it("has a serviceTypes filter", () => {
@@ -103,7 +109,18 @@ describe("BB", () => {
     expect(shallow_BB().state().expanded).toEqual(true);
   });
 
+  it("doesn't show child only cards", () => {
+    const benefitCards = shallow_BB().find(".BenefitCards");
+    expect(benefitCards.length).toEqual(1);
+  });
+
   it("has the selected benefit cards", () => {
+    props.selectedEligibility = {
+      serviceType: { CAF: 1 },
+      serviceStatus: { released: 1 },
+      patronType: { ["service-person"]: 1 },
+      servicePersonVitalStatus: { alive: 1 }
+    };
     const benefitCards = shallow_BB().find(".BenefitCards");
     expect(benefitCards.length).toEqual(1);
     benefitCards.map((bt, i) => {

--- a/__tests__/fixtures/benefits.js
+++ b/__tests__/fixtures/benefits.js
@@ -1,18 +1,20 @@
 const benefitsFixture = [
   {
-    id: "0",
+    id: "1",
     vacNameEn: "Disability Award",
     vacNameFr: "Prix ​​d'invalidité",
     benefitPageEn: "English link",
-    benefitPageFr: "French link"
+    benefitPageFr: "French link",
+    availableIndependently: "Requires Gateway Benefit"
   },
   {
-    id: "1",
+    id: "0",
     vacNameEn: "Disability Pension",
     vacNameFr: "Pension d'invalidité",
     benefitPageEn: "English link",
     benefitPageFr: "French link",
-    childBenefits: ["0"]
+    childBenefits: ["1"],
+    availableIndependently: "Independant"
   }
 ];
 

--- a/__tests__/fixtures/eligibilityPaths.js
+++ b/__tests__/fixtures/eligibilityPaths.js
@@ -5,6 +5,13 @@ const elegibilityPathsFixture = [
     serviceType: "CAF",
     serviceStatus: "released",
     benefits: ["0"]
+  },
+  {
+    patronType: "service-person",
+    servicePersonVitalStatus: "na",
+    serviceType: "RCMP",
+    serviceStatus: "released",
+    benefits: ["1"]
   }
 ];
 

--- a/components/BB.js
+++ b/components/BB.js
@@ -292,16 +292,21 @@ export class BB extends Component<Props> {
                   />
                 </Grid>
 
-                {benefits.map((benefit, i) => (
-                  <BenefitCard
-                    id={"bc" + i}
-                    className="BenefitCards"
-                    benefit={benefit}
-                    allBenefits={benefits}
-                    t={this.props.t}
-                    key={i}
-                  />
-                ))}
+                {benefits.map(
+                  (benefit, i) =>
+                    benefit.availableIndependently === "Independant" ? (
+                      <BenefitCard
+                        id={"bc" + i}
+                        className="BenefitCards"
+                        benefit={benefit}
+                        allBenefits={benefits}
+                        t={this.props.t}
+                        key={i}
+                      />
+                    ) : (
+                      ""
+                    )
+                )}
               </Grid>
             </Grid>
           </Grid>


### PR DESCRIPTION
If a benefit requires a gateway benefit, only show it as a child benefit, not as a main card.

Also, added a column to AirTable benefits table to support this.