### PR TITLE
Only build next on Heroku not CI or locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
-    "postinstall": "next build",
+    "heroku-postbuild": "next build",
     "start": "NODE_ENV=production node server.js",
     "test": "NODE_ENV=test jest --coverage",
     "test:e2e": "testcafe chrome testcafe/",


### PR DESCRIPTION
Trying to fix the fact that we build next after every package install - it only needs to be built in production