### PR TITLE
Make ExpansionSummary headings selectable

### DIFF
--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -18,7 +18,11 @@ const styles = () => ({
   cardDescriptionText: {
     fontSize: "20px",
     fontWeight: 400,
-    padding: "15px 0px"
+    padding: "15px 0px",
+    "-webkit-user-select": "all",
+    "-moz-user-select": "all",
+    "-ms-user-select": "all",
+    "user-select": "all"
   },
   collapse: {
     paddingTop: "25px"
@@ -34,6 +38,10 @@ const styles = () => ({
     borderLeft: "5px solid #808080"
   },
   ExpansionPanelSummary: {
+    "-webkit-user-select": "none",
+    "-moz-user-select": "none",
+    "-ms-user-select": "none",
+    "user-select": "none",
     "&[aria-expanded*=true]": {
       backgroundColor: "#f8f8f8"
     }

--- a/components/embedded_benefit_card.js
+++ b/components/embedded_benefit_card.js
@@ -18,7 +18,11 @@ const styles = theme => ({
   },
   heading: {
     fontSize: theme.typography.pxToRem(15),
-    fontWeight: theme.typography.fontWeightRegular
+    fontWeight: theme.typography.fontWeightRegular,
+    "-webkit-user-select": "all",
+    "-moz-user-select": "all",
+    "-ms-user-select": "all",
+    "user-select": "all"
   },
   ExpansionPanelClosed: {
     borderLeft: "5px solid"
@@ -27,6 +31,10 @@ const styles = theme => ({
     borderLeft: "5px solid #808080"
   },
   ExpansionPanelSummary: {
+    "-webkit-user-select": "none",
+    "-moz-user-select": "none",
+    "-ms-user-select": "none",
+    "user-select": "none",
     "&[aria-expanded*=true]": {
       backgroundColor: "#f8f8f8"
     }


### PR DESCRIPTION
Address #320. When a div is fully clickable, the action can override the select event. One way to circumvent that is to use the CSS `user-select` property. (https://css-tricks.com/almanac/properties/u/user-select/). This allows a select event to select the entire text at once vs. being interrupted by the click event. The behavior is slight odd but it works. If you click on a title it will open the card and select the title, if you click somewhere outside of the card header it deselects it. To create the ideal situation of just making it selectable you would need to modify the ExpansionPanel component itself which might be more work that it is worth.

I also looked into testing if we can make sure that certain CSS rules are present on an element. Enzyme seems to only allow that for classes vs. individual rules.