### PR TITLE
Fix Heroku R10 timeouts

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: yarn build && yarn start
+web: yarn start

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
+    "postinstall": "next build",
     "start": "NODE_ENV=production node server.js",
     "test": " NODE_ENV=test jest --coverage",
     "lint": "node_modules/eslint/bin/eslint.js pages components __tests__",


### PR DESCRIPTION
I think this might fix #349 (R10 errors causing a time out on Heroku).
Following 
https://help.heroku.com/P1AVPANS/why-is-my-node-js-app-crashing-with-an-r10-error
and
https://devcenter.heroku.com/articles/getting-started-with-nodejs#define-a-procfile
I took the `yarn build` out of the `Procfile` and added it as a postinstall script in `packages.json`