### PR TITLE
Fix filter reset of NeedButton

### DIFF
--- a/components/need_button.js
+++ b/components/need_button.js
@@ -29,7 +29,7 @@ export class NeedButton extends Component {
       <FormControlLabel
         control={
           <Checkbox
-            checked={this.props.selectedNeeds[need.id]}
+            checked={this.props.selectedNeeds[need.id] !== undefined}
             onChange={() => this.handleClick(need.id)}
             value={need.id}
             color="primary"


### PR DESCRIPTION
fixes #1092 

We were treating `undefined` as `false`, but MaterialUI's `CheckBox` was not interpreting it this way.