### PR TITLE
Improve airtable fetching

### DIFF
--- a/pages/data-validation.js
+++ b/pages/data-validation.js
@@ -221,7 +221,7 @@ DataValidation.propTypes = {
   examples: PropTypes.array.isRequired,
   i18n: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
-  timestamp: PropTypes.object,
+  timestamp: PropTypes.number.isRequired,
   classes: PropTypes.object.isRequired,
   translations: PropTypes.array.isRequired,
   areaOffices: PropTypes.array.isRequired

--- a/server.js
+++ b/server.js
@@ -22,14 +22,20 @@ const airTable = require("./utils/airtable_es2015");
 
 const { getGithubData } = require("./utils/statistics");
 
-getAllData = async function() {
+const getAllData = async function() {
   const githubData = await getGithubData();
   const airtableData = await airTable.hydrateFromAirtable();
-
   return { githubData: githubData, airtableData: airtableData };
 };
 
-// Promise.resolve(airTable.hydrateFromAirtable()).then(data => {
+const copyValidTables = (oldData, newData) => {
+  Object.keys(newData)
+    .filter(tableName => newData[tableName].length > 0)
+    .forEach(tableName => {
+      oldData[tableName] = newData[tableName];
+    });
+};
+
 Promise.resolve(getAllData()).then(allData => {
   let data = allData.airtableData;
   const githubData = allData.githubData;
@@ -75,7 +81,7 @@ Promise.resolve(getAllData()).then(allData => {
 
             setTimeout(function() {
               Promise.resolve(airTable.hydrateFromAirtable()).then(newData => {
-                data = newData;
+                copyValidTables(data, newData);
               });
             }, 1000 * 60 * 60);
 
@@ -99,7 +105,7 @@ Promise.resolve(getAllData()).then(allData => {
               console.log("Refreshing Cache ...");
               let referrer = req.header("Referer") || "/";
               Promise.resolve(airTable.hydrateFromAirtable()).then(newData => {
-                data = newData;
+                copyValidTables(data, newData);
                 res.redirect(referrer);
                 console.log("Cache refreshed @ " + data.timestamp);
               });

--- a/store.js
+++ b/store.js
@@ -69,7 +69,6 @@ export const reducer = (state = initialState, action) => {
 
     case "LOAD_DATA":
       newState = {
-        storeHydrated: action.data.storeHydrated || state.storeHydrated,
         favouriteBenefits:
           action.data.favouriteBenefits || state.favouriteBenefits,
         timestamp: action.data.timestamp || state.timestamp


### PR DESCRIPTION
fixes #923 

If the server can't fetch a table, just keep using the old data. Previously we'd throw away the old data in this situation.

to test: go rename one of the tables. after refreshing Azure that table is empty in the app, in this PR the old data is still there.