### PR TITLE
Fix print sorting

### DIFF
--- a/__tests__/components/BB_test.js
+++ b/__tests__/components/BB_test.js
@@ -299,7 +299,7 @@ describe("BB", () => {
       expect(mounted_BB().state().frIdx).not.toEqual(null);
     });
 
-    it("shows a text serach box is show_search url param is set", () => {
+    it("shows a text search box is show_search url param is set", () => {
       mounted_BB().setProps({ url: { query: { show_search: true } } });
       expect(
         mounted_BB()
@@ -380,10 +380,11 @@ describe("BB", () => {
         [{ id: "id1" }, { id: "id2" }],
         { patronType: "service-person" },
         { need1: "need1", need2: "need2" },
+        "sorting",
         "en"
       );
     expect(url).toEqual(
-      "print?lng=en&patronType=service-person&needs=need1,need2&benefits=id1,id2"
+      "print?lng=en&patronType=service-person&needs=need1,need2&sortBy=sorting&benefits=id1,id2"
     );
   });
 });

--- a/__tests__/pages/print_test.js
+++ b/__tests__/pages/print_test.js
@@ -62,13 +62,30 @@ describe("Print", () => {
     props.url.query["statusAndVitals"] = "releasedAlive";
     props.url.query["needs"] = "43534534,43534ewr534";
     expect(mountedPrint().find(".needsListItem").length).toEqual(2);
-
     expect(
       mountedPrint()
         .find(".eligibilityListItem")
         .find("b")
         .text()
     ).toEqual("service-person");
+  });
+
+  it("has a correct sortBenefits function when sorting by popularity", () => {
+    let BLInstance = mountedPrint().instance();
+    expect(
+      BLInstance.sortBenefits(benefitsFixture, "en", "popularity").map(
+        b => b.id
+      )
+    ).toEqual(["3", "1", "0"]);
+  });
+
+  it("has a correct sortBenefits function when sorting alphabetically", () => {
+    let BLInstance = mountedPrint().instance();
+    expect(
+      BLInstance.sortBenefits(benefitsFixture, "en", "alphabetical").map(
+        b => b.id
+      )
+    ).toEqual(["1", "0", "3"]);
   });
 
   it("renders benefits correctly", () => {

--- a/components/BB.js
+++ b/components/BB.js
@@ -261,6 +261,7 @@ export class BB extends Component {
     if (needsIDs.length > 0) {
       url += "&needs=" + needsIDs.join(",");
     }
+    url += "&sortBy=" + this.state.sortByValue;
     if (filteredBenefitsIDs.length > 0) {
       url += "&benefits=" + filteredBenefitsIDs.join(",");
     }

--- a/components/BB.js
+++ b/components/BB.js
@@ -246,6 +246,7 @@ export class BB extends Component {
     filteredBenefits,
     selectedEligibility,
     selectedNeeds,
+    sortby,
     language
   ) => {
     const filteredBenefitsIDs = filteredBenefits.map(b => b.id);
@@ -261,7 +262,7 @@ export class BB extends Component {
     if (needsIDs.length > 0) {
       url += "&needs=" + needsIDs.join(",");
     }
-    url += "&sortBy=" + this.state.sortByValue;
+    url += "&sortBy=" + sortby;
     if (filteredBenefitsIDs.length > 0) {
       url += "&benefits=" + filteredBenefitsIDs.join(",");
     }
@@ -283,6 +284,7 @@ export class BB extends Component {
       filteredBenefits,
       this.props.selectedEligibility,
       this.props.selectedNeeds,
+      this.state.sortByValue,
       t("current-language-code")
     );
 

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -134,6 +134,7 @@ export class Favourites extends Component {
     if (needsIDs.length > 0) {
       url += "&needs=" + needsIDs.join(",");
     }
+    url += "&sortBy=" + this.state.sortByValue;
     if (filteredBenefitsIDs.length > 0) {
       url += "&benefits=" + filteredBenefitsIDs.join(",");
     }
@@ -245,6 +246,7 @@ const mapStateToProps = reduxState => {
   return {
     benefits: reduxState.benefits,
     eligibilityPaths: reduxState.eligibilityPaths,
+    needs: reduxState.needs,
     examples: reduxState.examples,
     selectedEligibility: {
       patronType: reduxState.patronType,

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -119,6 +119,7 @@ export class Favourites extends Component {
     filteredBenefits,
     selectedEligibility,
     selectedNeeds,
+    sortBy,
     language
   ) => {
     const filteredBenefitsIDs = filteredBenefits.map(b => b.id);
@@ -134,7 +135,7 @@ export class Favourites extends Component {
     if (needsIDs.length > 0) {
       url += "&needs=" + needsIDs.join(",");
     }
-    url += "&sortBy=" + this.state.sortByValue;
+    url += "&sortBy=" + sortBy;
     if (filteredBenefitsIDs.length > 0) {
       url += "&benefits=" + filteredBenefitsIDs.join(",");
     }
@@ -153,6 +154,7 @@ export class Favourites extends Component {
       filteredBenefits,
       this.props.selectedEligibility,
       this.props.selectedNeeds,
+      this.state.sortByValue,
       t("current-language-code")
     );
 

--- a/utils/redux2i18n.js
+++ b/utils/redux2i18n.js
@@ -1,7 +1,6 @@
 exports.redux2i18n = undefined;
 
 var redux2i18n = (exports.redux2i18n = function redux2i18n(i18n, translations) {
-  // eslint-disable-line no-unused-vars
   // export const redux2i18n = (i18n, translations) => {
   let i18nEn = {};
   let i18nFr = {};

--- a/utils/redux2i18n.js
+++ b/utils/redux2i18n.js
@@ -1,6 +1,7 @@
 exports.redux2i18n = undefined;
 
 var redux2i18n = (exports.redux2i18n = function redux2i18n(i18n, translations) {
+  // eslint-disable-line no-unused-vars
   // export const redux2i18n = (i18n, translations) => {
   let i18nEn = {};
   let i18nFr = {};


### PR DESCRIPTION
fixes #459 

print page didn't have benefits sorted anymore. Fixed now.

I think the bug was introduced when we changed the print page from using BenefitList (which sorts the benefits internally) to manually unrolling the filteredBenefits.

Note that eventually we will probably move the sortedBenefits into redux and just pull that into the print page.