### PR TITLE
Logger abstraction

### DIFF
--- a/__tests__/utils/logger_test.js
+++ b/__tests__/utils/logger_test.js
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 import Logger from "../../utils/logger";
 
 describe("generatePaylod", () => {

--- a/__tests__/utils/logger_test.js
+++ b/__tests__/utils/logger_test.js
@@ -1,9 +1,9 @@
 /* eslint no-console: 0 */
 import Logger from "../../utils/logger";
 
-describe("generatePaylod", () => {
+describe("generatePayload", () => {
   it("creates a payload based on standard options", () => {
-    let result = Logger.generatePaylod("foo", "bar", {});
+    let result = Logger.generatePayload("foo", "bar", {});
     expect(result.cloudEventsVersion).toEqual("0.1");
     expect(result.contentType).toEqual("text/plain");
     expect(result.body).toEqual("bar");
@@ -17,7 +17,7 @@ describe("generatePaylod", () => {
   });
 
   it("allows you to override payload options", () => {
-    let result = Logger.generatePaylod("foo", "bar", { source: "/biz" });
+    let result = Logger.generatePayload("foo", "bar", { source: "/biz" });
     expect(result.source).toEqual("/biz");
   });
 });

--- a/__tests__/utils/logger_test.js
+++ b/__tests__/utils/logger_test.js
@@ -1,0 +1,94 @@
+import Logger from "../../utils/logger";
+
+describe("generatePaylod", () => {
+  it("creates a payload based on standard options", () => {
+    let result = Logger.generatePaylod("foo", "bar", {});
+    expect(result.cloudEventsVersion).toEqual("0.1");
+    expect(result.contentType).toEqual("text/plain");
+    expect(result.body).toEqual("bar");
+    expect(result.eventID.indexOf("-")).not.toEqual(-1);
+    expect(result.eventTime.indexOf("T")).not.toEqual(-1);
+    expect(result.eventType).toEqual(
+      "com.github.cds-snc.vac-benefits-directory.foo"
+    );
+    expect(result.eventTypeVersion).toEqual("1.0");
+    expect(result.source).toEqual("/");
+  });
+
+  it("allows you to override payload options", () => {
+    let result = Logger.generatePaylod("foo", "bar", { source: "/biz" });
+    expect(result.source).toEqual("/biz");
+  });
+});
+
+describe("debug", () => {
+  it("creates a debug level event and sends it to console log", () => {
+    console.log = jest.fn();
+    let result = Logger.debug("This is a debug message");
+    expect(console.log).toBeCalled();
+    expect(result.eventType).toEqual(
+      "com.github.cds-snc.vac-benefits-directory.debug"
+    );
+  });
+
+  it("allows you to override the default options", () => {
+    console.log = jest.fn();
+    let result = Logger.debug("This is a debug message", { source: "/foo" });
+    expect(console.log).toBeCalled();
+    expect(result.source).toEqual("/foo");
+  });
+});
+
+describe("error", () => {
+  it("creates a error level event and sends it to console log", () => {
+    console.error = jest.fn();
+    let result = Logger.error("This is an error message");
+    expect(console.error).toBeCalled();
+    expect(result.eventType).toEqual(
+      "com.github.cds-snc.vac-benefits-directory.error"
+    );
+  });
+
+  it("allows you to override the default options", () => {
+    console.error = jest.fn();
+    let result = Logger.error("This is an error message", { source: "/foo" });
+    expect(console.error).toBeCalled();
+    expect(result.source).toEqual("/foo");
+  });
+});
+
+describe("info", () => {
+  it("creates a info level event and sends it to console log", () => {
+    console.log = jest.fn();
+    let result = Logger.info("This is a info message");
+    expect(console.log).toBeCalled();
+    expect(result.eventType).toEqual(
+      "com.github.cds-snc.vac-benefits-directory.info"
+    );
+  });
+
+  it("allows you to override the default options", () => {
+    console.log = jest.fn();
+    let result = Logger.info("This is a info message", { source: "/foo" });
+    expect(console.log).toBeCalled();
+    expect(result.source).toEqual("/foo");
+  });
+});
+
+describe("warn", () => {
+  it("creates a warn level event and sends it to console log", () => {
+    console.log = jest.fn();
+    let result = Logger.warn("This is a warn message");
+    expect(console.log).toBeCalled();
+    expect(result.eventType).toEqual(
+      "com.github.cds-snc.vac-benefits-directory.warn"
+    );
+  });
+
+  it("allows you to override the default options", () => {
+    console.log = jest.fn();
+    let result = Logger.warn("This is a warn message", { source: "/foo" });
+    expect(console.log).toBeCalled();
+    expect(result.source).toEqual("/foo");
+  });
+});

--- a/server.js
+++ b/server.js
@@ -102,6 +102,12 @@ Promise.resolve(getAllData()).then(allData => {
             setTimeout(function() {
               Promise.resolve(airTable.hydrateFromAirtable()).then(newData => {
                 copyValidTables(data, newData);
+                Logger.info(
+                  "Cache refreshed automatically @ " + data.timestamp,
+                  {
+                    source: "/server.js"
+                  }
+                );
               });
             }, 1000 * 60 * 60);
 

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,42 +1,112 @@
-export default class Logger {
-  static debug(msg, options = {}) {
-    let payload = this.generatePaylod("debug", msg, options);
-    console.log(JSON.stringify(payload));
-    return payload;
-  }
+"use strict";
 
-  static error(msg, options = {}) {
-    let payload = this.generatePaylod("error", msg, options);
-    console.error(JSON.stringify(payload));
-    return payload;
-  }
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 
-  static info(msg, options = {}) {
-    let payload = this.generatePaylod("info", msg, options);
-    console.log(JSON.stringify(payload));
-    return payload;
+var _createClass = (function() {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
   }
+  return function(Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) defineProperties(Constructor, staticProps);
+    return Constructor;
+  };
+})();
 
-  static warn(msg, options = {}) {
-    let payload = this.generatePaylod("warn", msg, options);
-    console.log(JSON.stringify(payload));
-    return payload;
-  }
-
-  static generatePaylod(level, msg, options) {
-    const envDetails = process.env.CIRCLE_SHA1
-      ? process.env.CIRCLE_SHA1.substring(0, 7)
-      : process.env.NODE_ENV;
-    const standardPayload = {
-      cloudEventsVersion: "0.1",
-      contentType: "text/plain",
-      body: msg,
-      eventID: `${envDetails}-${Date.now()}`,
-      eventTime: new Date().toISOString(),
-      eventType: `com.github.cds-snc.vac-benefits-directory.${level}`,
-      eventTypeVersion: "1.0",
-      source: "/"
-    };
-    return Object.assign(standardPayload, options);
+function _classCallCheck(instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
   }
 }
+
+var Logger = (function() {
+  function Logger() {
+    _classCallCheck(this, Logger);
+  }
+
+  _createClass(Logger, null, [
+    {
+      key: "debug",
+      value: function debug(msg) {
+        var options =
+          arguments.length > 1 && arguments[1] !== undefined
+            ? arguments[1]
+            : {};
+
+        var payload = this.generatePaylod("debug", msg, options);
+        console.log(JSON.stringify(payload));
+        return payload;
+      }
+    },
+    {
+      key: "error",
+      value: function error(msg) {
+        var options =
+          arguments.length > 1 && arguments[1] !== undefined
+            ? arguments[1]
+            : {};
+
+        var payload = this.generatePaylod("error", msg, options);
+        console.error(JSON.stringify(payload));
+        return payload;
+      }
+    },
+    {
+      key: "info",
+      value: function info(msg) {
+        var options =
+          arguments.length > 1 && arguments[1] !== undefined
+            ? arguments[1]
+            : {};
+
+        var payload = this.generatePaylod("info", msg, options);
+        console.log(JSON.stringify(payload));
+        return payload;
+      }
+    },
+    {
+      key: "warn",
+      value: function warn(msg) {
+        var options =
+          arguments.length > 1 && arguments[1] !== undefined
+            ? arguments[1]
+            : {};
+
+        var payload = this.generatePaylod("warn", msg, options);
+        console.log(JSON.stringify(payload));
+        return payload;
+      }
+    },
+    {
+      key: "generatePaylod",
+      value: function generatePaylod(level, msg, options) {
+        var envDetails = process.env.CIRCLE_SHA1
+          ? process.env.CIRCLE_SHA1.substring(0, 7)
+          : process.env.NODE_ENV;
+        var standardPayload = {
+          cloudEventsVersion: "0.1",
+          contentType: "text/plain",
+          body: msg,
+          eventID: envDetails + "-" + Date.now(),
+          eventTime: new Date().toISOString(),
+          eventType: "com.github.cds-snc.vac-benefits-directory." + level,
+          eventTypeVersion: "1.0",
+          source: "/"
+        };
+        return Object.assign(standardPayload, options);
+      }
+    }
+  ]);
+
+  return Logger;
+})();
+
+exports.default = Logger;

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -41,7 +41,7 @@ var Logger = (function() {
             ? arguments[1]
             : {};
 
-        var payload = this.generatePaylod("debug", msg, options);
+        var payload = this.generatePayload("debug", msg, options);
         console.log(JSON.stringify(payload));
         return payload;
       }
@@ -54,7 +54,7 @@ var Logger = (function() {
             ? arguments[1]
             : {};
 
-        var payload = this.generatePaylod("error", msg, options);
+        var payload = this.generatePayload("error", msg, options);
         console.error(JSON.stringify(payload));
         return payload;
       }
@@ -67,7 +67,7 @@ var Logger = (function() {
             ? arguments[1]
             : {};
 
-        var payload = this.generatePaylod("info", msg, options);
+        var payload = this.generatePayload("info", msg, options);
         console.log(JSON.stringify(payload));
         return payload;
       }
@@ -80,14 +80,14 @@ var Logger = (function() {
             ? arguments[1]
             : {};
 
-        var payload = this.generatePaylod("warn", msg, options);
+        var payload = this.generatePayload("warn", msg, options);
         console.log(JSON.stringify(payload));
         return payload;
       }
     },
     {
-      key: "generatePaylod",
-      value: function generatePaylod(level, msg, options) {
+      key: "generatePayload",
+      value: function generatePayload(level, msg, options) {
         var envDetails = process.env.CIRCLE_SHA1
           ? process.env.CIRCLE_SHA1.substring(0, 7)
           : process.env.NODE_ENV;

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,42 @@
+export default class Logger {
+  static debug(msg, options = {}) {
+    let payload = this.generatePaylod("debug", msg, options);
+    console.log(JSON.stringify(payload));
+    return payload;
+  }
+
+  static error(msg, options = {}) {
+    let payload = this.generatePaylod("error", msg, options);
+    console.error(JSON.stringify(payload));
+    return payload;
+  }
+
+  static info(msg, options = {}) {
+    let payload = this.generatePaylod("info", msg, options);
+    console.log(JSON.stringify(payload));
+    return payload;
+  }
+
+  static warn(msg, options = {}) {
+    let payload = this.generatePaylod("warn", msg, options);
+    console.log(JSON.stringify(payload));
+    return payload;
+  }
+
+  static generatePaylod(level, msg, options) {
+    const envDetails = process.env.CIRCLE_SHA1
+      ? process.env.CIRCLE_SHA1.substring(0, 7)
+      : process.env.NODE_ENV;
+    const standardPayload = {
+      cloudEventsVersion: "0.1",
+      contentType: "text/plain",
+      body: msg,
+      eventID: `${envDetails}-${Date.now()}`,
+      eventTime: new Date().toISOString(),
+      eventType: `com.github.cds-snc.vac-benefits-directory.${level}`,
+      eventTypeVersion: "1.0",
+      source: "/"
+    };
+    return Object.assign(standardPayload, options);
+  }
+}


### PR DESCRIPTION
Closes #1268. Added a logger abstraction that adds the following methods `Logger.info`, `Logger.debug`, `Logger.warn`, `Logger.error`. All except error will log to `console.log`, error will log to `console.error`.  The log format is based on https://github.com/cloudevents/spec/blob/v0.1/json-format.md. Event ID is currently the short SHA with a timestamp.

The log out put looks like
```
{  
   "cloudEventsVersion":"0.1",
   "contentType":"text/plain",
   "body":"Refreshing Cache ...",
   "eventID":"6388324-1539183052434",
   "eventTime":"2018-10-10T14:50:52.434Z",
   "eventType":"com.github.cds-snc.vac-benefits-directory.info",
   "eventTypeVersion":"1.0",
   "source":"/server.js"
}

{  
   "cloudEventsVersion":"0.1",
   "contentType":"text/plain",
   "body":"Cache refreshed @ 1539183054624",
   "eventID":"6388324-1539183054629",
   "eventTime":"2018-10-10T14:50:54.629Z",
   "eventType":"com.github.cds-snc.vac-benefits-directory.info",
   "eventTypeVersion":"1.0",
   "source":"/server.js"
}

{  
   "cloudEventsVersion":"0.1",
   "contentType":"application/json",
   "body":{  
      "name":"FetchError",
      "message":"request to https://api.airtable.com/v0/appoFDwVvNMRSaO6o/questionClearLogic?view=Grid%20view failed, reason: getaddrinfo ENOTFOUND api.airtable.com api.airtable.com:443",
      "type":"system",
      "errno":"ENOTFOUND",
      "code":"ENOTFOUND"
   },
   "eventID":"6388324-1539183152070",
   "eventTime":"2018-10-10T14:52:32.070Z",
   "eventType":"com.github.cds-snc.vac-benefits-directory.error",
   "eventTypeVersion":"1.0",
   "source":"/utils/airtable_es2015.js"
}
```
