### PR TITLE
add return value to fetch

### DIFF
--- a/__tests__/pages/data-validation_tests.js
+++ b/__tests__/pages/data-validation_tests.js
@@ -175,6 +175,7 @@ describe("DataValidation", () => {
 
     it("loops through benefits and sends the benefit ID to the /checkURL endpoint", done => {
       global.fetch = jest.fn();
+      global.fetch.mockReturnValue(new Promise(() => {}));
       Promise.resolve(
         mountedDataValidation()
           .instance()


### PR DESCRIPTION
fixes #1080 

we were mocking the `fetch` function without giving it a fake return value.