### PR TITLE
Refactor card footer

### DIFF
--- a/__tests__/components/benefit_card_test.js
+++ b/__tests__/components/benefit_card_test.js
@@ -5,6 +5,7 @@ import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
 import { BenefitCard } from "../../components/benefit_cards";
 import benefitsFixture from "../fixtures/benefits";
 import needsFixture from "../fixtures/needs";
+import multipleChoiceOptionsFixture from "../fixtures/multiple_choice_options";
 
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
@@ -49,7 +50,8 @@ describe("BenefitCard", () => {
       selectedNeeds: {},
       benefits: benefitsFixture,
       favouriteBenefits: [],
-      eligibilityPaths: eligibilityPathsFixture
+      eligibilityPaths: eligibilityPathsFixture,
+      multipleChoiceOptions: multipleChoiceOptionsFixture
     };
     props.store = mockStore(reduxData);
 

--- a/__tests__/components/benefit_list_test.js
+++ b/__tests__/components/benefit_list_test.js
@@ -6,6 +6,7 @@ expect.extend(toHaveNoViolations);
 
 import benefitsFixture from "../fixtures/benefits";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
+import multipleChoiceOptionsFixture from "../fixtures/multiple_choice_options";
 
 import configureStore from "redux-mock-store";
 import needsFixture from "../fixtures/needs";
@@ -31,6 +32,7 @@ describe("BenefitList", () => {
       benefits: benefitsFixture,
       favouriteBenefits: [],
       eligibilityPaths: eligibilityPathsFixture,
+      multipleChoiceOptions: multipleChoiceOptionsFixture,
       needs: needsFixture,
       selectedNeeds: {}
     };

--- a/__tests__/components/benefit_pane_test.js
+++ b/__tests__/components/benefit_pane_test.js
@@ -9,6 +9,7 @@ import benefitsFixture from "../fixtures/benefits";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
 import needsFixture from "../fixtures/needs";
 import questionsFixture from "../fixtures/questions";
+import multipleChoiceOptionsFixture from "../fixtures/multiple_choice_options";
 
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
@@ -51,6 +52,7 @@ describe("BenefitsPane", () => {
       benefits: benefitsFixture,
       favouriteBenefits: [],
       eligibilityPaths: eligibilityPathsFixture,
+      multipleChoiceOptions: multipleChoiceOptionsFixture,
       filteredBenefits: benefitsFixture,
       needs: needsFixture,
       searchString: "",

--- a/__tests__/components/benefit_pane_test.js
+++ b/__tests__/components/benefit_pane_test.js
@@ -120,10 +120,10 @@ describe("BenefitsPane", () => {
         ).toEqual(0);
       });
 
-      it("returns 1 if one selectedEligibilty is selected", () => {
+      it("returns 1 if one selectedEligibility is selected", () => {
         mounted().setProps({
           profileFilters: {
-            patronType: eligibilityPathsFixture[0].patronType
+            patronType: "p1"
           }
         });
         expect(
@@ -150,7 +150,7 @@ describe("BenefitsPane", () => {
         mounted().setProps({ selectedNeeds: needsSelection });
         mounted().setProps({
           profileFilters: {
-            patronType: eligibilityPathsFixture[0].patronType
+            patronType: "p1"
           }
         });
         expect(

--- a/__tests__/components/card_footer_test.js
+++ b/__tests__/components/card_footer_test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import configureStore from "redux-mock-store";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
+import multipleChoiceOptionsFixture from "../fixtures/multiple_choice_options";
 import { CardFooter } from "../../components/card_footer";
 import benefitsFixture from "../fixtures/benefits";
 const { axe, toHaveNoViolations } = require("jest-axe");
@@ -19,7 +20,8 @@ describe("CardFooter", () => {
     mockStore = configureStore();
     reduxData = {
       benefits: benefitsFixture,
-      eligibilityPaths: eligibilityPathsFixture
+      eligibilityPaths: eligibilityPathsFixture,
+      multipleChoiceOptions: multipleChoiceOptionsFixture
     };
     props.store = mockStore(reduxData);
 
@@ -90,14 +92,20 @@ describe("CardFooter", () => {
     expect(mounted.state().open).toEqual(true);
   });
 
-  it("has a correct getBenefitIds function", () => {
-    expect(
-      mount(<CardFooter {...props} {...reduxData} />)
-        .instance()
-        .getBenefitIds(reduxData.eligibilityPaths)
-    ).toEqual({
-      veteran: new Set(["benefit_0", "benefit_2"]),
-      family: new Set(["benefit_2"])
+  describe("getBenefitIds", () => {
+    it("finds service person and family benefits", () => {
+      expect(
+        mount(<CardFooter {...props} {...reduxData} />)
+          .instance()
+          .getBenefitIds(
+            reduxData.eligibilityPaths,
+            ["mco_p2", "mco_p3"],
+            ["mco_p2"]
+          )
+      ).toEqual({
+        veteran: new Set(["benefit_1", "benefit_2", "benefit_3"]),
+        family: new Set(["benefit_2"])
+      });
     });
   });
 

--- a/__tests__/fixtures/eligibilityPaths.js
+++ b/__tests__/fixtures/eligibilityPaths.js
@@ -2,26 +2,22 @@ const eligibilityPathsFixture = [
   {
     id: "ep_0",
     requirements: ["mco_p1", "mco_s1"],
-    benefits: ["benefit_0", "benefit_2"],
-    patronType: "service-person"
+    benefits: ["benefit_0", "benefit_2"]
   },
   {
     id: "ep_1",
     requirements: ["mco_p2"],
-    benefits: ["benefit_2"],
-    patronType: "family"
+    benefits: ["benefit_2"]
   },
   {
     id: "ep_2",
     requirements: ["mco_p3"],
-    benefits: ["benefit_1", "benefit_3"],
-    patronType: "organization"
+    benefits: ["benefit_1", "benefit_3"]
   },
   {
     id: "ep_3",
     requirements: ["mco_p1", "mco_s2"],
-    benefits: ["benefit_3", "benefit_1"],
-    patronType: "organization"
+    benefits: ["benefit_3", "benefit_1"]
   }
 ];
 

--- a/__tests__/pages/all-benefits_test.js
+++ b/__tests__/pages/all-benefits_test.js
@@ -7,6 +7,7 @@ import { AllBenefits } from "../../pages/all-benefits";
 import benefitsFixture from "../fixtures/benefits";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
 import needsFixture from "../fixtures/needs";
+import multipleChoiceOptionsFixture from "../fixtures/multiple_choice_options";
 import translate from "../fixtures/translate";
 import configureStore from "redux-mock-store";
 
@@ -46,6 +47,7 @@ describe("AllBenefits", () => {
       cookiesDisabled: false,
       benefits: benefitsFixture,
       eligibilityPaths: eligibilityPathsFixture,
+      multipleChoiceOptions: multipleChoiceOptionsFixture,
       needs: needsFixture,
       searchString: "",
       selectedNeeds: {},

--- a/store.js
+++ b/store.js
@@ -2,7 +2,7 @@ import lunr from "lunr";
 import stemmerSupport from "lunr-languages/lunr.stemmer.support.js";
 import fr from "lunr-languages/lunr.fr.js";
 import { createStore } from "redux";
-import airtableConstants from "./utils/airtable_constants";
+import airtableConstants from "./utils/hardcoded_strings";
 
 stemmerSupport(lunr);
 fr(lunr);

--- a/utils/airtable_es2015.js
+++ b/utils/airtable_es2015.js
@@ -4,7 +4,7 @@ const Logger = require("./logger").default;
 
 exports.hydrateFromAirtable = exports.writeFeedback = undefined;
 
-var airtableConstants = require("./airtable_constants");
+var airtableConstants = require("./hardcoded_strings");
 var readKey = process.env.AIRTABLE_READ_KEY;
 var writeKey = process.env.AIRTABLE_WRITE_KEY;
 var baseKey = process.env.AIRTABLE_BASE_KEY || "appoFDwVvNMRSaO6o";

--- a/utils/hardcoded_strings.js
+++ b/utils/hardcoded_strings.js
@@ -9,3 +9,6 @@ exports.tableNames = [
   "questionDisplayLogic",
   "questionClearLogic"
 ];
+
+exports.servicePersonOptions = ["veteran", "servingMember"];
+exports.familyOptions = ["family"];


### PR DESCRIPTION
fixes #1349 
Use `requirements` column to determine Veteran / family benefits instead of the deprecated `patronType` column. Also remove `patronType` from the `eligibilityPaths` fixture.