### PR TITLE
Improve mobile styling

### DIFF
--- a/components/area_office_table.js
+++ b/components/area_office_table.js
@@ -39,6 +39,10 @@ const bold = css`
   font-weight: bold;
 `;
 const tableText = css`
+  font-size: 18px;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    font-size: 14px;
+  }
   margin-top: 4px;
   margin-bottom: 0px;
 `;

--- a/components/benefit_card_additional_info.js
+++ b/components/benefit_card_additional_info.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
 import { connect } from "react-redux";
 import { css } from "react-emotion";
+import { globalTheme } from "../theme";
 
 const cardTop = css`
   border-bottom: 1px solid #8b8b8b;
@@ -21,6 +22,8 @@ const parentIcon = css`
 const headerDesc = css`
   flex-grow: 1;
   color: #434343;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    font-size: 12px;
 `;
 
 export class BenefitCardHeaderMoreInfo extends Component {

--- a/components/benefit_card_header.js
+++ b/components/benefit_card_header.js
@@ -4,6 +4,7 @@ import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
 import { logEvent } from "../utils/analytics";
 import { connect } from "react-redux";
 import { css } from "react-emotion";
+import { globalTheme } from "../theme";
 
 const cardTop = css`
   border-bottom: 1px solid #8b8b8b;
@@ -22,6 +23,9 @@ const parentIcon = css`
 const headerDesc = css`
   flex-grow: 1;
   color: #434343;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    font-size: 12px;
+  }
 `;
 const headerUrl = css`
   color: #006cc9;

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -29,6 +29,9 @@ const cardDescriptionText = css`
     padding-bottom: 20px;
   }
 `;
+const buttonRow = css`
+  margin-top: 18px;
+`;
 const root = css`
   width: 100%;
 `;
@@ -102,7 +105,7 @@ export class BenefitCard extends Component {
               ))}
             </div>
 
-            <Grid container>
+            <Grid container className={buttonRow}>
               {this.props.showFavourite ? (
                 <Grid item xs={4}>
                   <FavouriteButton

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -14,6 +14,7 @@ import BenefitCardHeaderMoreInfo from "./benefit_card_additional_info";
 import OneLiner from "./typography/one_liner";
 import Header4 from "./typography/header4";
 import Button from "./button";
+import { globalTheme } from "../theme";
 
 const cardBody = css`
   padding: 25px !important;
@@ -23,6 +24,10 @@ const cardBody = css`
 const cardDescriptionText = css`
   padding-top: 26px;
   padding-bottom: 30px;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    padding-top: 14px;
+    padding-bottom: 20px;
+  }
 `;
 const root = css`
   width: 100%;

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -10,6 +10,7 @@ import Header2 from "./typography/header2";
 import Button from "./button";
 import HeaderButton from "./header_button";
 import GuidedExperienceLink from "./typography/guided_experience_link";
+import { globalTheme } from "../theme";
 
 const root = css`
   border: solid 1px grey;
@@ -19,6 +20,9 @@ const root = css`
 
 const box = css`
   padding: 25px 63px 63px 63px;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    padding: 17px 26px 55px 26px;
+  }
   display: inline-flex;
 `;
 

--- a/components/need_tag.js
+++ b/components/need_tag.js
@@ -10,6 +10,9 @@ const needsTag = css`
   border-radius: 1;
   display: inline-flex;
   padding: 4px 8px;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    font-size: 12px;
+  }
 `;
 
 export class NeedTag extends Component {

--- a/components/typography/header1.js
+++ b/components/typography/header1.js
@@ -6,6 +6,9 @@ import { cx, css } from "react-emotion";
 const style = css`
   font-family: ${globalTheme.fontFamily};
   font-size: 52px;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    font-size: 30px;
+  }
   font-weight: 900;
   color: ${globalTheme.colour.greyishBrown};
   margin: 0px;

--- a/components/typography/header2.js
+++ b/components/typography/header2.js
@@ -6,6 +6,9 @@ import { cx, css } from "react-emotion";
 const style = css`
   font-family: ${globalTheme.fontFamily};
   font-size: 36px;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    font-size: 20px;
+  }
   font-weight: 900;
   color: ${globalTheme.colour.greyishBrown};
   margin: 0px;

--- a/components/typography/header4.js
+++ b/components/typography/header4.js
@@ -6,6 +6,9 @@ import { cx, css } from "react-emotion";
 const style = css`
   font-family: ${globalTheme.fontFamily};
   font-size: 18px;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    font-size: 14px;
+  }
   font-weight: bold;
   color: ${globalTheme.colour.greyishBrown};
   margin: 0px;

--- a/components/typography/one_liner.js
+++ b/components/typography/one_liner.js
@@ -6,6 +6,9 @@ import { cx, css } from "react-emotion";
 const style = css`
   font-family: ${globalTheme.fontFamily};
   font-size: 24px;
+  @media only screen and (max-width: ${globalTheme.max.mobile}) {
+    font-size: 16px;
+  }
   font-weight: normal;
   color: ${globalTheme.colour.greyishBrown};
   margin: 0px;


### PR DESCRIPTION
resolves #1231 

A bunch of tweaks to the font sizes and padding for mobile.

Brings the app more in line with the designs in [Zeplin](https://app.zeplin.io/project/5acbd659dc553ec84805afd4/dashboard)