### PR TITLE
Clean up header anchor link

### DIFF
--- a/__tests__/components/embedded_benefit_card_test.js
+++ b/__tests__/components/embedded_benefit_card_test.js
@@ -35,7 +35,7 @@ describe("EmbeddedBenefitCard", () => {
   it("has a blank target", () => {
     expect(
       mountedEmbeddedBenefitCard()
-        .find("HeaderAnchorLink")
+        .find("HeaderButton")
         .prop("target")
     ).toEqual("_blank");
   });
@@ -46,7 +46,7 @@ describe("EmbeddedBenefitCard", () => {
     );
     expect(
       mountedEmbeddedBenefitCard()
-        .find("HeaderAnchorLink")
+        .find("HeaderButton")
         .prop("href")
     ).toEqual(benefitsFixture[0].benefitPageEn);
     expect(mountedEmbeddedBenefitCard().text()).toContain(
@@ -65,7 +65,7 @@ describe("EmbeddedBenefitCard", () => {
       );
       expect(
         mountedEmbeddedBenefitCard()
-          .find("HeaderAnchorLink")
+          .find("HeaderButton")
           .prop("href")
       ).toEqual(benefitsFixture[0].benefitPageFr);
       expect(mountedEmbeddedBenefitCard().text()).toContain(

--- a/__tests__/components/header_button_test.js
+++ b/__tests__/components/header_button_test.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { mount } from "enzyme";
-import HeaderAnchorLink from "../../components/header_anchor_link";
+import HeaderButton from "../../components/header_button";
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
 
-describe("HeaderAnchorLink", () => {
+describe("HeaderButton", () => {
   let props;
   beforeEach(() => {
     props = {
@@ -13,11 +13,11 @@ describe("HeaderAnchorLink", () => {
   });
 
   it("passes axe tests", async () => {
-    let html = mount(<HeaderAnchorLink {...props} />).html();
+    let html = mount(<HeaderButton {...props} />).html();
     expect(await axe(html)).toHaveNoViolations();
   });
 
   it("shows children", () => {
-    expect(mount(<HeaderAnchorLink {...props} />).text()).toEqual("header");
+    expect(mount(<HeaderButton {...props} />).text()).toEqual("header");
   });
 });

--- a/components/BB.js
+++ b/components/BB.js
@@ -5,6 +5,7 @@ import InputLabel from "@material-ui/core/InputLabel";
 import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
 import Select from "@material-ui/core/Select";
+import Print from "@material-ui/icons/Print";
 import "babel-polyfill/dist/polyfill";
 import BenefitList from "../components/benefit_list";
 import ProfileNeedsSelector from "./profile_needs_selector";
@@ -153,8 +154,8 @@ export class BB extends Component {
                     href={this.props.printUrl}
                     target="print_page"
                     id="printButton"
-                    icon="print"
                   >
+                    <Print />{" "}
                     <span className={nonMobileStyle}> {t("Print")} </span>
                   </HeaderAnchorLink>
                 </Grid>

--- a/components/BB.js
+++ b/components/BB.js
@@ -18,7 +18,7 @@ import SearchIcon from "@material-ui/icons/Search";
 import { css } from "react-emotion";
 import Container from "../components/container";
 import Header2 from "../components/header2";
-import HeaderAnchorLink from "../components/header_anchor_link";
+import HeaderButton from "./header_button";
 import Body from "../components/body";
 import { globalTheme } from "../theme";
 
@@ -139,7 +139,7 @@ export class BB extends Component {
             <div className={container2}>
               <Grid container spacing={24}>
                 <Grid item xs={12} md={9}>
-                  <HeaderAnchorLink
+                  <HeaderButton
                     className={anchors}
                     href={this.props.favouritesUrl}
                   >
@@ -148,9 +148,9 @@ export class BB extends Component {
                       " (" +
                       this.props.favouriteBenefits.length +
                       ")"}
-                  </HeaderAnchorLink>
+                  </HeaderButton>
 
-                  <HeaderAnchorLink
+                  <HeaderButton
                     className={anchors}
                     href={this.props.printUrl}
                     target="print_page"
@@ -158,7 +158,7 @@ export class BB extends Component {
                   >
                     <Print />{" "}
                     <span className={nonMobileStyle}> {t("Print")} </span>
-                  </HeaderAnchorLink>
+                  </HeaderButton>
                 </Grid>
                 <Grid item xs={12}>
                   <Header2 className={"BenefitsCounter " + title}>

--- a/components/BB.js
+++ b/components/BB.js
@@ -18,11 +18,11 @@ import Container from "../components/container";
 import Header2 from "../components/header2";
 import HeaderAnchorLink from "../components/header_anchor_link";
 import Body from "../components/body";
+import { globalTheme } from "../theme";
 
 const outerDiv = css`
   padding-bottom: 16px !important;
 `;
-
 const topPadding = css`
   padding-top: 30px;
 `;
@@ -84,6 +84,11 @@ const inputIcon = css`
 `;
 const anchors = css`
   margin-right: 20px;
+`;
+const nonMobileStyle = css`
+  @media only screen and (max-width: ${globalTheme.max.xs}) {
+    display: none;
+  }
 `;
 
 export class BB extends Component {
@@ -149,8 +154,9 @@ export class BB extends Component {
                     target="print_page"
                     id="printButton"
                     icon="print"
-                    nonMobile={t("Print")}
-                  />
+                  >
+                    <span className={nonMobileStyle}> {t("Print")} </span>
+                  </HeaderAnchorLink>
                 </Grid>
                 <Grid item xs={12}>
                   <Header2 className={"BenefitsCounter " + title}>

--- a/components/BB.js
+++ b/components/BB.js
@@ -6,6 +6,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
 import Select from "@material-ui/core/Select";
 import Print from "@material-ui/icons/Print";
+import Bookmark from "@material-ui/icons/Bookmark";
 import "babel-polyfill/dist/polyfill";
 import BenefitList from "../components/benefit_list";
 import ProfileNeedsSelector from "./profile_needs_selector";
@@ -140,9 +141,9 @@ export class BB extends Component {
                 <Grid item xs={12} md={9}>
                   <HeaderAnchorLink
                     className={anchors}
-                    icon="bookmark"
                     href={this.props.favouritesUrl}
                   >
+                    <Bookmark />
                     {t("B3.favouritesButtonText") +
                       " (" +
                       this.props.favouriteBenefits.length +

--- a/components/embedded_benefit_card.js
+++ b/components/embedded_benefit_card.js
@@ -5,7 +5,7 @@ import { logEvent } from "../utils/analytics";
 import Paper from "@material-ui/core/Paper";
 import { css } from "react-emotion";
 import OneLiner from "./one_liner";
-import HeaderAnchorLink from "../components/header_anchor_link";
+import HeaderButton from "./header_button";
 
 const root = css`
   margin: 20px;
@@ -39,7 +39,7 @@ export class EmbeddedBenefitCard extends Component {
 
     return (
       <Paper className={root}>
-        <HeaderAnchorLink
+        <HeaderButton
           id={"embedded-" + benefit.id}
           target="_blank"
           rel="noopener noreferrer"
@@ -55,7 +55,7 @@ export class EmbeddedBenefitCard extends Component {
           }
         >
           {language === "en" ? benefit.vacNameEn : benefit.vacNameFr}
-        </HeaderAnchorLink>
+        </HeaderButton>
 
         <Grid container spacing={24}>
           <Grid item xs={12}>

--- a/components/favourite_button.js
+++ b/components/favourite_button.js
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import Cookies from "universal-cookie";
 import { css } from "react-emotion";
 import { globalTheme } from "../theme";
-import HeaderAnchorLink from "./header_anchor_link";
+import HeaderButton from "./header_button";
 
 const bookmarkButton = css`
   margin-left: -5px !important;
@@ -48,7 +48,7 @@ export class FavouriteButton extends Component {
     const isBookmarked =
       this.props.favouriteBenefits.indexOf(this.props.benefit.id) > -1;
     return (
-      <HeaderAnchorLink
+      <HeaderButton
         id={"favourite-" + this.props.benefit.id}
         className={bookmarkButton}
         aria-label={this.props.t("B3.favouritesButtonText")}
@@ -74,7 +74,7 @@ export class FavouriteButton extends Component {
               : "B3.favouritesButtonBTextMobile"
           )}
         </span>
-      </HeaderAnchorLink>
+      </HeaderButton>
     );
   }
 }

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -6,6 +6,7 @@ import BenefitList from "./benefit_list";
 import { connect } from "react-redux";
 import { getPrintUrl } from "../selectors/urls";
 import Bookmark from "@material-ui/icons/BookmarkBorder";
+import Print from "@material-ui/icons/Print";
 import Link from "next/link";
 import { css } from "react-emotion";
 import Container from "./container";
@@ -123,9 +124,8 @@ export class Favourites extends Component {
               href={this.props.printUrl}
               target="print_page"
               id="printButton"
-              icon="print"
             >
-              &nbsp; {t("Print")}
+              <Print /> {t("Print")}
             </HeaderAnchorLink>
 
             <Header2 className={contactUsTitle}>

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -12,7 +12,7 @@ import { css } from "react-emotion";
 import Container from "./container";
 import Header1 from "./header1";
 import Header2 from "./header2";
-import HeaderAnchorLink from "./header_anchor_link";
+import HeaderButton from "./header_button";
 import Body from "./body";
 
 const backLink = css`
@@ -77,14 +77,14 @@ export class Favourites extends Component {
       <Container id="favourites">
         <Grid className={outerGrid} container spacing={24}>
           <Grid item xs={12} className={topMatter}>
-            <HeaderAnchorLink
+            <HeaderButton
               id="backButton"
               className={backLink}
               href={this.get_link("benefits-directory")}
               arrow="back"
             >
               {t("favourites.back_link")}
-            </HeaderAnchorLink>
+            </HeaderButton>
 
             <Header1 className={"BenefitsCounter"}>
               {t("favourites.saved_benefits", { x: filteredBenefits.length })}
@@ -120,13 +120,13 @@ export class Favourites extends Component {
             )}
           </Grid>
           <Grid item md={4} xs={12}>
-            <HeaderAnchorLink
+            <HeaderButton
               href={this.props.printUrl}
               target="print_page"
               id="printButton"
             >
               <Print /> {t("Print")}
-            </HeaderAnchorLink>
+            </HeaderButton>
 
             <Header2 className={contactUsTitle}>
               {t("favourites.contact_us")}

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -81,7 +81,7 @@ export class Favourites extends Component {
               id="backButton"
               className={backLink}
               href={this.get_link("benefits-directory")}
-              icon="arrowBack"
+              arrow="back"
             >
               {t("favourites.back_link")}
             </HeaderAnchorLink>

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -9,7 +9,7 @@ import Container from "./container";
 import Header1 from "./header1";
 import Header2 from "./header2";
 import Button from "./button";
-import HeaderAnchorLink from "./header_anchor_link";
+import HeaderButton from "./header_button";
 
 const root = css`
   border: solid 1px grey;
@@ -62,7 +62,7 @@ export class GuidedExperience extends Component {
     const eligibilityKeys = Object.keys(selectedEligibility);
     return (
       <Container id="guidedExperience">
-        <HeaderAnchorLink
+        <HeaderButton
           id="prevButton"
           disableRipple
           href={
@@ -77,7 +77,7 @@ export class GuidedExperience extends Component {
           arrow="back"
         >
           {t("back")}
-        </HeaderAnchorLink>
+        </HeaderButton>
         <div className={root}>
           <Grid container spacing={24} className={box}>
             <Grid item xs={12} md={12}>

--- a/components/header_anchor_link.js
+++ b/components/header_anchor_link.js
@@ -36,9 +36,9 @@ class HeaderAnchorLink extends Component {
       children,
       onClick,
       href,
-      rel,
       target,
-      size
+      size,
+      otherProps
     } = this.props;
 
     let buttonOnClick;
@@ -61,9 +61,8 @@ class HeaderAnchorLink extends Component {
           size === "small" ? cx(style, small, className) : cx(style, className)
         }
         id={"a-" + id}
-        aria-label={this.props["aria-label"]}
         onClick={buttonOnClick}
-        rel={rel}
+        {...otherProps}
       >
         {arrow === "back" ? <ArrowBack /> : null}
         {children}
@@ -76,9 +75,7 @@ class HeaderAnchorLink extends Component {
 HeaderAnchorLink.propTypes = {
   id: PropTypes.string,
   size: PropTypes.string,
-  "aria-label": PropTypes.string,
   href: PropTypes.string,
-  rel: PropTypes.string,
   target: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.string,

--- a/components/header_anchor_link.js
+++ b/components/header_anchor_link.js
@@ -4,7 +4,6 @@ import { globalTheme } from "../theme";
 import { cx, css } from "react-emotion";
 import ArrowBack from "@material-ui/icons/ArrowBack";
 import ArrowForward from "@material-ui/icons/ArrowForward";
-import Bookmark from "@material-ui/icons/Bookmark";
 import CloseIcon from "@material-ui/icons/Close";
 
 const style = css`
@@ -58,7 +57,6 @@ class HeaderAnchorLink extends Component {
         target={target}
       >
         {icon === "arrowBack" ? <ArrowBack /> : null}
-        {icon === "bookmark" ? <Bookmark /> : null}
         {children}
         {icon === "arrowForward" ? <ArrowForward /> : null}
         {icon === "close" ? <CloseIcon className={closeIcon} /> : null}

--- a/components/header_anchor_link.js
+++ b/components/header_anchor_link.js
@@ -32,11 +32,6 @@ const closeIcon = css`
   margin-left: ${globalTheme.unit};
   font-weight: bold;
 `;
-const nonMobileStyle = css`
-  @media only screen and (max-width: ${globalTheme.max.xs}) {
-    display: none;
-  }
-`;
 
 class HeaderAnchorLink extends Component {
   render() {
@@ -45,7 +40,6 @@ class HeaderAnchorLink extends Component {
       icon,
       className,
       children,
-      nonMobile,
       onClick,
       href,
       rel,
@@ -68,9 +62,6 @@ class HeaderAnchorLink extends Component {
         {icon === "bookmark" ? <Bookmark /> : null}
         {icon === "print" ? <Print /> : null}
         {children}
-        {nonMobile ? (
-          <span className={nonMobileStyle}> {nonMobile} </span>
-        ) : null}
         {icon === "arrowForward" ? <ArrowForward /> : null}
         {icon === "close" ? <CloseIcon className={closeIcon} /> : null}
       </a>
@@ -93,7 +84,6 @@ HeaderAnchorLink.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.string,
   label: PropTypes.object,
-  nonMobile: PropTypes.string,
   onClick: PropTypes.func
 };
 

--- a/components/header_anchor_link.js
+++ b/components/header_anchor_link.js
@@ -4,7 +4,6 @@ import { globalTheme } from "../theme";
 import { cx, css } from "react-emotion";
 import ArrowBack from "@material-ui/icons/ArrowBack";
 import ArrowForward from "@material-ui/icons/ArrowForward";
-import CloseIcon from "@material-ui/icons/Close";
 
 const style = css`
   display: inline-block;
@@ -24,11 +23,6 @@ const style = css`
 `;
 const small = css`
   font-size: 18px;
-`;
-const closeIcon = css`
-  font-size: 100% !important;
-  margin-left: ${globalTheme.unit};
-  font-weight: bold;
 `;
 
 class HeaderAnchorLink extends Component {
@@ -59,7 +53,6 @@ class HeaderAnchorLink extends Component {
         {icon === "arrowBack" ? <ArrowBack /> : null}
         {children}
         {icon === "arrowForward" ? <ArrowForward /> : null}
-        {icon === "close" ? <CloseIcon className={closeIcon} /> : null}
       </a>
     );
   }

--- a/components/header_anchor_link.js
+++ b/components/header_anchor_link.js
@@ -29,7 +29,7 @@ class HeaderAnchorLink extends Component {
   render() {
     const {
       id,
-      icon,
+      arrow,
       className,
       children,
       onClick,
@@ -50,9 +50,9 @@ class HeaderAnchorLink extends Component {
         rel={rel}
         target={target}
       >
-        {icon === "arrowBack" ? <ArrowBack /> : null}
+        {arrow === "back" ? <ArrowBack /> : null}
         {children}
-        {icon === "arrowForward" ? <ArrowForward /> : null}
+        {arrow === "forward" ? <ArrowForward /> : null}
       </a>
     );
   }
@@ -71,7 +71,7 @@ HeaderAnchorLink.propTypes = {
     PropTypes.object
   ]),
   className: PropTypes.string,
-  icon: PropTypes.string,
+  arrow: PropTypes.string,
   label: PropTypes.object,
   onClick: PropTypes.func
 };

--- a/components/header_anchor_link.js
+++ b/components/header_anchor_link.js
@@ -5,7 +5,6 @@ import { cx, css } from "react-emotion";
 import ArrowBack from "@material-ui/icons/ArrowBack";
 import ArrowForward from "@material-ui/icons/ArrowForward";
 import Bookmark from "@material-ui/icons/Bookmark";
-import Print from "@material-ui/icons/Print";
 import CloseIcon from "@material-ui/icons/Close";
 
 const style = css`
@@ -60,7 +59,6 @@ class HeaderAnchorLink extends Component {
       >
         {icon === "arrowBack" ? <ArrowBack /> : null}
         {icon === "bookmark" ? <Bookmark /> : null}
-        {icon === "print" ? <Print /> : null}
         {children}
         {icon === "arrowForward" ? <ArrowForward /> : null}
         {icon === "close" ? <CloseIcon className={closeIcon} /> : null}

--- a/components/header_button.js
+++ b/components/header_button.js
@@ -27,7 +27,7 @@ const small = css`
   font-size: 18px;
 `;
 
-class HeaderAnchorLink extends Component {
+class HeaderButton extends Component {
   render() {
     const {
       id,
@@ -72,7 +72,7 @@ class HeaderAnchorLink extends Component {
   }
 }
 
-HeaderAnchorLink.propTypes = {
+HeaderButton.propTypes = {
   id: PropTypes.string,
   size: PropTypes.string,
   href: PropTypes.string,
@@ -88,4 +88,4 @@ HeaderAnchorLink.propTypes = {
   onClick: PropTypes.func
 };
 
-export default HeaderAnchorLink;
+export default HeaderButton;

--- a/components/profile_needs_selector.js
+++ b/components/profile_needs_selector.js
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import { Grid, Paper } from "@material-ui/core";
 import { globalTheme } from "../theme";
 import { css } from "react-emotion";
-import HeaderAnchorLink from "../components/header_anchor_link";
+import HeaderButton from "./header_button";
 import CloseIcon from "@material-ui/icons/Close";
 
 const root = css`
@@ -74,7 +74,7 @@ export class ProfileNeedsSelector extends Component {
           {t("filters")}{" "}
           {JSON.stringify(this.props.selectedNeeds) !== "{}" ||
           this.props.patronType !== "" ? (
-            <HeaderAnchorLink
+            <HeaderButton
               id={"ClearFilters"}
               className={clearButton}
               onClick={() => {
@@ -83,7 +83,7 @@ export class ProfileNeedsSelector extends Component {
             >
               {t("reset filters")} {"(" + this.countSelected() + ")"}
               <CloseIcon className={closeIcon} />
-            </HeaderAnchorLink>
+            </HeaderButton>
           ) : (
             ""
           )}

--- a/components/profile_needs_selector.js
+++ b/components/profile_needs_selector.js
@@ -77,7 +77,6 @@ export class ProfileNeedsSelector extends Component {
             <HeaderAnchorLink
               id={"ClearFilters"}
               className={clearButton}
-              icon="close"
               onClick={() => {
                 this.clearFilters();
               }}

--- a/components/profile_needs_selector.js
+++ b/components/profile_needs_selector.js
@@ -7,6 +7,7 @@ import { Grid, Paper } from "@material-ui/core";
 import { globalTheme } from "../theme";
 import { css } from "react-emotion";
 import HeaderAnchorLink from "../components/header_anchor_link";
+import CloseIcon from "@material-ui/icons/Close";
 
 const root = css`
   padding: 25px !important;
@@ -30,6 +31,11 @@ const filterTitle = css`
   margin-bottom: 5px;
   font-weight: bold;
   font-size: 22px;
+`;
+const closeIcon = css`
+  font-size: 100% !important;
+  margin-left: ${globalTheme.unit};
+  font-weight: bold;
 `;
 
 export class ProfileNeedsSelector extends Component {
@@ -77,6 +83,7 @@ export class ProfileNeedsSelector extends Component {
               }}
             >
               {t("reset filters")} {"(" + this.countSelected() + ")"}
+              <CloseIcon className={closeIcon} />
             </HeaderAnchorLink>
           ) : (
             ""

--- a/components/profile_needs_selector_mobile.js
+++ b/components/profile_needs_selector_mobile.js
@@ -10,7 +10,7 @@ import { connect } from "react-redux";
 import { Grid } from "@material-ui/core";
 import { globalTheme } from "../theme";
 import { css } from "react-emotion";
-import HeaderAnchorLink from "../components/header_anchor_link";
+import HeaderButton from "./header_button";
 
 const root = css`
   background-color: #f5f5f5 !important;
@@ -96,7 +96,7 @@ export class ProfileNeedsSelectorMobile extends Component {
               {JSON.stringify(this.props.selectedNeeds) !== "{}" ||
               this.props.patronType !== "" ? (
                 <h3 variant="title" className={filterTitle}>
-                  <HeaderAnchorLink
+                  <HeaderButton
                     id="ClearFiltersMobile"
                     className={clearButton}
                     onClick={() => {
@@ -104,7 +104,7 @@ export class ProfileNeedsSelectorMobile extends Component {
                     }}
                   >
                     {t("reset filters")} {"(" + this.countSelected() + ")"}
-                  </HeaderAnchorLink>
+                  </HeaderButton>
                 </h3>
               ) : (
                 ""


### PR DESCRIPTION
resolves #1163 

pushes most of the icons back out into the calling code (to be passed as children). Renames since it's not a link anymore.