### PR TITLE
fixed the bug where the share modal was not getting the most current url

### DIFF
--- a/__tests__/components/share_modal_test.js
+++ b/__tests__/components/share_modal_test.js
@@ -21,6 +21,7 @@ describe("ShareModal", () => {
       isOpen: true,
       closeModal: jest.fn(),
       t: () => "en",
+      url: "test_url",
       titles: { share: "" },
       share: {
         copy_prompt: "",

--- a/components/BB.js
+++ b/components/BB.js
@@ -61,7 +61,7 @@ export class BB extends Component {
   }
 
   render() {
-    const { t } = this.props; // eslint-disable-line no-unused-vars
+    const { t, url, store } = this.props; // eslint-disable-line no-unused-vars
 
     return (
       <div
@@ -107,6 +107,7 @@ export class BB extends Component {
                   isOpen={this.state.showModal}
                   onRequestClose={() => this.setState({ showModal: false })}
                   closeModal={() => this.setState({ showModal: false })}
+                  url={url}
                   t={t}
                 />
               </Grid>
@@ -116,8 +117,8 @@ export class BB extends Component {
         <Container className={topPadding}>
           <Grid container spacing={32}>
             <Grid item lg={4} md={4} sm={5} xs={12}>
-              <ProfileNeedsSelectorMobile t={t} store={this.props.store} />
-              <ProfileNeedsSelector t={t} store={this.props.store} />
+              <ProfileNeedsSelectorMobile t={t} store={store} />
+              <ProfileNeedsSelector t={t} store={store} />
             </Grid>
             <Grid item lg={8} md={8} sm={7} xs={12}>
               <Grid container spacing={16}>
@@ -133,12 +134,7 @@ export class BB extends Component {
                 </Grid>
               </Grid>
 
-              <BenefitsPane
-                id="BenefitsPane"
-                t={t}
-                store={this.props.store}
-                url={this.props.url}
-              />
+              <BenefitsPane id="BenefitsPane" t={t} store={store} url={url} />
             </Grid>
           </Grid>
         </Container>

--- a/components/share_modal.js
+++ b/components/share_modal.js
@@ -115,11 +115,11 @@ class ShareModal extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      url: ""
+      origin: ""
     };
   }
   componentDidMount() {
-    this.setState({ url: window.location.href });
+    this.setState({ origin: window.location.origin });
   }
 
   copyText(e) {
@@ -141,7 +141,6 @@ class ShareModal extends Component {
 
   render() {
     const { isOpen, onRequestClose, closeModal, t } = this.props;
-
     // Only render modal on the client - portals are not supported on the server and fail tests
     if (process.browser) {
       return (
@@ -163,7 +162,7 @@ class ShareModal extends Component {
             <URLInputBox
               type="text"
               id="shareTarget"
-              value={this.state.url}
+              value={this.state.origin + this.props.url.asPath}
               readOnly
             />
             <CopyButton
@@ -187,6 +186,7 @@ ShareModal.propTypes = {
   isOpen: PropTypes.bool,
   onRequestClose: PropTypes.func,
   closeModal: PropTypes.func,
+  url: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired
 };
 if (process.browser) ReactModal.setAppElement("#main");


### PR DESCRIPTION
Closes #1491 

This turned out to be fairly easy since the current url is passed as a prop to each page, so when it changes that will trigger the modal to re-render.