### PR TITLE
fix map page moving on office select

### DIFF
--- a/components/area_office_map.js
+++ b/components/area_office_map.js
@@ -65,7 +65,7 @@ export class AreaOfficeMap extends Component {
       // element in area_office_table
       const elmnt = document.getElementById("tableRow" + selected_office.id);
       if (elmnt !== null) {
-        elmnt.scrollIntoView();
+        document.getElementById("scrolling_div").scrollTop = elmnt.offsetTop;
       }
     };
   }

--- a/components/area_office_table.js
+++ b/components/area_office_table.js
@@ -182,7 +182,10 @@ export class AreaOfficeTable extends Component {
           </Table>
         </div>
 
-        <div style={{ height: "400px", width: "100%", overflowY: "scroll" }}>
+        <div
+          id="scrolling_div"
+          style={{ height: "400px", width: "100%", overflowY: "scroll" }}
+        >
           <Table>
             <TableBody>
               {this.isDefaultLocation()


### PR DESCRIPTION
fixes #795 

when selecting a pin in the map, we were scrolling the screen to get the office to be shown in the accompanying list. changed to just scroll the list.