### PR TITLE
change benefit filtering logic

### DIFF
--- a/__tests__/components/BB_test.js
+++ b/__tests__/components/BB_test.js
@@ -109,10 +109,10 @@ describe("BB", () => {
     expect(shallow_BB().state().expanded).toEqual(true);
   });
 
-  it("doesn't show child only cards", () => {
-    const benefitCards = shallow_BB().find(".BenefitCards");
-    expect(benefitCards.length).toEqual(1);
-  });
+  // it("doesn't show child only cards", () => {
+  //   const benefitCards = shallow_BB().find(".BenefitCards");
+  //   expect(benefitCards.length).toEqual(1);
+  // });
 
   it("has the selected benefit cards", () => {
     props.selectedEligibility = {

--- a/components/BB.js
+++ b/components/BB.js
@@ -165,7 +165,7 @@ export class BB extends Component<Props> {
 
     const { t, classes } = this.props; // eslint-disable-line no-unused-vars
 
-    const benefits = this.filteredBenefits(
+    const filteredBenefits = this.filteredBenefits(
       this.props.benefits,
       this.props.eligibilityPaths,
       this.props.selectedEligibility,
@@ -292,14 +292,14 @@ export class BB extends Component<Props> {
                   />
                 </Grid>
 
-                {benefits.map(
+                {filteredBenefits.map(
                   (benefit, i) =>
-                    benefit.availableIndependently === "Independant" ? (
+                    true || benefit.availableIndependently === "Independant" ? ( // eslint-disable-line no-constant-condition
                       <BenefitCard
                         id={"bc" + i}
                         className="BenefitCards"
                         benefit={benefit}
-                        allBenefits={benefits}
+                        allBenefits={this.props.benefits}
                         t={this.props.t}
                         key={i}
                       />


### PR DESCRIPTION
re conversations in Slack, change the way we filter the benefit cards:
- show main cards for a benefit even if it appears as a child card
- show all child cards of a gateway benefit, even if some of those child cards do not match the filters.