### PR TITLE
Filter changes

### DIFF
--- a/__tests__/components/BB_test.js
+++ b/__tests__/components/BB_test.js
@@ -39,9 +39,8 @@ describe("BB", () => {
       examples: [],
       selectedEligibility: {
         serviceType: {},
-        serviceStatus: {},
         patronType: {},
-        servicePersonVitalStatus: {}
+        statusAndVitals: {}
       },
       toggleSelectedEligibility: jest.fn(),
       classes: {
@@ -98,30 +97,26 @@ describe("BB", () => {
         {
           patronType: "p1",
           serviceType: "na",
-          servicePersonVitalStatus: "na",
-          serviceStatus: "na",
+          statusAndVitals: "na",
           benefits: ["0"]
         },
         {
           patronType: "p2",
           serviceType: "na",
-          servicePersonVitalStatus: "na",
-          serviceStatus: "na",
+          statusAndVitals: "na",
           benefits: ["2"]
         },
         {
           patronType: "p3",
           serviceType: "na",
-          servicePersonVitalStatus: "na",
-          serviceStatus: "na",
+          statusAndVitals: "na",
           benefits: ["1", "3"]
         }
       ];
       selectedEligibility = {
         patronType: {},
         serviceType: {},
-        serviceStatus: {},
-        servicePersonVitalStatus: {}
+        statusAndVitals: {}
       };
     });
 
@@ -185,9 +180,8 @@ describe("BB", () => {
   it("has the selected benefit cards", () => {
     props.selectedEligibility = {
       serviceType: { CAF: 1 },
-      serviceStatus: { released: 1 },
       patronType: { ["service-person"]: 1 },
-      servicePersonVitalStatus: { alive: 1 }
+      statusAndVitals: { released: 1 }
     };
     const benefitCards = shallow_BB().find(".BenefitCards");
     expect(benefitCards.length).toEqual(1);

--- a/__tests__/fixtures/eligibilityPaths.js
+++ b/__tests__/fixtures/eligibilityPaths.js
@@ -1,16 +1,14 @@
 const elegibilityPathsFixture = [
   {
     patronType: "service-person",
-    servicePersonVitalStatus: "na",
     serviceType: "CAF",
-    serviceStatus: "released",
+    statusAndVitals: "na",
     benefits: ["0"]
   },
   {
     patronType: "service-person",
-    servicePersonVitalStatus: "na",
+    statusAndVitals: "na",
     serviceType: "RCMP",
-    serviceStatus: "released",
     benefits: ["1"]
   }
 ];

--- a/__tests__/pages/A_test.js
+++ b/__tests__/pages/A_test.js
@@ -50,8 +50,7 @@ describe("A", () => {
       selectedEligibility: {
         patronType: { family: "family" },
         serviceType: { CAF: "CAF" },
-        serviceStatus: {},
-        servicePersonVitalStatus: {}
+        statusAndVitals: {}
       }
     };
     const expectedURL =
@@ -68,8 +67,7 @@ describe("A", () => {
       selectedEligibility: {
         patronType: { family: "family" },
         serviceType: { CAF: "CAF" },
-        serviceStatus: {},
-        servicePersonVitalStatus: {}
+        statusAndVitals: {}
       }
     });
     expect(AInstance.state.selectedEligibility.serviceType).toEqual({
@@ -82,8 +80,7 @@ describe("A", () => {
       selectedEligibility: {
         patronType: {},
         serviceType: {},
-        serviceStatus: {},
-        servicePersonVitalStatus: {}
+        statusAndVitals: {}
       }
     });
     expect(Router.push).toBeCalledWith("/A?section=S");
@@ -108,8 +105,7 @@ describe("A", () => {
       selectedEligibility: {
         patronType: { family: "family" },
         serviceType: { CAF: "CAF" },
-        serviceStatus: {},
-        servicePersonVitalStatus: {}
+        statusAndVitals: {}
       }
     };
     expect(mountedA().state()).toEqual(expectedState);

--- a/components/BB.js
+++ b/components/BB.js
@@ -286,7 +286,7 @@ export class BB extends Component {
                         this.props.selectedEligibility.statusAndVitals
                       }
                       setUserProfile={id =>
-                        this.props.setUserProfile("serviceStatus", id)
+                        this.props.setUserProfile("statusAndVitals", id)
                       }
                       // isDisabled={
                       //   !this.props.selectedEligibility.serviceType.hasOwnProperty(

--- a/components/BB.js
+++ b/components/BB.js
@@ -69,8 +69,9 @@ export class BB extends Component {
     [
       "serviceType",
       "patronType",
-      "serviceStatus",
-      "servicePersonVitalStatus"
+      "statusAndVitals"
+      // "serviceStatus",
+      // "servicePersonVitalStatus"
     ].forEach(criteria => {
       if (
         Object.keys(selected[criteria]).length &&
@@ -192,21 +193,11 @@ export class BB extends Component {
         return { id: st, name_en: st, name_fr: "FF " + st };
       });
 
-    let serviceStatuses = Array.from(
-      new Set(this.props.eligibilityPaths.map(ep => ep.serviceStatus))
+    let statusAndVitals = Array.from(
+      new Set(this.props.eligibilityPaths.map(ep => ep.statusAndVitals))
     )
       .filter(st => st !== "na")
-      .concat(["still serving"])
-      .map(st => {
-        return { id: st, name_en: st, name_fr: "FF " + st };
-      });
-
-    let servicePersonVitalStatuses = Array.from(
-      new Set(
-        this.props.eligibilityPaths.map(ep => ep.servicePersonVitalStatus)
-      )
-    )
-      .filter(st => st !== "na")
+      // .concat(["still serving"])
       .map(st => {
         return { id: st, name_en: st, name_fr: "FF " + st };
       });
@@ -257,7 +248,7 @@ export class BB extends Component {
                     <DropDownSelector
                       id="patronTypeFilter"
                       t={t}
-                      legend={"B3.PatronType"}
+                      legend={t("B3.Benefits for")}
                       filters={patronTypes}
                       selectedFilters={
                         this.props.selectedEligibility.patronType
@@ -273,7 +264,7 @@ export class BB extends Component {
                     <DropDownSelector
                       id="serviceTypeFilter"
                       t={t}
-                      legend={"B3.ServiceType"}
+                      legend={t("B3.ServiceType")}
                       filters={serviceTypes}
                       selectedFilters={
                         this.props.selectedEligibility.serviceType
@@ -289,48 +280,23 @@ export class BB extends Component {
                     <DropDownSelector
                       id="serviceStatusFilter"
                       t={t}
-                      legend={"B3.serviceStatus"}
-                      filters={serviceStatuses}
+                      legend={t("B3.serviceStatus")}
+                      filters={statusAndVitals}
                       selectedFilters={
-                        this.props.selectedEligibility.serviceStatus
+                        this.props.selectedEligibility.statusAndVitals
                       }
                       setUserProfile={id =>
                         this.props.setUserProfile("serviceStatus", id)
                       }
-                      isDisabled={
-                        !this.props.selectedEligibility.serviceType.hasOwnProperty(
-                          "CAF"
-                        )
-                      }
-                      disabledString={t("disabled-serviceStatusFilter")}
+                      // isDisabled={
+                      //   !this.props.selectedEligibility.serviceType.hasOwnProperty(
+                      //     "CAF"
+                      //   )
+                      // }
+                      // disabledString={t("disabled-serviceStatusFilter")}
                     />
                   </Grid>
 
-                  <Grid item xs={12}>
-                    <DropDownSelector
-                      id="servicePersonVitalStatusFilter"
-                      t={t}
-                      legend={"B3.servicePersonVitalStatus"}
-                      filters={servicePersonVitalStatuses}
-                      selectedFilters={
-                        this.props.selectedEligibility.servicePersonVitalStatus
-                      }
-                      setUserProfile={id =>
-                        this.props.setUserProfile(
-                          "servicePersonVitalStatus",
-                          id
-                        )
-                      }
-                      isDisabled={
-                        !this.props.selectedEligibility.patronType.hasOwnProperty(
-                          "family"
-                        )
-                      }
-                      disabledString={t(
-                        "disabled-servicePersonVitalStatusFilter"
-                      )}
-                    />
-                  </Grid>
                   <br />
                 </Collapse>
                 <Grid item xs={12}>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -39,11 +39,12 @@
     "Status": "Status",
     "Needs": "Needs",
     "Filter Benefits": "Filter Benefits",
-    "ServiceType": "Which service type?",
+    "ServiceType": "Service type",
     "PatronType": "Who are you looking for?",
-    "serviceStatus": "What is the status?",
+    "serviceStatus": "Service status",
     "servicePersonVitalStatus": "Is the service member alive?",
-    "What do you need help with?": "What do you need help with?"
+    "What do you need help with?": "What do you need help with?",
+    "Benefits for": "Benefits for"
   },
   "child benefits": "With this benefit, you may also have access to",
   "alpha": "For testing only.",
@@ -88,5 +89,7 @@
   "Find out more": "Find out more",
   "Available to": "Available to",
   "examples": "Depending on your needs this program can provide",
-  "Close all": "Close all"
+  "Close all": "Close all",
+  "stillServing": "Still-serving",
+  "releasedAlive": "Released"
 }

--- a/locales/en/common.missing.json
+++ b/locales/en/common.missing.json
@@ -1,3 +1,5 @@
 {
-  "Close all": "Close all"
+  "Benefits for": "Benefits for",
+  "Service type": "Service type",
+  "Service status": "Service status"
 }

--- a/locales/en/common.missing.json
+++ b/locales/en/common.missing.json
@@ -1,5 +1,0 @@
-{
-  "Benefits for": "Benefits for",
-  "Service type": "Service type",
-  "Service status": "Service status"
-}

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -39,11 +39,12 @@
     "Status": "Statut",
     "Needs": "Besoins",
     "Filter Benefits": "Filtrer les avantages",
-    "ServiceType": "Quel type de service?",
+    "ServiceType": "Type de service",
     "PatronType": "Qui cherches-tu?",
-    "serviceStatus": "Quel est le statut?",
+    "serviceStatus": "État du service",
     "servicePersonVitalStatus": "Est-ce que le Vétéran est en vie?",
-    "What do you need help with?": "Avec quoi as tu besoin d'aide?"
+    "What do you need help with?": "Avec quoi as tu besoin d'aide?",
+    "Benefits for": "Avantages pour"
   },
   "child benefits": "Avec cet avantage, vous pouvez également avoir accès",
   "alpha": "Pour les tests seulement",
@@ -89,5 +90,7 @@
   "Find out more": "En savoir plus",
   "Available to": "Disponible pour",
   "examples": "Selon vos besoins, ce programme peut fournir",
-  "Close all": "Ferme tout"
+  "Close all": "Ferme tout",
+  "stillServing": "Toujours en train de servir",
+  "releasedAlive": "Libéré"
 }

--- a/pages/A.js
+++ b/pages/A.js
@@ -19,7 +19,6 @@ export class A extends Component {
         patronType: {},
         serviceType: {},
         statusAndVitals: {}
-        // servicePersonVitalStatus: {}
       }
     };
   }
@@ -47,17 +46,13 @@ export class A extends Component {
       myURL.searchParams = this.getUrlParams(newUrl);
       const section = myURL.searchParams.section;
       let filters = {};
-      [
-        "selectedNeeds",
-        "patronType",
-        "serviceType",
-        "statusAndVitals"
-        // "servicePersonVitalStatus"
-      ].forEach(filter => {
-        filters[filter] = myURL.searchParams[filter]
-          ? this.stringToMap(myURL.searchParams[filter])
-          : {};
-      });
+      ["selectedNeeds", "patronType", "serviceType", "statusAndVitals"].forEach(
+        filter => {
+          filters[filter] = myURL.searchParams[filter]
+            ? this.stringToMap(myURL.searchParams[filter])
+            : {};
+        }
+      );
       const newState = {
         section: section || "BB",
         selectedNeeds: filters.selectedNeeds,
@@ -65,25 +60,19 @@ export class A extends Component {
           patronType: filters.patronType,
           serviceType: filters.serviceType,
           statusAndVitals: filters.statusAndVitals
-          // servicePersonVitalStatus: filters.servicePersonVitalStatus
         }
       };
       this.setState(newState);
     };
 
     let filters = {};
-    [
-      "selectedNeeds",
-      "patronType",
-      "serviceType",
-      "statusAndVitals"
-      // "serviceStatus"
-      // "servicePersonVitalStatus"
-    ].forEach(filter => {
-      filters[filter] = this.props.url.query[filter]
-        ? this.stringToMap(this.props.url.query[filter])
-        : {};
-    });
+    ["selectedNeeds", "patronType", "serviceType", "statusAndVitals"].forEach(
+      filter => {
+        filters[filter] = this.props.url.query[filter]
+          ? this.stringToMap(this.props.url.query[filter])
+          : {};
+      }
+    );
     const newState = {
       section: this.props.url.query.section || "BB",
       selectedNeeds: filters.selectedNeeds,
@@ -91,8 +80,6 @@ export class A extends Component {
         patronType: filters.patronType,
         serviceType: filters.serviceType,
         statusAndVitals: filters.statusAndVitals
-        // serviceStatus: filters.serviceStatus,
-        // servicePersonVitalStatus: filters.servicePersonVitalStatus
       }
     };
     this.setState(newState);
@@ -112,13 +99,7 @@ export class A extends Component {
     if (Object.keys(state.selectedNeeds).length > 0) {
       href += "&selectedNeeds=" + Object.keys(state.selectedNeeds).join();
     }
-    [
-      "patronType",
-      "serviceType",
-      "statusAndVitals"
-      // "serviceStatus"
-      // "servicePersonVitalStatus"
-    ].forEach(criteria => {
+    ["patronType", "serviceType", "statusAndVitals"].forEach(criteria => {
       if (Object.keys(state.selectedEligibility[criteria]).length > 0) {
         href += `&${criteria}=${Object.keys(
           state.selectedEligibility[criteria]
@@ -172,8 +153,6 @@ export class A extends Component {
         patronType: {},
         serviceType: {},
         statusAndVitals: {}
-        //   serviceStatus: {},
-        //   servicePersonVitalStatus: {}
       }
     };
     this.setState(newState);

--- a/pages/A.js
+++ b/pages/A.js
@@ -18,8 +18,8 @@ export class A extends Component {
       selectedEligibility: {
         patronType: {},
         serviceType: {},
-        serviceStatus: {},
-        servicePersonVitalStatus: {}
+        statusAndVitals: {}
+        // servicePersonVitalStatus: {}
       }
     };
   }
@@ -51,8 +51,8 @@ export class A extends Component {
         "selectedNeeds",
         "patronType",
         "serviceType",
-        "serviceStatus",
-        "servicePersonVitalStatus"
+        "statusAndVitals"
+        // "servicePersonVitalStatus"
       ].forEach(filter => {
         filters[filter] = myURL.searchParams[filter]
           ? this.stringToMap(myURL.searchParams[filter])
@@ -64,8 +64,8 @@ export class A extends Component {
         selectedEligibility: {
           patronType: filters.patronType,
           serviceType: filters.serviceType,
-          serviceStatus: filters.serviceStatus,
-          servicePersonVitalStatus: filters.servicePersonVitalStatus
+          statusAndVitals: filters.statusAndVitals
+          // servicePersonVitalStatus: filters.servicePersonVitalStatus
         }
       };
       this.setState(newState);
@@ -76,8 +76,9 @@ export class A extends Component {
       "selectedNeeds",
       "patronType",
       "serviceType",
-      "serviceStatus",
-      "servicePersonVitalStatus"
+      "statusAndVitals"
+      // "serviceStatus"
+      // "servicePersonVitalStatus"
     ].forEach(filter => {
       filters[filter] = this.props.url.query[filter]
         ? this.stringToMap(this.props.url.query[filter])
@@ -89,8 +90,9 @@ export class A extends Component {
       selectedEligibility: {
         patronType: filters.patronType,
         serviceType: filters.serviceType,
-        serviceStatus: filters.serviceStatus,
-        servicePersonVitalStatus: filters.servicePersonVitalStatus
+        statusAndVitals: filters.statusAndVitals
+        // serviceStatus: filters.serviceStatus,
+        // servicePersonVitalStatus: filters.servicePersonVitalStatus
       }
     };
     this.setState(newState);
@@ -113,8 +115,9 @@ export class A extends Component {
     [
       "patronType",
       "serviceType",
-      "serviceStatus",
-      "servicePersonVitalStatus"
+      "statusAndVitals"
+      // "serviceStatus"
+      // "servicePersonVitalStatus"
     ].forEach(criteria => {
       if (Object.keys(state.selectedEligibility[criteria]).length > 0) {
         href += `&${criteria}=${Object.keys(
@@ -168,8 +171,9 @@ export class A extends Component {
       selectedEligibility: {
         patronType: {},
         serviceType: {},
-        serviceStatus: {},
-        servicePersonVitalStatus: {}
+        statusAndVitals: {}
+        //   serviceStatus: {},
+        //   servicePersonVitalStatus: {}
       }
     };
     this.setState(newState);


### PR DESCRIPTION
combined serviceStatus and servicePersonVitalStatus filters into statusAndVitals filter to conform to https://app.zeplin.io/project/5acbd659dc553ec84805afd4/screen/5b1156c59194e27a365f8a25?did=5b11610f5696c3a573bdfa04&cmid=5b11610f5696c3a573bdfa05

Haven't implemented radio buttons yet. Will disable the "still serving" option for WWII/Korea veterans at that point.