### PR TITLE
Janky filter dropdown

### DIFF
--- a/__tests__/components/BB_test.js
+++ b/__tests__/components/BB_test.js
@@ -89,11 +89,11 @@ describe("BB", () => {
   });
 
   it("has the ProfileSelector component", () => {
-    expect(mounted_BB().find("ProfileSelector").length).toEqual(1);
+    expect(mounted_BB().find("ProfileSelector").length).not.toEqual(0);
   });
 
   it("has the NeedsSelector component", () => {
-    expect(mounted_BB().find("NeedsSelector").length).toEqual(1);
+    expect(mounted_BB().find("NeedsSelector").length).not.toEqual(0);
   });
 
   it("has a Clear Filters button", () => {

--- a/__tests__/components/needs_selector_test.js
+++ b/__tests__/components/needs_selector_test.js
@@ -47,7 +47,7 @@ describe("NeedsSelector", () => {
 
   it("has the exact number of children as passed", () => {
     const select = mountedNeedsSelector()
-      .find("#needs_buttons")
+      // .find("#needs_buttons")
       .find("Button");
     expect(select.length).toEqual(needsFixture.length);
   });

--- a/__tests__/components/profile_needs_selector_mobile_test.js
+++ b/__tests__/components/profile_needs_selector_mobile_test.js
@@ -1,13 +1,13 @@
 import React from "react";
 import { mount } from "enzyme";
-import { ProfileNeedsSelector } from "../../components/profile_needs_selector";
+import { ProfileNeedsSelectorMobile } from "../../components/profile_needs_selector_mobile";
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
 import needsFixture from "../fixtures/needs";
 import configureStore from "redux-mock-store";
 
-describe("ProfileNeedsSelector", () => {
+describe("ProfileNeedsSelectorMobile", () => {
   let props;
   let mockStore, reduxData;
 
@@ -43,7 +43,9 @@ describe("ProfileNeedsSelector", () => {
   });
 
   it("passes axe tests", async () => {
-    let html = mount(<ProfileNeedsSelector {...props} {...reduxData} />).html();
+    let html = mount(
+      <ProfileNeedsSelectorMobile {...props} {...reduxData} />
+    ).html();
     expect(await axe(html)).toHaveNoViolations();
   });
 
@@ -51,8 +53,8 @@ describe("ProfileNeedsSelector", () => {
     reduxData.patronType = "";
     props.store = mockStore(reduxData);
     expect(
-      mount(<ProfileNeedsSelector {...props} {...reduxData} />)
-        .find("#ClearFilters")
+      mount(<ProfileNeedsSelectorMobile {...props} {...reduxData} />)
+        .find("#ClearFiltersMobile")
         .first().length
     ).toEqual(0);
   });
@@ -61,8 +63,8 @@ describe("ProfileNeedsSelector", () => {
     reduxData.patronType = "organization";
     props.store = mockStore(reduxData);
     expect(
-      mount(<ProfileNeedsSelector {...props} {...reduxData} />)
-        .find("#ClearFilters")
+      mount(<ProfileNeedsSelectorMobile {...props} {...reduxData} />)
+        .find("#ClearFiltersMobile")
         .first().length
     ).toEqual(1);
   });
@@ -71,8 +73,8 @@ describe("ProfileNeedsSelector", () => {
     reduxData.selectedNeeds = {};
     props.store = mockStore(reduxData);
     expect(
-      mount(<ProfileNeedsSelector {...props} {...reduxData} />)
-        .find("#ClearFilters")
+      mount(<ProfileNeedsSelectorMobile {...props} {...reduxData} />)
+        .find("#ClearFiltersMobile")
         .first().length
     ).toEqual(0);
   });
@@ -81,15 +83,15 @@ describe("ProfileNeedsSelector", () => {
     reduxData.selectedNeeds = { foo: "bar" };
     props.store = mockStore(reduxData);
     expect(
-      mount(<ProfileNeedsSelector {...props} {...reduxData} />)
-        .find("#ClearFilters")
+      mount(<ProfileNeedsSelectorMobile {...props} {...reduxData} />)
+        .find("#ClearFiltersMobile")
         .first().length
     ).toEqual(1);
   });
 
   it("has a correct clearFilters function", () => {
     let instance = mount(
-      <ProfileNeedsSelector {...props} {...reduxData} />
+      <ProfileNeedsSelectorMobile {...props} {...reduxData} />
     ).instance();
     instance.clearFilters();
     expect(reduxData.setPatronType).toBeCalledWith("");

--- a/__tests__/components/profile_selector_test.js
+++ b/__tests__/components/profile_selector_test.js
@@ -43,7 +43,7 @@ describe("ProfileSelector", () => {
   it("has a patronType filter", () => {
     expect(
       mount(<ProfileSelector {...props} {...reduxData} />)
-        .find("#patronTypeFilter")
+        .find(".patronTypeFilter")
         .first().length
     ).toEqual(1);
   });
@@ -51,45 +51,45 @@ describe("ProfileSelector", () => {
   it("shows each question when showQuestion is true ", () => {
     expect(
       mount(<ProfileSelector {...props} {...reduxData} />)
-        .find("#serviceTypeFilter")
+        .find(".serviceTypeFilter")
         .first().length
     ).toEqual(1);
     expect(
       mount(<ProfileSelector {...props} {...reduxData} />)
-        .find("#statusAndVitalsFilter")
+        .find(".statusAndVitalsFilter")
         .first().length
     ).toEqual(1);
     expect(
       mount(<ProfileSelector {...props} {...reduxData} />)
-        .find("#serviceHealthIssueFilter")
+        .find(".serviceHealthIssueFilter")
         .first().length
     ).toEqual(1);
   });
 
-  it("shows each question when showQuestion is false ", () => {
+  it("does not show any questions when showQuestion is false", () => {
     reduxData.showServiceType = false;
     reduxData.showStatusAndVitals = false;
     reduxData.showServiceHealthIssue = false;
     expect(
       mount(<ProfileSelector {...props} {...reduxData} />)
-        .find("#serviceTypeFilter")
+        .find(".serviceTypeFilter")
         .first().length
     ).toEqual(0);
     expect(
       mount(<ProfileSelector {...props} {...reduxData} />)
-        .find("#statusAndVitalsFilter")
+        .find(".statusAndVitalsFilter")
         .first().length
     ).toEqual(0);
     expect(
       mount(<ProfileSelector {...props} {...reduxData} />)
-        .find("#serviceHealthIssueFilter")
+        .find(".serviceHealthIssueFilter")
         .first().length
     ).toEqual(0);
   });
 
   it("has the correct radio button text", () => {
     const text = mount(<ProfileSelector {...props} {...reduxData} />)
-      .find("#patronTypeFilter")
+      .find(".patronTypeFilter")
       .first()
       .find("FormControlLabel")
       .first()

--- a/components/BB.js
+++ b/components/BB.js
@@ -13,6 +13,7 @@ import TextField from "@material-ui/core/TextField";
 import "babel-polyfill/dist/polyfill";
 import BenefitList from "../components/benefit_list";
 import ProfileNeedsSelector from "./profile_needs_selector";
+import ProfileNeedsSelectorMobile from "./profile_needs_selector_mobile";
 import { connect } from "react-redux";
 import { getFilteredBenefits } from "../selectors/benefits";
 import Bookmark from "@material-ui/icons/Bookmark";
@@ -238,6 +239,7 @@ export class BB extends Component {
           <Grid item xs={12}>
             <Grid container spacing={32} className={classes.container}>
               <Grid item lg={4} md={4} sm={5} xs={12}>
+                <ProfileNeedsSelectorMobile t={t} store={this.props.store} />
                 <ProfileNeedsSelector t={t} store={this.props.store} />
               </Grid>
               <Grid item lg={8} md={8} sm={7} xs={12}>

--- a/components/needs_selector.js
+++ b/components/needs_selector.js
@@ -33,7 +33,7 @@ export class NeedsSelector extends Component {
             </Typography>
           </Grid>
           <Grid
-            id="needs_buttons"
+            // id="needs_buttons"
             item
             xs={12}
             className={classes.needsButtons}

--- a/components/profile_needs_selector.js
+++ b/components/profile_needs_selector.js
@@ -83,9 +83,8 @@ export class ProfileNeedsSelector extends Component {
       <Paper className={classes.root}>
         <Typography variant="title" className={classnames(classes.filterTitle)}>
           {t("filters")}{" "}
-          {(JSON.stringify(this.props.selectedNeeds) !== "{}" ||
-            this.props.patronType !== "") &&
-          pageWidth > 600 ? (
+          {JSON.stringify(this.props.selectedNeeds) !== "{}" ||
+          this.props.patronType !== "" ? (
             <Button
               className={classnames(classes.clearButton)}
               id="ClearFilters"
@@ -108,29 +107,6 @@ export class ProfileNeedsSelector extends Component {
           </Grid>
           <Grid item sm={12}>
             <NeedsSelector t={t} pageWidth={pageWidth} store={store} />
-
-            {(JSON.stringify(this.props.selectedNeeds) !== "{}" ||
-              this.props.patronType !== "") &&
-            pageWidth <= 600 ? (
-              <Typography
-                variant="title"
-                className={classnames(classes.filterTitle)}
-              >
-                <Button
-                  className={classnames(classes.clearButton)}
-                  id="ClearFilters"
-                  variant="flat"
-                  size="small"
-                  onClick={() => {
-                    this.clearFilters();
-                  }}
-                >
-                  {t("reset filters")} {"(" + this.countSelected() + ")"}
-                </Button>
-              </Typography>
-            ) : (
-              ""
-            )}
           </Grid>
         </Grid>
       </Paper>

--- a/components/profile_needs_selector.js
+++ b/components/profile_needs_selector.js
@@ -9,11 +9,13 @@ import ProfileSelector from "./profile_selector";
 import { withStyles } from "@material-ui/core/styles";
 import classnames from "classnames";
 import { connect } from "react-redux";
-import { Grid, Button } from "@material-ui/core";
+import { Grid, Button, Paper } from "@material-ui/core";
 import Typography from "@material-ui/core/Typography";
 
 const styles = theme => ({
   root: {
+    padding: "25px",
+    paddingTop: "20px",
     backgroundColor: "white",
     [theme.breakpoints.down(600)]: {
       display: "none"
@@ -34,7 +36,8 @@ const styles = theme => ({
     fontSize: "16px"
   },
   filterTitle: {
-    paddingRight: "0px"
+    paddingRight: "0px",
+    marginBottom: "25px"
   },
   gridItemButton: {
     textAlign: "center"
@@ -77,75 +80,60 @@ export class ProfileNeedsSelector extends Component {
   render() {
     const { t, pageWidth, store, classes } = this.props;
     return (
-      <ExpansionPanel
-        className={classnames(classes.root)}
-        defaultExpanded
-        expanded={pageWidth >= 600 ? true : this.state.open}
-      >
-        <ExpansionPanelSummary
-          className={classnames(classes.summary)}
-          expandIcon={pageWidth >= 600 ? "" : <ExpandMoreIcon />}
-          onClick={pageWidth >= 600 ? foo => foo : () => this.toggleOpenState()}
-        >
-          <Typography
-            variant="title"
-            className={classnames(classes.filterTitle)}
-          >
-            {t("filters")}{" "}
+      <Paper className={classes.root}>
+        <Typography variant="title" className={classnames(classes.filterTitle)}>
+          {t("filters")}{" "}
+          {(JSON.stringify(this.props.selectedNeeds) !== "{}" ||
+            this.props.patronType !== "") &&
+          pageWidth > 600 ? (
+            <Button
+              className={classnames(classes.clearButton)}
+              id="ClearFilters"
+              variant="flat"
+              size="small"
+              onClick={() => {
+                this.clearFilters();
+              }}
+            >
+              {t("reset filters")} {"(" + this.countSelected() + ")"}
+            </Button>
+          ) : (
+            ""
+          )}
+        </Typography>
+
+        <Grid container>
+          <Grid item sm={12} className={classnames(classes.profileSelector)}>
+            <ProfileSelector t={t} store={store} />
+          </Grid>
+          <Grid item sm={12}>
+            <NeedsSelector t={t} pageWidth={pageWidth} store={store} />
+
             {(JSON.stringify(this.props.selectedNeeds) !== "{}" ||
               this.props.patronType !== "") &&
-            pageWidth > 600 ? (
-              <Button
-                className={classnames(classes.clearButton)}
-                id="ClearFilters"
-                variant="flat"
-                size="small"
-                onClick={() => {
-                  this.clearFilters();
-                }}
+            pageWidth <= 600 ? (
+              <Typography
+                variant="title"
+                className={classnames(classes.filterTitle)}
               >
-                {t("reset filters")} {"(" + this.countSelected() + ")"}
-              </Button>
+                <Button
+                  className={classnames(classes.clearButton)}
+                  id="ClearFilters"
+                  variant="flat"
+                  size="small"
+                  onClick={() => {
+                    this.clearFilters();
+                  }}
+                >
+                  {t("reset filters")} {"(" + this.countSelected() + ")"}
+                </Button>
+              </Typography>
             ) : (
               ""
             )}
-          </Typography>
-        </ExpansionPanelSummary>
-
-        <ExpansionPanelDetails>
-          <Grid container>
-            <Grid item sm={12} className={classnames(classes.profileSelector)}>
-              <ProfileSelector t={t} store={store} />
-            </Grid>
-            <Grid item sm={12}>
-              <NeedsSelector t={t} pageWidth={pageWidth} store={store} />
-
-              {(JSON.stringify(this.props.selectedNeeds) !== "{}" ||
-                this.props.patronType !== "") &&
-              pageWidth <= 600 ? (
-                <Typography
-                  variant="title"
-                  className={classnames(classes.filterTitle)}
-                >
-                  <Button
-                    className={classnames(classes.clearButton)}
-                    id="ClearFilters"
-                    variant="flat"
-                    size="small"
-                    onClick={() => {
-                      this.clearFilters();
-                    }}
-                  >
-                    {t("reset filters")} {"(" + this.countSelected() + ")"}
-                  </Button>
-                </Typography>
-              ) : (
-                ""
-              )}
-            </Grid>
           </Grid>
-        </ExpansionPanelDetails>
-      </ExpansionPanel>
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/components/profile_needs_selector.js
+++ b/components/profile_needs_selector.js
@@ -1,9 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import NeedsSelector from "./needs_selector";
 import ProfileSelector from "./profile_selector";
 import { withStyles } from "@material-ui/core/styles";

--- a/components/profile_needs_selector_mobile.js
+++ b/components/profile_needs_selector_mobile.js
@@ -111,7 +111,7 @@ export class ProfileNeedsSelectorMobile extends Component {
                 >
                   <Button
                     className={classnames(classes.clearButton)}
-                    id="ClearFilters"
+                    id="ClearFiltersMobile"
                     variant="flat"
                     size="small"
                     onClick={() => {

--- a/components/profile_needs_selector_mobile.js
+++ b/components/profile_needs_selector_mobile.js
@@ -15,7 +15,7 @@ import Typography from "@material-ui/core/Typography";
 const styles = theme => ({
   root: {
     backgroundColor: "white",
-    [theme.breakpoints.down(600)]: {
+    [theme.breakpoints.up(600)]: {
       display: "none"
     }
   },
@@ -41,7 +41,7 @@ const styles = theme => ({
   }
 });
 
-export class ProfileNeedsSelector extends Component {
+export class ProfileNeedsSelectorMobile extends Component {
   state = {
     open: false
   };
@@ -80,35 +80,18 @@ export class ProfileNeedsSelector extends Component {
       <ExpansionPanel
         className={classnames(classes.root)}
         defaultExpanded
-        expanded={pageWidth >= 600 ? true : this.state.open}
+        expanded={this.state.open}
       >
         <ExpansionPanelSummary
           className={classnames(classes.summary)}
-          expandIcon={pageWidth >= 600 ? "" : <ExpandMoreIcon />}
-          onClick={pageWidth >= 600 ? foo => foo : () => this.toggleOpenState()}
+          expandIcon={<ExpandMoreIcon />}
+          onClick={() => this.toggleOpenState()}
         >
           <Typography
             variant="title"
             className={classnames(classes.filterTitle)}
           >
             {t("filters")}{" "}
-            {(JSON.stringify(this.props.selectedNeeds) !== "{}" ||
-              this.props.patronType !== "") &&
-            pageWidth > 600 ? (
-              <Button
-                className={classnames(classes.clearButton)}
-                id="ClearFilters"
-                variant="flat"
-                size="small"
-                onClick={() => {
-                  this.clearFilters();
-                }}
-              >
-                {t("reset filters")} {"(" + this.countSelected() + ")"}
-              </Button>
-            ) : (
-              ""
-            )}
           </Typography>
         </ExpansionPanelSummary>
 
@@ -120,9 +103,8 @@ export class ProfileNeedsSelector extends Component {
             <Grid item sm={12}>
               <NeedsSelector t={t} pageWidth={pageWidth} store={store} />
 
-              {(JSON.stringify(this.props.selectedNeeds) !== "{}" ||
-                this.props.patronType !== "") &&
-              pageWidth <= 600 ? (
+              {JSON.stringify(this.props.selectedNeeds) !== "{}" ||
+              this.props.patronType !== "" ? (
                 <Typography
                   variant="title"
                   className={classnames(classes.filterTitle)}
@@ -182,7 +164,7 @@ const mapStateToProps = reduxState => {
   };
 };
 
-ProfileNeedsSelector.propTypes = {
+ProfileNeedsSelectorMobile.propTypes = {
   classes: PropTypes.object.isRequired,
   selectedNeeds: PropTypes.object.isRequired,
   patronType: PropTypes.string.isRequired,
@@ -203,4 +185,4 @@ ProfileNeedsSelector.propTypes = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps1
-)(withStyles(styles)(ProfileNeedsSelector));
+)(withStyles(styles)(ProfileNeedsSelectorMobile));

--- a/components/profile_selector.js
+++ b/components/profile_selector.js
@@ -34,7 +34,7 @@ export class ProfileSelector extends Component {
           {t("B3.Filter by eligibility")}
         </Typography>
         <Grid container spacing={8}>
-          <Grid item xs={12} id="patronTypeFilter">
+          <Grid item xs={12} className="patronTypeFilter">
             <RadioSelector
               t={t}
               legend={t("B3.Benefits for")}
@@ -44,7 +44,7 @@ export class ProfileSelector extends Component {
           </Grid>
 
           {showServiceType ? (
-            <Grid item xs={12} id="serviceTypeFilter">
+            <Grid item xs={12} className="serviceTypeFilter">
               <RadioSelector
                 t={t}
                 legend={t("B3.ServiceType")}
@@ -57,7 +57,7 @@ export class ProfileSelector extends Component {
           )}
 
           {showStatusAndVitals ? (
-            <Grid item xs={12} id="statusAndVitalsFilter">
+            <Grid item xs={12} className="statusAndVitalsFilter">
               <RadioSelector
                 t={t}
                 legend={t("B3.serviceStatus")}
@@ -70,7 +70,7 @@ export class ProfileSelector extends Component {
           )}
 
           {showServiceHealthIssue ? (
-            <Grid item xs={12} id="serviceHealthIssueFilter">
+            <Grid item xs={12} className="serviceHealthIssueFilter">
               <RadioSelector
                 t={t}
                 legend={t(


### PR DESCRIPTION
fixes #790 
Use breakpoints to stop ProfileNeedsSelector flicker on mobile (where it would first appear as just a box, then switch to an open expansion panel, then close).  Decided that the cleanest way was to make two components, one for desktop and one for mobile. Had to futz with ids to get the axe tests to not complain about repeated ids.