### PR TITLE
Changed back behaviour, fixed tests

### DIFF
--- a/__tests__/pages/A_test.js
+++ b/__tests__/pages/A_test.js
@@ -19,10 +19,7 @@ expect.extend(toHaveNoViolations);
 jest.mock("react-ga");
 
 describe("A", () => {
-  Router.router = {
-    push: jest.fn()
-  };
-  Router.push = jest.fn();
+  Router.replace = jest.fn();
 
   let props;
   let _mountedA;
@@ -92,7 +89,7 @@ describe("A", () => {
       "/A?section=S&selectedNeeds=health,financial&patronType=family&serviceType=CAF&lng=en";
     AInstance.setState(state);
     AInstance.setURL(state);
-    expect(Router.push).toBeCalledWith(expectedURL);
+    expect(Router.replace).toBeCalledWith(expectedURL);
   });
 
   it("componentWillMount sets state correctly from empty url", () => {

--- a/__tests__/pages/benefits_directory_test.js
+++ b/__tests__/pages/benefits_directory_test.js
@@ -18,10 +18,7 @@ expect.extend(toHaveNoViolations);
 jest.mock("react-ga");
 
 describe("BenefitsDirectory", () => {
-  Router.router = {
-    push: jest.fn()
-  };
-  Router.push = jest.fn();
+  Router.replace = jest.fn();
 
   let props;
   let _mountedBenefitsDirectory;
@@ -121,6 +118,6 @@ describe("BenefitsDirectory", () => {
     const expectedURL =
       "/benefits-directory?lng=en&selectedNeeds=health,financial&patronType=family&serviceType=CAF&searchString=foo";
     AInstance.setURL();
-    expect(Router.push).toBeCalledWith(expectedURL);
+    expect(Router.replace).toBeCalledWith(expectedURL);
   });
 });

--- a/components/search.js
+++ b/components/search.js
@@ -13,8 +13,6 @@ import parse from "autosuggest-highlight/parse";
 import { connect } from "react-redux";
 import { withStyles } from "@material-ui/core/styles";
 
-import Router from "next/router";
-
 const styles = theme => ({
   container: {
     flexGrow: 1,
@@ -97,7 +95,7 @@ export class Search extends Component {
       this.props.t("current-language-code") +
       "&searchString=" +
       this.state.value;
-    Router.push(href);
+    window.location.href = href;
   };
 
   getSuggestions = value => {

--- a/pages/A.js
+++ b/pages/A.js
@@ -61,7 +61,7 @@ export class A extends Component {
       }
     });
     href += "&lng=" + this.props.t("current-language-code");
-    Router.push(href);
+    Router.replace(href);
   };
 
   setSection = section => {

--- a/pages/benefits-directory.js
+++ b/pages/benefits-directory.js
@@ -55,7 +55,6 @@ export class BenefitsDirectory extends Component {
 
   render() {
     const { i18n, t } = this.props; // eslint-disable-line no-unused-vars
-    console.log(this.props.url);
     return (
       <Layout
         i18n={this.props.i18n}

--- a/pages/benefits-directory.js
+++ b/pages/benefits-directory.js
@@ -50,11 +50,12 @@ export class BenefitsDirectory extends Component {
     if (this.props.searchString !== "") {
       href += `&searchString=${encodeURIComponent(this.props.searchString)}`;
     }
-    Router.push(href);
+    Router.replace(href);
   };
 
   render() {
     const { i18n, t } = this.props; // eslint-disable-line no-unused-vars
+    console.log(this.props.url);
     return (
       <Layout
         i18n={this.props.i18n}


### PR DESCRIPTION
Closes #877 
Closes #872 

Hitting the browser back button now always goes to the previous page, rather than the previous state on the same page.

One drawback is that hitting browser back from (for example) the 3rd page of guided experience will take you back to the landing page. I tried to change this to go to the previous section but it didn't work.