### PR TITLE
made lunr version in tests dynamic

### DIFF
--- a/__tests__/components/search_test.js
+++ b/__tests__/components/search_test.js
@@ -5,6 +5,7 @@ import benefitsFixture from "../fixtures/benefits";
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
 import configureStore from "redux-mock-store";
+import lunr from "lunr";
 
 describe("Search", () => {
   let props;
@@ -30,7 +31,7 @@ describe("Search", () => {
     reduxData = {
       benefits: benefitsFixture,
       enIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameEn", "oneLineDescriptionEn"],
         fieldVectors: [
           ["vacNameEn/1", [0, 0.288]],
@@ -49,7 +50,7 @@ describe("Search", () => {
         pipeline: ["stemmer"]
       }),
       frIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameFr", "oneLineDescriptionFr"],
         fieldVectors: [
           ["vacNameFr/1", [0, 0.288]],

--- a/__tests__/pages/benefits_directory_test.js
+++ b/__tests__/pages/benefits_directory_test.js
@@ -12,7 +12,7 @@ import examplesFixture from "../fixtures/examples";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
 import areaOfficesFixture from "../fixtures/area_offices";
 import translate from "../fixtures/translate";
-
+import lunr from "lunr";
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
 
@@ -52,7 +52,7 @@ describe("BenefitsDirectory", () => {
       examples: examplesFixture,
       eligibilityPaths: eligibilityPathsFixture,
       enIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameEn", "oneLineDescriptionEn"],
         fieldVectors: [
           ["vacNameEn/1", [0, 0.288]],
@@ -71,7 +71,7 @@ describe("BenefitsDirectory", () => {
         pipeline: ["stemmer"]
       }),
       frIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameFr", "oneLineDescriptionFr"],
         fieldVectors: [
           ["vacNameFr/1", [0, 0.288]],

--- a/__tests__/pages/favourites_page_test.js
+++ b/__tests__/pages/favourites_page_test.js
@@ -2,7 +2,7 @@
 
 import { shallow } from "enzyme";
 import Router from "next/router";
-
+import lunr from "lunr";
 import React from "react";
 import { FavouritesPage } from "../../pages/favourites";
 import benefitsFixture from "../fixtures/benefits";
@@ -43,7 +43,7 @@ describe("Favourites Page", () => {
       examples: examplesFixture,
       eligibilityPaths: eligibilityPathsFixture,
       enIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameEn", "oneLineDescriptionEn"],
         fieldVectors: [
           ["vacNameEn/1", [0, 0.288]],
@@ -62,7 +62,7 @@ describe("Favourites Page", () => {
         pipeline: ["stemmer"]
       }),
       frIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameFr", "oneLineDescriptionFr"],
         fieldVectors: [
           ["vacNameFr/1", [0, 0.288]],

--- a/__tests__/pages/index_test.js
+++ b/__tests__/pages/index_test.js
@@ -7,6 +7,7 @@ import { App } from "../../pages/index";
 import benefitsFixture from "../fixtures/benefits";
 import configureStore from "redux-mock-store";
 import translate from "../fixtures/translate";
+import lunr from "lunr";
 
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
@@ -34,7 +35,7 @@ describe("Index page", () => {
       translations: [],
       benefits: benefitsFixture,
       enIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameEn", "oneLineDescriptionEn"],
         fieldVectors: [
           ["vacNameEn/1", [0, 0.288]],
@@ -54,7 +55,7 @@ describe("Index page", () => {
       }),
       favouriteBenefits: [],
       frIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameFr", "oneLineDescriptionFr"],
         fieldVectors: [
           ["vacNameFr/1", [0, 0.288]],

--- a/__tests__/selectors/benefits_test.js
+++ b/__tests__/selectors/benefits_test.js
@@ -1,4 +1,5 @@
 import { getFilteredBenefits } from "../../selectors/benefits";
+import lunr from "lunr";
 
 describe("getFilteredBenefits", () => {
   let props;
@@ -57,7 +58,7 @@ describe("getFilteredBenefits", () => {
         }
       ],
       enIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameEn", "oneLineDescriptionEn"],
         fieldVectors: [
           ["vacNameEn/1", [0, 0.288]],
@@ -76,7 +77,7 @@ describe("getFilteredBenefits", () => {
         pipeline: ["stemmer"]
       }),
       frIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameFr", "oneLineDescriptionFr"],
         fieldVectors: [
           ["vacNameFr/1", [0, 0.288]],

--- a/__tests__/selectors/urls_test.js
+++ b/__tests__/selectors/urls_test.js
@@ -1,4 +1,5 @@
 import { getFavouritesUrl, getPrintUrl } from "../../selectors/urls";
+import lunr from "lunr";
 
 describe("getFavouritesUrl", () => {
   let props;
@@ -163,7 +164,7 @@ describe("getPrintUrl", () => {
         }
       ],
       enIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameEn", "oneLineDescriptionEn"],
         fieldVectors: [
           ["vacNameEn/1", [0, 0.288]],
@@ -182,7 +183,7 @@ describe("getPrintUrl", () => {
         pipeline: ["stemmer"]
       }),
       frIdx: JSON.stringify({
-        version: "2.3.1",
+        version: lunr.version,
         fields: ["vacNameFr", "oneLineDescriptionFr"],
         fieldVectors: [
           ["vacNameFr/1", [0, 0.288]],


### PR DESCRIPTION
fixes #1076 

our tests used a fixed (previous) version of lunr that started throwing warnings when we upgraded the modules.