### PR TITLE
Stop buttons from getting stuck in a depressed state

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -40,9 +40,6 @@ const styles = () => ({
 
 const theme = createMuiTheme({
   overrides: {
-    MuiButton: {
-      root: { "&:focus": { opacity: 0.3 } }
-    },
     MuiTouchRipple: {
       childPulsate: { opacity: 0 },
       ripplePulsate: { opacity: 0 }


### PR DESCRIPTION
Closes #835

It's not obvious now when the button is focussed (by hitting tab) but maybe we can fix that later.