### PR TITLE
Hide statusAndVitals filter for Veteran / WSV

### DIFF
--- a/components/BB.js
+++ b/components/BB.js
@@ -245,6 +245,15 @@ export class BB extends Component {
 
   render() {
     const { t, classes } = this.props; // eslint-disable-line no-unused-vars
+
+    if (
+      this.props.selectedEligibility.patronType === "service-person" &&
+      this.props.selectedEligibility.serviceType === "WSV (WWII or Korea)" &&
+      this.props.selectedEligibility.statusAndVitals !== "releasedAlive"
+    ) {
+      this.props.setUserProfile("statusAndVitals", "releasedAlive");
+    }
+
     const filteredBenefits = this.filterBenefits(
       this.props.benefits,
       this.props.eligibilityPaths,

--- a/components/BB.js
+++ b/components/BB.js
@@ -246,14 +246,6 @@ export class BB extends Component {
   render() {
     const { t, classes } = this.props; // eslint-disable-line no-unused-vars
 
-    if (
-      this.props.selectedEligibility.patronType === "service-person" &&
-      this.props.selectedEligibility.serviceType === "WSV (WWII or Korea)" &&
-      this.props.selectedEligibility.statusAndVitals !== "releasedAlive"
-    ) {
-      this.props.setUserProfile("statusAndVitals", "releasedAlive");
-    }
-
     const filteredBenefits = this.filterBenefits(
       this.props.benefits,
       this.props.eligibilityPaths,

--- a/components/profile_selector.js
+++ b/components/profile_selector.js
@@ -125,7 +125,11 @@ class ProfileSelector extends Component {
             )}
 
             {selectedEligibility.serviceType != "" &&
-            selectedEligibility.patronType != "organization" ? (
+            selectedEligibility.patronType != "organization" &&
+            !(
+              selectedEligibility.patronType === "service-person" &&
+              selectedEligibility.serviceType === "WSV (WWII or Korea)"
+            ) ? (
               <Grid item xs={12} id="statusAndVitalsFilter">
                 <RadioSelector
                   t={t}

--- a/pages/A.js
+++ b/pages/A.js
@@ -332,24 +332,29 @@ export class A extends Component {
   };
 
   render() {
-    // reset illegal choices
+    // reset bad choices
+    let selectedEligibility = this.state.selectedEligibility;
+    if (
+      this.state.selectedEligibility.patronType === "service-person" &&
+      this.state.selectedEligibility.statusAndVitals === "deceased"
+    ) {
+      selectedEligibility.statusAndVitals = "";
+      this.setState({ selectedEligibility: selectedEligibility });
+    }
+    if (
+      this.state.selectedEligibility.serviceType === "WSV (WWII or Korea)" &&
+      this.state.selectedEligibility.statusAndVitals === "stillServing"
+    ) {
+      selectedEligibility.statusAndVitals = "";
+      this.setState({ selectedEligibility: selectedEligibility });
+    }
+    // Guided Experience skips statusAndVitals for service-person / WSV
     if (
       this.state.section !== "BB" &&
       this.state.selectedEligibility.patronType === "service-person" &&
       this.state.selectedEligibility.serviceType === "WSV (WWII or Korea)" &&
       this.state.selectedEligibility.statusAndVitals !== ""
     ) {
-      let selectedEligibility = this.state.selectedEligibility;
-      selectedEligibility.statusAndVitals = "";
-      this.setState({ selectedEligibility: selectedEligibility });
-    }
-    if (
-      this.state.section !== "BB" &&
-      this.state.selectedEligibility.patronType === "family" &&
-      this.state.selectedEligibility.serviceType === "WSV (WWII or Korea)" &&
-      this.state.selectedEligibility.statusAndVitals === "stillServing"
-    ) {
-      let selectedEligibility = this.state.selectedEligibility;
       selectedEligibility.statusAndVitals = "";
       this.setState({ selectedEligibility: selectedEligibility });
     }


### PR DESCRIPTION
fixes #377

In BB if the profile is Veteran / WSV, then there's only one legal statusAndVitals choice, "Released".
* auto-select "Released" (in case there's some benefits that require Released status)
* hide filter