### PR TITLE
Disable cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,11 +125,9 @@ workflows:
   build_and_deploy:
    jobs:
      - build
-     - integration
      - deploy:
         requires:
          - build
-         - integration
         filters:
           branches:
             only:


### PR DESCRIPTION
Right now our Cypress tests are shit, there's no point in running them. Let's disable them for now, and if we want to do proper Cypress testing at a later date we can rewrite them and re-enable.