### PR TITLE
Option B filter logic

### DIFF
--- a/__tests__/selectors/benefits_B_test.js
+++ b/__tests__/selectors/benefits_B_test.js
@@ -1,0 +1,132 @@
+import { getFilteredBenefits } from "../../selectors/benefits";
+
+describe("getFilteredBenefits", () => {
+  let props;
+  let state;
+
+  beforeEach(() => {
+    props = {
+      t: () => "en"
+    };
+    state = {
+      benefits: [
+        {
+          id: "0",
+          childBenefits: [],
+          availableIndependently: "Requires Gateway Benefit"
+        },
+        {
+          id: "1",
+          childBenefits: [],
+          availableIndependently: "Independent"
+        },
+        {
+          id: "2",
+          childBenefits: ["0", "1", "4"],
+          availableIndependently: "Independent"
+        },
+        {
+          id: "3",
+          childBenefits: ["4"],
+          availableIndependently: "Independent"
+        },
+        {
+          id: "4",
+          childBenefits: [],
+          availableIndependently: "Requires Gateway Benefit"
+        }
+      ],
+      eligibilityPaths: [
+        {
+          patronType: "p1",
+          serviceType: "na",
+          statusAndVitals: "na",
+          benefits: ["0", "2", "4"]
+        },
+        {
+          patronType: "p2",
+          serviceType: "na",
+          statusAndVitals: "na",
+          benefits: ["2"]
+        },
+        {
+          patronType: "p3",
+          serviceType: "na",
+          statusAndVitals: "na",
+          benefits: ["1", "3", "4"]
+        }
+      ],
+      enIdx: JSON.stringify({
+        version: "2.2.1",
+        fields: ["vacNameEn", "oneLineDescriptionEn"],
+        fieldVectors: [
+          ["vacNameEn/1", [0, 0.288]],
+          ["oneLineDescriptionEn/1", [1, 0.288]]
+        ],
+        invertedIndex: [
+          [
+            "biz",
+            { _index: 1, vacNameEn: {}, oneLineDescriptionEn: { "1": {} } }
+          ],
+          [
+            "fiz",
+            { _index: 0, vacNameEn: { "1": {} }, oneLineDescriptionEn: {} }
+          ]
+        ],
+        pipeline: ["stemmer"]
+      }),
+      frIdx: JSON.stringify({
+        version: "2.2.1",
+        fields: ["vacNameFr", "oneLineDescriptionFr"],
+        fieldVectors: [
+          ["vacNameFr/1", [0, 0.288]],
+          ["oneLineDescriptionFr/1", [1, 0.288]]
+        ],
+        invertedIndex: [
+          [
+            "biz",
+            { _index: 1, vacNameFr: {}, oneLineDescriptionFr: { "1": {} } }
+          ],
+          [
+            "fiz",
+            { _index: 0, vacNameFr: { "1": {} }, oneLineDescriptionFr: {} }
+          ]
+        ],
+        pipeline: ["stemmer"]
+      }),
+      needs: [],
+      selectedNeeds: {},
+      patronType: "",
+      searchString: "",
+      serviceType: "",
+      statusAndVitals: ""
+    };
+  });
+
+  // don't show benefit 0 because it's not independent
+  it("displays benefits 1, 2 and 3 if nothing selected", () => {
+    let returnValue = getFilteredBenefits(state, props).map(b => b.id);
+    returnValue.sort();
+    expect(returnValue).toEqual(["1", "2", "3"]);
+  });
+
+  // 0 and 2 match, but 0 is a child of  -> show both
+  it("display benefits 0, 2 if patronType p1", () => {
+    state.patronType = "p1";
+    expect(getFilteredBenefits(state, props).map(b => b.id)).toEqual([
+      "0",
+      "2"
+    ]);
+  });
+
+  it("runs a lunr search on the english index if searchString is set an english is used", () => {
+    state.searchString = "Fiz";
+    expect(getFilteredBenefits(state, props).map(b => b.id)).toEqual(["1"]);
+  });
+
+  it("runs a lunr search on the french index if searchString is set an french is used", () => {
+    props.t = () => "fr";
+    state.searchString = "Fiz";
+    expect(getFilteredBenefits(state, props).map(b => b.id)).toEqual(["1"]);
+  });
+});

