### PR TITLE
Refactor eligibility paths

### DIFF
--- a/__tests__/selectors/benefits_test.js
+++ b/__tests__/selectors/benefits_test.js
@@ -2,6 +2,7 @@ import lunr from "lunr";
 import {
   getProfileFilters,
   pathToDict,
+  eligibilityMatch,
   getFilteredBenefitsWithoutSearch,
   getFilteredBenefits
 } from "../../selectors/benefits";
@@ -47,23 +48,14 @@ describe("Benefits Selectors", () => {
       eligibilityPaths: [
         {
           requirements: ["patronType: p1"],
-          patronType: "p1",
-          serviceType: "na",
-          statusAndVitals: "na",
           benefits: ["0", "2", "4"]
         },
         {
           requirements: ["patronType: p2"],
-          patronType: "p2",
-          serviceType: "na",
-          statusAndVitals: "na",
           benefits: ["2"]
         },
         {
           requirements: ["patronType: p3"],
-          patronType: "p3",
-          serviceType: "na",
-          statusAndVitals: "na",
           benefits: ["1", "3", "4"]
         }
       ],
@@ -176,19 +168,147 @@ describe("Benefits Selectors", () => {
 
   describe("pathToDict function", () => {
     it("works as expected", () => {
-      const ep = { requirements: ["patronType: p3", "serviceType: s1"] };
+      const ep = {
+        requirements: ["patronType: p3", "serviceType: s1", "patronType: p1"]
+      };
       const actual = pathToDict(
         ep,
         state.multipleChoiceOptions,
         state.questions
       );
       expect(actual).toEqual({
-        patronType: "p3",
-        serviceType: "s1",
-        statusAndVitals: "",
-        serviceHealthIssue: "",
-        needs: ""
+        patronType: ["p3", "p1"],
+        serviceType: ["s1"],
+        statusAndVitals: [],
+        serviceHealthIssue: [],
+        needs: []
       });
+    });
+  });
+
+  describe("eligibilityMatch", () => {
+    it("matches if nothing selected", () => {
+      const ep = {
+        requirements: ["patronType: p3"],
+        patronType: "p3",
+        serviceType: "na",
+        statusAndVitals: "na",
+        benefits: ["1", "3", "4"]
+      };
+      const selected = {
+        patronType: "",
+        serviceType: "",
+        statusAndVitals: ""
+      };
+      const actual = eligibilityMatch(
+        ep,
+        selected,
+        state.multipleChoiceOptions,
+        state.questions
+      );
+      expect(actual).toEqual(true);
+    });
+
+    it("matches if requirements undefined", () => {
+      const ep = {
+        requirements: undefined,
+        patronType: "p3",
+        serviceType: "na",
+        statusAndVitals: "na",
+        benefits: ["1", "3", "4"]
+      };
+      const selected = {
+        patronType: "p3",
+        serviceType: "",
+        statusAndVitals: ""
+      };
+      const actual = eligibilityMatch(
+        ep,
+        selected,
+        state.multipleChoiceOptions,
+        state.questions
+      );
+      expect(actual).toEqual(true);
+    });
+
+    it("matches if requirements empty", () => {
+      const ep = {
+        requirements: [],
+        patronType: "p3",
+        serviceType: "na",
+        statusAndVitals: "na",
+        benefits: ["1", "3", "4"]
+      };
+      const selected = {
+        patronType: "p3",
+        serviceType: "",
+        statusAndVitals: ""
+      };
+      const actual = eligibilityMatch(
+        ep,
+        selected,
+        state.multipleChoiceOptions,
+        state.questions
+      );
+      expect(actual).toEqual(true);
+    });
+
+    it("matches if selections match", () => {
+      const ep = {
+        requirements: ["patronType: p3"],
+        patronType: "p3",
+        serviceType: "na",
+        statusAndVitals: "na",
+        benefits: ["1", "3", "4"]
+      };
+      const selected = {
+        patronType: "p3",
+        serviceType: "",
+        statusAndVitals: ""
+      };
+      const actual = eligibilityMatch(
+        ep,
+        selected,
+        state.multipleChoiceOptions,
+        state.questions
+      );
+      expect(actual).toEqual(true);
+    });
+
+    it("doesn't match if selections don't match", () => {
+      const ep = {
+        requirements: ["patronType: p3"]
+      };
+      const selected = {
+        patronType: "p2",
+        serviceType: "",
+        statusAndVitals: ""
+      };
+      const actual = eligibilityMatch(
+        ep,
+        selected,
+        state.multipleChoiceOptions,
+        state.questions
+      );
+      expect(actual).toEqual(false);
+    });
+
+    it("matches if selection included in requirements along with others", () => {
+      const ep = {
+        requirements: ["patronType: p3", "patronType: p2"]
+      };
+      const selected = {
+        patronType: "p2",
+        serviceType: "",
+        statusAndVitals: ""
+      };
+      const actual = eligibilityMatch(
+        ep,
+        selected,
+        state.multipleChoiceOptions,
+        state.questions
+      );
+      expect(actual).toEqual(true);
     });
   });
 

--- a/__tests__/selectors/benefits_test.js
+++ b/__tests__/selectors/benefits_test.js
@@ -1,6 +1,7 @@
 import lunr from "lunr";
 import {
   getProfileFilters,
+  pathToDict,
   getFilteredBenefitsWithoutSearch,
   getFilteredBenefits
 } from "../../selectors/benefits";
@@ -81,6 +82,11 @@ describe("Benefits Selectors", () => {
           variable_name: "p3",
           linked_question: "patronType",
           id: "patronType: p3"
+        },
+        {
+          variable_name: "s1",
+          linked_question: "serviceType",
+          id: "serviceType: s1"
         }
       ],
       enIdx: JSON.stringify({
@@ -165,6 +171,24 @@ describe("Benefits Selectors", () => {
       expect(returnValue.serviceType).toEqual("st");
       expect(returnValue.statusAndVitals).toEqual("sv");
       expect(returnValue.serviceHealthIssue).toEqual(undefined);
+    });
+  });
+
+  describe("pathToDict function", () => {
+    it("works as expected", () => {
+      const ep = { requirements: ["patronType: p3", "serviceType: s1"] };
+      const actual = pathToDict(
+        ep,
+        state.multipleChoiceOptions,
+        state.questions
+      );
+      expect(actual).toEqual({
+        patronType: "p3",
+        serviceType: "s1",
+        statusAndVitals: "",
+        serviceHealthIssue: "",
+        needs: ""
+      });
     });
   });
 

--- a/__tests__/selectors/benefits_test.js
+++ b/__tests__/selectors/benefits_test.js
@@ -45,22 +45,42 @@ describe("Benefits Selectors", () => {
       ],
       eligibilityPaths: [
         {
+          requirements: ["patronType: p1"],
           patronType: "p1",
           serviceType: "na",
           statusAndVitals: "na",
           benefits: ["0", "2", "4"]
         },
         {
+          requirements: ["patronType: p2"],
           patronType: "p2",
           serviceType: "na",
           statusAndVitals: "na",
           benefits: ["2"]
         },
         {
+          requirements: ["patronType: p3"],
           patronType: "p3",
           serviceType: "na",
           statusAndVitals: "na",
           benefits: ["1", "3", "4"]
+        }
+      ],
+      multipleChoiceOptions: [
+        {
+          variable_name: "p1",
+          linked_question: "patronType",
+          id: "patronType: p1"
+        },
+        {
+          variable_name: "p2",
+          linked_question: "patronType",
+          id: "patronType: p2"
+        },
+        {
+          variable_name: "p3",
+          linked_question: "patronType",
+          id: "patronType: p3"
         }
       ],
       enIdx: JSON.stringify({

--- a/__tests__/selectors/urls_test.js
+++ b/__tests__/selectors/urls_test.js
@@ -148,22 +148,42 @@ describe("getPrintUrl", () => {
       selectedAreaOffice: "",
       eligibilityPaths: [
         {
+          requirements: ["patronType: p1"],
           patronType: "p1",
           serviceType: "na",
           statusAndVitals: "na",
           benefits: ["0", "2", "4"]
         },
         {
+          requirements: ["patronType: p2"],
           patronType: "p2",
           serviceType: "na",
           statusAndVitals: "na",
           benefits: ["2"]
         },
         {
+          requirements: ["patronType: p3"],
           patronType: "p3",
           serviceType: "na",
           statusAndVitals: "na",
           benefits: ["1", "3", "4"]
+        }
+      ],
+      multipleChoiceOptions: [
+        {
+          variable_name: "p1",
+          linked_question: "patronType",
+          id: "patronType: p1"
+        },
+        {
+          variable_name: "p2",
+          linked_question: "patronType",
+          id: "patronType: p2"
+        },
+        {
+          variable_name: "p3",
+          linked_question: "patronType",
+          id: "patronType: p3"
         }
       ],
       enIdx: JSON.stringify({
@@ -237,7 +257,7 @@ describe("getPrintUrl", () => {
   it("adds serviceHealthIssue string to the URL", () => {
     state.serviceHealthIssue = "foo";
     expect(getPrintUrl(state, props, params)).toEqual(
-      "/print?lng=en&sortBy=relevance&serviceHealthIssue=foo"
+      "/print?lng=en&sortBy=relevance&benefits=0,1,2,3,4&serviceHealthIssue=foo"
     );
   });
 

--- a/selectors/benefits.js
+++ b/selectors/benefits.js
@@ -26,7 +26,7 @@ export const getProfileFilters = createSelector(
   }
 );
 
-const pathToDict = (ep, multipleChoiceOptions, questions) => {
+export const pathToDict = (ep, multipleChoiceOptions, questions) => {
   let dict = {};
   questions.forEach(q => {
     dict[q.variable_name] = "";


### PR DESCRIPTION
resolves #1296 

Added a `requirements` column to the `eligibilityPaths` sheet in Airtable that's linked to the `multipleChoiceOptions` sheet. Code in this PR uses this new column to compute the filtered benefits. 