### PR TITLE
Add selector for changing benefit sort order

### DIFF
--- a/__tests__/components/BB_test.js
+++ b/__tests__/components/BB_test.js
@@ -137,14 +137,23 @@ describe("BB", () => {
     });
   });
 
-  it("has a correct sortBenefits function", () => {
+  it("has a correct sortBenefits function when sorting by relevance", () => {
     let BBInstance = shallow_BB().instance();
-    // console.log(BBInstance.sortBenefits(benefitsFixture, "en"))
-    expect(BBInstance.sortBenefits(benefitsFixture, "en")[0]).toEqual(
-      benefitsFixture.filter(o => {
-        return o.id === "3";
-      })[0]
-    );
+    expect(
+      BBInstance.sortBenefits(benefitsFixture, "en").map(b => b.id)
+    ).toEqual(["3", "1", "0"]);
+  });
+
+  it("has a correct sortBenefits function when sorting alphabetically", () => {
+    let BBInstance = shallow_BB().instance();
+    BBInstance.setState({ sortByValue: "alphabetical" });
+    expect(
+      BBInstance.sortBenefits(benefitsFixture, "en").map(b => b.id)
+    ).toEqual(["1", "0", "3"]);
+  });
+
+  it("has a sortBy selector", () => {
+    expect(shallow_BB().find("#sortBySelector").length).toEqual(1);
   });
 
   it("has a serviceTypes filter", () => {

--- a/components/BB.js
+++ b/components/BB.js
@@ -161,21 +161,6 @@ export class BB extends Component {
   };
 
   sortBenefits = (filteredBenefits, language) => {
-    if (this.state.sortByValue === "alphabetical") {
-      let vacName = language === "en" ? "vacNameEn" : "vacNameFr";
-      return filteredBenefits.sort((a, b) => {
-        let nameA = a[vacName].toUpperCase();
-        let nameB = b[vacName].toUpperCase(); // ignore upper and lowercase
-        if (nameA < nameB) {
-          return -1;
-        }
-        if (nameA > nameB) {
-          return 1;
-        }
-        return 0;
-      });
-    }
-
     filteredBenefits.forEach(b => {
       if (b.sortingPriority === undefined) {
         b.sortingPriority = "low";
@@ -184,7 +169,10 @@ export class BB extends Component {
     });
 
     let sorting_fn = (a, b) => {
-      if (a.sortingNumber === b.sortingNumber) {
+      if (
+        this.state.sortByValue === "alphabetical" ||
+        a.sortingNumber === b.sortingNumber
+      ) {
         // sort alphabetically
         let vacName = language === "en" ? "vacNameEn" : "vacNameFr";
         let nameA = a[vacName].toUpperCase();

--- a/components/BB.js
+++ b/components/BB.js
@@ -8,6 +8,11 @@ import classnames from "classnames";
 import { withStyles } from "material-ui/styles";
 import red from "material-ui/colors/red";
 import Typography from "material-ui/Typography";
+import { InputLabel } from "material-ui/Input";
+import { MenuItem } from "material-ui/Menu";
+import { FormControl } from "material-ui/Form";
+import Select from "material-ui/Select";
+
 import "babel-polyfill/dist/polyfill";
 
 import BenefitCard from "../components/benefit_cards";
@@ -42,12 +47,20 @@ const styles = theme => ({
   collapse: {
     textAlign: "right",
     textDecoration: "underline"
+  },
+  formControl: {
+    margin: theme.spacing.unit,
+    minWidth: 120
+  },
+  sortBy: {
+    textAlign: "right"
   }
 });
 
 export class BB extends Component {
   state = {
-    expanded: true
+    expanded: true,
+    sortByValue: "relevance"
   };
   children = [];
 
@@ -148,6 +161,21 @@ export class BB extends Component {
   };
 
   sortBenefits = (filteredBenefits, language) => {
+    if (this.state.sortByValue === "alphabetical") {
+      let vacName = language === "en" ? "vacNameEn" : "vacNameFr";
+      return filteredBenefits.sort((a, b) => {
+        let nameA = a[vacName].toUpperCase();
+        let nameB = b[vacName].toUpperCase(); // ignore upper and lowercase
+        if (nameA < nameB) {
+          return -1;
+        }
+        if (nameA > nameB) {
+          return 1;
+        }
+        return 0;
+      });
+    }
+
     filteredBenefits.forEach(b => {
       if (b.sortingPriority === undefined) {
         b.sortingPriority = "low";
@@ -173,6 +201,10 @@ export class BB extends Component {
       return a.sortingNumber - b.sortingNumber;
     };
     return filteredBenefits.sort(sorting_fn);
+  };
+
+  handleSortByChange = event => {
+    this.setState({ sortByValue: event.target.value });
   };
 
   render() {
@@ -356,6 +388,23 @@ export class BB extends Component {
                     handleChange={this.props.setSelectedNeeds}
                   />
                 </Grid>
+
+                <Grid item xs={12} className={classnames(classes.sortBy)}>
+                  <FormControl
+                    id="sortBySelector"
+                    className={classes.formControl}
+                  >
+                    <InputLabel>Sort By</InputLabel>
+                    <Select
+                      value={this.state.sortByValue}
+                      onChange={this.handleSortByChange}
+                    >
+                      <MenuItem value={"relevance"}>Relevance</MenuItem>
+                      <MenuItem value={"alphabetical"}>Alphabetical</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Grid>
+
                 <Grid item xs={12} className={classnames(classes.collapse)}>
                   <Button
                     id="CollapseBenefits"

--- a/components/BB.js
+++ b/components/BB.js
@@ -394,13 +394,17 @@ export class BB extends Component {
                     id="sortBySelector"
                     className={classes.formControl}
                   >
-                    <InputLabel>Sort By</InputLabel>
+                    <InputLabel>{t("B3.Sort By")}</InputLabel>
                     <Select
                       value={this.state.sortByValue}
                       onChange={this.handleSortByChange}
                     >
-                      <MenuItem value={"relevance"}>Relevance</MenuItem>
-                      <MenuItem value={"alphabetical"}>Alphabetical</MenuItem>
+                      <MenuItem value={"relevance"}>
+                        {t("B3.Relevance")}
+                      </MenuItem>
+                      <MenuItem value={"alphabetical"}>
+                        {t("B3.Alphabetical")}
+                      </MenuItem>
                     </Select>
                   </FormControl>
                 </Grid>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -43,7 +43,10 @@
     "PatronType": "Who are you looking for?",
     "serviceStatus": "What is the status?",
     "servicePersonVitalStatus": "Is the service member alive?",
-    "What do you need help with?": "What do you need help with?"
+    "What do you need help with?": "What do you need help with?",
+    "Sort By": "Sort By",
+    "Relevance": "Relevance",
+    "Alphabetical": "Alphabetical"
   },
   "child benefits": "With this benefit, you may also have access to",
   "alpha": "For testing only.",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -43,7 +43,10 @@
     "PatronType": "Qui cherches-tu?",
     "serviceStatus": "Quel est le statut?",
     "servicePersonVitalStatus": "Est-ce que le Vétéran est en vie?",
-    "What do you need help with?": "Avec quoi as tu besoin d'aide?"
+    "What do you need help with?": "Avec quoi as tu besoin d'aide?",
+    "Sort By": "Trier par",
+    "Relevance": "Pertinence",
+    "Alphabetical": "Alphabétique"
   },
   "child benefits": "Avec cet avantage, vous pouvez également avoir accès",
   "alpha": "Pour les tests seulement",


### PR DESCRIPTION
resolves #257 

Add a dropdown that allows sorting the benefit list by relevance (current way) or alphabetical.