### PR TITLE
remove code that was throwing warnings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,10 +21,5 @@ module.exports = {
       lines: 75,
       statements: 75
     }
-  },
-  testEnvironmentOptions: {
-    beforeParse(window) {
-      window.scrollTo = () => {};
-    }
   }
 };


### PR DESCRIPTION
fixes #1078 

jest was complaining that part of our configuration didn't correspond to anything it knew about.