### PR TITLE
First screen of guided experience does not show "My selection"

### DIFF
--- a/__tests__/components/guided_experience_test.js
+++ b/__tests__/components/guided_experience_test.js
@@ -147,4 +147,18 @@ describe("GuidedExperience", () => {
     props.helperText = "";
     expect(mounted_GuidedExperience().find("Body").length).toEqual(0);
   });
+
+  it("my selection text appears when there are breadcrumbs", () => {
+    expect(mounted_GuidedExperience().text()).toContain(
+      "B3.Filter by eligibility"
+    );
+  });
+
+  it("my selection text doesn't appear when there are no breadcrumbs", () => {
+    props.reduxState.patronType = "";
+    props.reduxState.serviceType = "";
+    expect(mounted_GuidedExperience().text()).not.toContain(
+      "B3.Filter by eligibility"
+    );
+  });
 });

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -43,7 +43,7 @@ export class GuidedExperience extends Component {
       .filter(x => x != "needs");
     let jsx_array = eligibilityKeys.map((k, i) => {
       if (!reduxState[k] || k === this.props.id) {
-        return "";
+        return null;
       } else {
         let option = reduxState.multipleChoiceOptions.filter(
           x => x.variable_name === reduxState[k]
@@ -103,6 +103,7 @@ export class GuidedExperience extends Component {
       });
 
     const jumpButtons = this.jumpButtons(t, reduxState);
+    const nonNullBreadcrumbs = jumpButtons.filter(x => x != null);
 
     return (
       <Container id="guidedExperience">
@@ -126,7 +127,9 @@ export class GuidedExperience extends Component {
           <Grid container spacing={24}>
             <Grid item xs={12} md={12}>
               <FilterText style={{ display: "inline-block" }}>
-                {t("B3.Filter by eligibility")}
+                {nonNullBreadcrumbs.length === 0
+                  ? ""
+                  : t("B3.Filter by eligibility")}
               </FilterText>
               {jumpButtons}
             </Grid>


### PR DESCRIPTION
Closes #1433 

In guided experience, "My selection" text is not visible when there are no breadcrumbs.