--- a/__tests__/selectors/benefits_B_test.js
+++ b/__tests__/selectors/benefits_B_test.js
@@ -1,4 +1,4 @@
-import { getFilteredBenefits } from "../../selectors/benefits";
+import { getFilteredBenefits } from "../../selectors/benefits_B";
 
 describe("getFilteredBenefits", () => {
   let props;
@@ -103,19 +103,18 @@ describe("getFilteredBenefits", () => {
     };
   });
 
-  // don't show benefit 0 because it's not independent
-  it("displays benefits 1, 2 and 3 if nothing selected", () => {
+  it("displays all benefits if nothing selected", () => {
     let returnValue = getFilteredBenefits(state, props).map(b => b.id);
     returnValue.sort();
-    expect(returnValue).toEqual(["1", "2", "3"]);
+    expect(returnValue).toEqual(["0", "1", "2", "3", "4"]);
   });
 
-  // 0 and 2 match, but 0 is a child of  -> show both
-  it("display benefits 0, 2 if patronType p1", () => {
+  it("displays benefits 0, 2, 4 if patronType p1", () => {
     state.patronType = "p1";
     expect(getFilteredBenefits(state, props).map(b => b.id)).toEqual([
       "0",
-      "2"
+      "2",
+      "4"
     ]);
   });
 

--- a/selectors/benefits_B.js
+++ b/selectors/benefits_B.js
@@ -1,0 +1,101 @@
+import lunr from "lunr";
+import { createSelector } from "reselect";
+
+const getBenefits = state => state.benefits;
+const getCurrentLanguage = (state, props) => props.t("current-language-code");
+const getEligibilityPaths = state => state.eligibilityPaths;
+const getEnIdx = state => state.enIdx;
+const getFrIdx = state => state.frIdx;
+const getNeeds = state => state.needs;
+const getNeedsFilter = state => state.selectedNeeds;
+const getPatronFilter = state => state.patronType;
+const getSearchStringFilter = state => state.searchString;
+const getServiceFilter = state => state.serviceType;
+const getStatusFilter = state => state.statusAndVitals;
+
+export const getFilteredBenefits = createSelector(
+  [
+    getPatronFilter,
+    getServiceFilter,
+    getStatusFilter,
+    getNeedsFilter,
+    getBenefits,
+    getNeeds,
+    getEligibilityPaths,
+    getSearchStringFilter,
+    getCurrentLanguage,
+    getEnIdx,
+    getFrIdx
+  ],
+  (
+    patronFilter,
+    serviceFilter,
+    statusFilter,
+    selectedNeeds,
+    benefits,
+    needs,
+    eligibilityPaths,
+    searchString,
+    currentLanguage,
+    enIdx,
+    frIdx
+  ) => {
+    // Reinitalize indexes after they are serialized by Redux
+    enIdx = lunr.Index.load(JSON.parse(enIdx));
+    frIdx = lunr.Index.load(JSON.parse(frIdx));
+
+    let selectedEligibility = {
+      patronType: patronFilter,
+      serviceType: serviceFilter,
+      statusAndVitals: statusFilter
+    };
+    let eligibilityMatch = (path, selected) => {
+      let matches = true;
+      ["serviceType", "patronType", "statusAndVitals"].forEach(criteria => {
+        if (
+          selected[criteria] != "" &&
+          path[criteria] !== "na" &&
+          selected[criteria] != path[criteria]
+        ) {
+          matches = false;
+        }
+      });
+      return matches;
+    };
+
+    if (benefits.length === 0) {
+      return benefits;
+    }
+
+    // make it easy to invert the id
+    let benefitForId = {};
+    benefits.forEach(b => {
+      benefitForId[b.id] = b;
+    });
+
+    // find benefits that match
+    let eligibleBenefitIds = [];
+    eligibilityPaths.forEach(ep => {
+      if (eligibilityMatch(ep, selectedEligibility)) {
+        eligibleBenefitIds = eligibleBenefitIds.concat(ep.benefits);
+      }
+    });
+
+    let benefitIdsForSelectedNeeds = [];
+    if (Object.keys(selectedNeeds).length > 0) {
+      Object.keys(selectedNeeds).forEach(id => {
+        const need = needs.filter(n => n.id === id)[0];
+        benefitIdsForSelectedNeeds = benefitIdsForSelectedNeeds.concat(
+          need.benefits
+        );
+      });
+    } else {
+      benefitIdsForSelectedNeeds = benefits.map(b => b.id);
+    }
+    let matchingBenefitIds = eligibleBenefitIds.filter(
+      id => benefitIdsForSelectedNeeds.indexOf(id) > -1
+    );
+
+    return matchingBenefitIds.map(id => benefitForId[id]);
+  }
+);

--- a/selectors/benefits_B.js
+++ b/selectors/benefits_B.js
@@ -53,9 +53,9 @@ export const getFilteredBenefits = createSelector(
       let matches = true;
       ["serviceType", "patronType", "statusAndVitals"].forEach(criteria => {
         if (
-          selected[criteria] != "" &&
+          selected[criteria] !== "" &&
           path[criteria] !== "na" &&
-          selected[criteria] != path[criteria]
+          selected[criteria] !== path[criteria]
         ) {
           matches = false;
         }
@@ -66,12 +66,6 @@ export const getFilteredBenefits = createSelector(
     if (benefits.length === 0) {
       return benefits;
     }
-
-    // make it easy to invert the id
-    let benefitForId = {};
-    benefits.forEach(b => {
-      benefitForId[b.id] = b;
-    });
 
     // find benefits that match
     let eligibleBenefitIds = [];
@@ -95,7 +89,22 @@ export const getFilteredBenefits = createSelector(
     let matchingBenefitIds = eligibleBenefitIds.filter(
       id => benefitIdsForSelectedNeeds.indexOf(id) > -1
     );
+    let matchingBenefits = benefits.filter(b =>
+      matchingBenefitIds.includes(b.id)
+    );
 
-    return matchingBenefitIds.map(id => benefitForId[id]);
+    // If there is a searchString the run another filter
+    if (searchString.trim() !== "") {
+      let results = [];
+      if (currentLanguage === "en") {
+        results = enIdx.search(searchString + "*");
+      } else {
+        results = frIdx.search(searchString + "*");
+      }
+      let resultIds = results.map(r => r.ref);
+      matchingBenefits = matchingBenefits.filter(b => resultIds.includes(b.id));
+    }
+
+    return matchingBenefits;
   }
 );


### PR DESCRIPTION
resolves #520 

Make a new version of the selector that filters benefits based on selected profile and needs. In this version, pass along any benefits that match both (regardless of parent/child relationships or independent status).