### PR TITLE
Removed unused material-ui icons from js bundles

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -23,7 +23,25 @@
             "hoist": true
           }
         ],
-        "transform-inline-environment-variables"
+        "transform-inline-environment-variables",
+        [
+          "babel-plugin-import",
+          {
+             "libraryName": "@material-ui/core",
+             "libraryDirectory": "",
+             "camel2DashComponentName": false
+          },
+          "tree-shaking-mui-core"
+        ],
+        [
+           "babel-plugin-import",
+           {
+              "libraryName": "@material-ui/icons",
+              "libraryDirectory": "",
+              "camel2DashComponentName": false
+           },
+           "tree-shaking-mui-icons"
+        ]
       ],
       "presets": [
         "next/babel"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "autosuggest-highlight": "^3.1.1",
     "babel-loader": "^7.1.5",
     "babel-plugin-emotion": "^9.2.6",
+    "babel-plugin-import": "^1.8.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "babel-polyfill": "^6.26.0",
     "body-parser": "^1.18.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,6 +278,12 @@
     "@babel/types" "7.0.0-rc.1"
     lodash "^4.17.10"
 
+"@babel/helper-module-imports@^7.0.0-beta.34":
+  version "7.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.4.tgz#b524ed4e814c4b79e93ef538d71d2e562254852e"
+  dependencies:
+    "@babel/types" "^7.0.0-rc.4"
+
 "@babel/helper-module-transforms@7.0.0-beta.42":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.42.tgz#4d260cc786e712e8440bef58dae28040b77a6183"
@@ -1280,6 +1286,14 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.0.0-rc.4":
+  version "7.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-rc.4.tgz#304dbb9097fadcd35a59a53859a0b4c519186b38"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
 "@cdssnc/gcui@^0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@cdssnc/gcui/-/gcui-0.0.30.tgz#29f7668ce0e0acc8f614fcc9f027064d7129194a"
@@ -2051,6 +2065,12 @@ babel-plugin-emotion@^9.2.6:
     mkdirp "^0.5.1"
     source-map "^0.5.7"
     touch "^1.0.0"
+
+babel-plugin-import@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-import/-/babel-plugin-import-1.8.0.tgz#260deddd78f6fea0d110e1d106ba72a518d3c88c"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0-beta.34"
 
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"


### PR DESCRIPTION
Closes #1003 

Our bundle for /benefits-directory went from 370 KB (gzipped) to 50 KB! Similar reductions for all the other pages using icons. 

See attached Archive.zip file for the before and after of what our js bundle looks like, or run it yourself with `yarn bundle_analyzer`.
[Archive.zip](https://github.com/cds-snc/vac-benefits-directory/files/2325241/Archive.zip)
