### PR TITLE
make Airtable base key configurable

### DIFF
--- a/utils/airtable_es2015.js
+++ b/utils/airtable_es2015.js
@@ -7,6 +7,7 @@ exports.hydrateFromAirtable = exports.writeFeedback = undefined;
 var airtableConstants = require("./airtable_constants");
 var readKey = process.env.AIRTABLE_READ_KEY;
 var writeKey = process.env.AIRTABLE_WRITE_KEY;
+var baseKey = process.env.AIRTABLE_BASE_KEY || "appoFDwVvNMRSaO6o";
 
 var replaceId = function replaceId(
   sheet,
@@ -34,10 +35,7 @@ var fetchTableFromAirtable = async function fetchTableFromAirtable(table) {
   var jsonRecords = [];
   try {
     do {
-      var url =
-        "https://api.airtable.com/v0/appoFDwVvNMRSaO6o/" +
-        table +
-        "?view=Grid%20view";
+      var url = `https://api.airtable.com/v0/${baseKey}/${table}?view=Grid%20view`;
       if (offset) {
         url = url + "&offset=" + offset;
       }


### PR DESCRIPTION
allow us in the future to deploy master and use with a different Airtable base without code changes.