### PR TITLE
stop child card disclosure from floating to right of card

### DIFF
--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -22,10 +22,6 @@ const buttonStyles = {
   marginRight: "25px"
 };
 
-const chevronStyle = {
-  float: "right"
-};
-
 const collapseStyle = {
   backgroundColor: "#eee",
   padding: "25px"
@@ -121,7 +117,6 @@ export class BenefitCard extends Component<Props> {
                     onClick={this.handleExpandClick}
                     aria-expanded={this.state.expanded}
                     aria-label="Show more"
-                    style={chevronStyle}
                   >
                     <ExpandMoreIcon />
                   </IconButton>


### PR DESCRIPTION
Now that cards are wider it looks funny to have the disclosure all the way to the right.

We might want to allow the user to click on the line of text as well and use an accordion disclosure. 