### PR TITLE
Streamlined polyfilling

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,17 @@
 module.exports = {
   webpack: (config, { dev }) => {
+    const originalEntry = config.entry;
+
+    config.entry = async () => {
+      const entries = await originalEntry();
+
+      if (entries["main.js"]) {
+        entries["main.js"].unshift("./utils/polyfills.js");
+      }
+
+      return entries;
+    };
+
     if (dev) {
       config.module.rules.push({
         test: /\.js$/,

--- a/pages/A.js
+++ b/pages/A.js
@@ -10,7 +10,6 @@ import Cookies from "universal-cookie";
 import GuidedExperience from "../components/guided_experience";
 import GuidedExperienceProfile from "../components/guided_experience_profile";
 import GuidedExperienceNeeds from "../components/guided_experience_needs";
-import "../utils/polyfills";
 
 export class A extends Component {
   constructor() {

--- a/pages/data-validation.js
+++ b/pages/data-validation.js
@@ -11,7 +11,6 @@ import ReactMoment from "react-moment";
 import { withI18next } from "../lib/withI18next";
 import Layout from "../components/layout";
 import { connect } from "react-redux";
-import "../utils/polyfills";
 
 const styles = theme => ({
   root: {

--- a/pages/map.js
+++ b/pages/map.js
@@ -12,7 +12,6 @@ import { Grid, Button } from "@material-ui/core";
 import ArrowBack from "@material-ui/icons/ArrowBack";
 import Paper from "@material-ui/core/Paper/index";
 import Link from "next/link";
-import "../utils/polyfills";
 
 const styles = theme => ({
   paper: {

--- a/utils/polyfills.js
+++ b/utils/polyfills.js
@@ -3,6 +3,6 @@
 // Add polyfills here. Check all available here: https://github.com/zloirock/core-js
 // This files runs at the very beginning (even before React and Next.js core)
 
-// FOLLOWING IS THE IMPORT I NEEDED FOR IE 11, 10
+// FOLLOWING IS THE IMPORT NEEDED FOR IE 11, 10
 import "core-js/fn/object/assign";
 import "core-js/fn/object/entries";

--- a/utils/polyfills.js
+++ b/utils/polyfills.js
@@ -1,46 +1,8 @@
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#Polyfill
+/* eslint no-extend-native: 0 */
 
-if (!Object.entries)
-  Object.entries = function(obj) {
-    var ownProps = Object.keys(obj),
-      i = ownProps.length,
-      resArray = new Array(i); // preallocate the Array
-    while (i--) resArray[i] = [ownProps[i], obj[ownProps[i]]];
+// Add polyfills here. Check all available here: https://github.com/zloirock/core-js
+// This files runs at the very beginning (even before React and Next.js core)
 
-    return resArray;
-  };
-
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
-
-if (typeof Object.assign != "function") {
-  // Must be writable: true, enumerable: false, configurable: true
-  Object.defineProperty(Object, "assign", {
-    value: function assign(target) {
-      // .length of function is 2
-      "use strict";
-      if (target == null) {
-        // TypeError if undefined or null
-        throw new TypeError("Cannot convert undefined or null to object");
-      }
-
-      var to = Object(target);
-
-      for (var index = 1; index < arguments.length; index++) {
-        var nextSource = arguments[index];
-
-        if (nextSource != null) {
-          // Skip over if undefined or null
-          for (var nextKey in nextSource) {
-            // Avoid bugs when hasOwnProperty is shadowed
-            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-              to[nextKey] = nextSource[nextKey];
-            }
-          }
-        }
-      }
-      return to;
-    },
-    writable: true,
-    configurable: true
-  });
-}
+// FOLLOWING IS THE IMPORT I NEEDED FOR IE 11, 10
+import "core-js/fn/object/assign";
+import "core-js/fn/object/entries";


### PR DESCRIPTION
With babel7 things were changed around `useBuiltins` (https://medium.freecodecamp.org/were-nearing-the-7-0-babel-release-here-s-all-the-cool-stuff-we-ve-been-doing-8c1ade684039). It is no longer discovering that `Object.assign` needs to be loaded with NextJS. NextJS has published solution that our solution is based on: https://github.com/zeit/next.js/tree/canary/examples/with-polyfills