### PR TITLE
Check for re-enabled cookies when hovering over favourite button

### DIFF
--- a/__tests__/components/benefit_card_test.js
+++ b/__tests__/components/benefit_card_test.js
@@ -9,6 +9,8 @@ import needsFixture from "../fixtures/needs";
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
 
+jest.mock("react-ga");
+
 describe("BenefitCard", () => {
   const mocked_fn = jest.fn();
   mocked_fn.mockReturnValue({ focus: jest.fn() });
@@ -42,6 +44,7 @@ describe("BenefitCard", () => {
     };
     mockStore = configureStore();
     reduxData = {
+      cookiesDisabled: false,
       needs: needsFixture,
       selectedNeeds: {},
       benefits: benefitsFixture,

--- a/__tests__/components/benefit_list_test.js
+++ b/__tests__/components/benefit_list_test.js
@@ -28,6 +28,7 @@ describe("BenefitList", () => {
 
     mockStore = configureStore();
     reduxData = {
+      cookiesDisabled: false,
       benefits: benefitsFixture,
       favouriteBenefits: [],
       eligibilityPaths: eligibilityPathsFixture,

--- a/__tests__/components/favourite_button_test.js
+++ b/__tests__/components/favourite_button_test.js
@@ -12,6 +12,8 @@ describe("FavouriteButton", () => {
 
   beforeEach(() => {
     props = {
+      cookiesDisabled: false,
+      setCookiesDisabled: jest.fn(),
       t: key => key,
       favouriteBenefits: ["0"],
       saveFavourites: jest.fn(),

--- a/__tests__/pages/all-benefits_test.js
+++ b/__tests__/pages/all-benefits_test.js
@@ -44,6 +44,7 @@ describe("AllBenefits", () => {
     _mountedAllBenefits = undefined;
     mockStore = configureStore();
     reduxData = {
+      cookiesDisabled: false,
       benefits: benefitsFixture,
       eligibilityPaths: eligibilityPathsFixture,
       examples: examplesFixture,

--- a/components/BB.js
+++ b/components/BB.js
@@ -73,6 +73,12 @@ export class BB extends Component {
     this.setState({ showDisabledCookieBanner: areCookiesDisabled() });
   }
 
+  componentDidUpdate() {
+    if (this.state.showDisabledCookieBanner && !this.props.cookiesDisabled) {
+      this.setState({ showDisabledCookieBanner: false });
+    }
+  }
+
   handleSortByChange = event => {
     this.props.setSortBy(event.target.value);
   };

--- a/components/favourite_button.js
+++ b/components/favourite_button.js
@@ -7,6 +7,7 @@ import Cookies from "universal-cookie";
 import { cx, css } from "react-emotion";
 import { globalTheme } from "../theme";
 import HeaderButton from "./header_button";
+import { areCookiesDisabled } from "../utils/common";
 
 const bookmarkButton = css`
   margin-left: -5px !important;
@@ -99,6 +100,9 @@ export class FavouriteButton extends Component {
         className={cx(bookmarkButton, tooltip)}
         aria-label={t("B3.favouritesButtonText")}
         onClick={() => this.toggleFavourite(this.props.benefit.id)}
+        onMouseOver={() => {
+          this.props.setCookiesDisabled(areCookiesDisabled());
+        }}
         size="small"
       >
         {isBookmarked ? (
@@ -137,6 +141,9 @@ const mapDispatchToProps = dispatch => {
         type: "LOAD_DATA",
         data: { favouriteBenefits: favouriteBenefits }
       });
+    },
+    setCookiesDisabled: areDisabled => {
+      dispatch({ type: "SET_COOKIES_DISABLED", data: areDisabled });
     }
   };
 };
@@ -151,6 +158,7 @@ const mapStateToProps = reduxState => {
 FavouriteButton.propTypes = {
   favouriteBenefits: PropTypes.array.isRequired,
   cookiesDisabled: PropTypes.bool.isRequired,
+  setCookiesDisabled: PropTypes.func.isRequired,
   saveFavourites: PropTypes.func.isRequired,
   benefit: PropTypes.object.isRequired,
   toggleOpenState: PropTypes.func.isRequired,

--- a/components/header_button.js
+++ b/components/header_button.js
@@ -35,6 +35,7 @@ class HeaderButton extends Component {
       className,
       children,
       onClick,
+      onMouseOver,
       href,
       target,
       size,
@@ -64,6 +65,7 @@ class HeaderButton extends Component {
         }
         id={"a-" + id}
         onClick={buttonOnClick}
+        onMouseOver={this.props.onMouseOver}
         {...otherProps}
       >
         {arrow === "back" ? <ArrowBack /> : null}
@@ -88,6 +90,7 @@ HeaderButton.propTypes = {
   arrow: PropTypes.string,
   label: PropTypes.object,
   onClick: PropTypes.func,
+  onMouseOver: PropTypes.func,
   disabled: PropTypes.bool
 };
 

--- a/components/header_button.js
+++ b/components/header_button.js
@@ -35,7 +35,6 @@ class HeaderButton extends Component {
       className,
       children,
       onClick,
-      onMouseOver,
       href,
       target,
       size,


### PR DESCRIPTION
1) disable cookies
2) load BD page. Cookies disabled alert shows, hover shows when over a benefit's favourite button
3) enable cookies
4) mouse over a favourite button. The hover should not appear, the alert should disappear, and the user should be able to click to add the benefit to favourites.