### PR TITLE
Fix for #564

### DIFF
--- a/components/federal_banner.js
+++ b/components/federal_banner.js
@@ -61,7 +61,7 @@ class FederalBanner extends Component {
       <div className={container}>
         <div className="svg-container">
           <GoCSignature
-            width="320px"
+            width="100%"
             lang={t("current-language-code")}
             flag="#fff"
             text="#fff"


### PR DESCRIPTION
Set federal logo to dynamic width - this should solve some of the problems with #564. Tested it on Android and it looked fine. Probably a lot of the other recent mobile layout fixes helped this as well. 