### PR TITLE
Added edit buttons to summary page

### DIFF
--- a/__tests__/components/guided_experience_summary_test.js
+++ b/__tests__/components/guided_experience_summary_test.js
@@ -1,0 +1,63 @@
+import React from "react";
+import { mount } from "enzyme";
+import { GuidedExperienceSummary } from "../../components/guided_experience_summary";
+const { axe, toHaveNoViolations } = require("jest-axe");
+expect.extend(toHaveNoViolations);
+import benefitsFixture from "../fixtures/benefits";
+import translate from "../fixtures/translate";
+import needsFixture from "../fixtures/needs";
+import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
+import questionsFixture from "../fixtures/questions";
+import questionDisplayLogicFixture from "../fixtures/question_display_logic";
+import multipleChoiceOptions from "../fixtures/multiple_choice_options";
+
+describe("GuidedExperienceSummary", () => {
+  let props, reduxState;
+  beforeEach(() => {
+    props = {
+      t: translate,
+      url: { query: {}, route: "/summary" }
+    };
+    reduxState = {
+      benefits: benefitsFixture,
+      filteredBenefits: benefitsFixture,
+      eligibilityPaths: eligibilityPathsFixture,
+      needs: needsFixture,
+      selectedNeeds: {},
+      serviceType: "s1",
+      patronType: "p1",
+      option: "",
+      questions: questionsFixture,
+      questionDisplayLogic: questionDisplayLogicFixture,
+      questionClearLogic: questionDisplayLogicFixture,
+      multipleChoiceOptions: multipleChoiceOptions
+    };
+    props.reduxState = reduxState;
+  });
+
+  it("passes axe tests", async () => {
+    let html = mount(<GuidedExperienceSummary {...props} />).html();
+    expect(await axe(html)).toHaveNoViolations();
+  });
+
+  it("renders the correct number of li elements", async () => {
+    expect(
+      mount(<GuidedExperienceSummary {...props} />).find("li").length
+    ).toEqual(3);
+  });
+
+  it("renders the correct number of breadcrumbs", async () => {
+    expect(
+      mount(<GuidedExperienceSummary {...props} />).find("AnchorLink").length
+    ).toEqual(5);
+  });
+
+  it("clicking a breadcrumb takes you to the correct url", async () => {
+    expect(
+      mount(<GuidedExperienceSummary {...props} />)
+        .find("AnchorLink")
+        .first()
+        .prop("href")
+    ).toEqual("/index?section=patronType");
+  });
+});

--- a/__tests__/pages/summary_test.js
+++ b/__tests__/pages/summary_test.js
@@ -32,6 +32,7 @@ describe("Summary", () => {
     mockStore = configureStore();
     reduxState = {
       benefits: benefitsFixture,
+      filteredBenefits: benefitsFixture,
       eligibilityPaths: eligibilityPathsFixture,
       needs: needsFixture,
       selectedNeeds: {},

--- a/components/guided_experience_summary.js
+++ b/components/guided_experience_summary.js
@@ -5,7 +5,7 @@ import { css } from "react-emotion";
 import { globalTheme } from "../theme";
 import AnchorLink from "./typography/anchor_link";
 import { connect } from "react-redux";
-import { mutateUrl } from "../utils/common";
+import { mutateUrl, showQuestion } from "../utils/common";
 
 const outerDiv = css`
   padding: 12px;
@@ -74,10 +74,10 @@ export class GuidedExperienceSummary extends Component {
 
   breadcrumbs = () => {
     const { t, reduxState, url } = this.props;
-    const questionVariableNames = reduxState.questions.map(
-      x => x.variable_name
-    );
-    // .filter(x => x != "needs");
+    reduxState.questions.map(x => x.variable_name);
+    const questionVariableNames = reduxState.questions
+      .map(x => x.variable_name)
+      .filter((x, i) => showQuestion(x, i, reduxState));
     let jsx_array = questionVariableNames.map((k, i) => {
       const question = reduxState.questions.filter(
         x => x.variable_name === k

--- a/components/guided_experience_summary.js
+++ b/components/guided_experience_summary.js
@@ -5,6 +5,7 @@ import { css } from "react-emotion";
 import { globalTheme } from "../theme";
 import AnchorLink from "./typography/anchor_link";
 import { connect } from "react-redux";
+import { mutateUrl } from "../utils/common";
 
 const outerDiv = css`
   padding: 12px;
@@ -26,91 +27,88 @@ const breadcrumbList = css`
   width: 100%;
 `;
 
+const rightAlign = css`
+  text-align: right;
+`;
+
 export class GuidedExperienceSummary extends Component {
+  getOptionBreadcrumbText = option => {
+    if (this.props.t("current-language-code") === "en") {
+      return option.ge_breadcrumb_english
+        ? option.ge_breadcrumb_english
+        : option.display_text_english;
+    } else {
+      return option.ge_breadcrumb_french
+        ? option.ge_breadcrumb_french
+        : option.display_text_french;
+    }
+  };
+
+  getQuestionBreadcrumbText = question => {
+    if (this.props.t("current-language-code") === "en") {
+      return question.breadcrumb_english;
+    } else {
+      return question.breadcrumb_french;
+    }
+  };
+
   breadcrumbs = () => {
-    const { t, reduxState } = this.props;
-    // console.log(this.props)
+    const { t, reduxState, url } = this.props;
     const questionVariableNames = reduxState.questions
       .map(x => x.variable_name)
       .filter(x => x != "needs");
     let jsx_array = questionVariableNames.map((k, i) => {
+      const question = reduxState.questions.filter(
+        x => x.variable_name === k
+      )[0];
+      let content;
       if (!reduxState[k]) {
-        return (
-          <li className={breadcrumbCss} key={i}>
-            Not answered
-          </li>
+        content = (
+          <div>
+            {this.getQuestionBreadcrumbText(question) +
+              " " +
+              t("ge.not_selected")}
+          </div>
         );
       } else {
         let option = reduxState.multipleChoiceOptions.filter(
           x => x.variable_name === reduxState[k]
         )[0];
-        let text;
-        if (t("current-language-code") === "en") {
-          text = option.ge_breadcrumb_english
-            ? option.ge_breadcrumb_english
-            : option.display_text_english;
-        } else {
-          text = option.ge_breadcrumb_french
-            ? option.ge_breadcrumb_french
-            : option.display_text_french;
-        }
-
-        return (
-          <li className={breadcrumbCss} key={i}>
-            <AnchorLink
-              id={"breadcrumbs" + i}
-              href="#"
-              fontSize={24}
-              // onClick={() => this.props.setSection(k)}
-            >
-              {text}
-            </AnchorLink>
-          </li>
+        content = (
+          <AnchorLink
+            href={mutateUrl(url, "/index", { section: k })}
+            fontSize={24}
+          >
+            {this.getOptionBreadcrumbText(option)}
+          </AnchorLink>
         );
       }
+      return (
+        <li className={breadcrumbCss} key={i}>
+          <Grid container>
+            <Grid item xs={9}>
+              {content}
+            </Grid>
+            <Grid item xs={3} className={rightAlign}>
+              <AnchorLink
+                href={mutateUrl(url, "/index", { section: k })}
+                fontSize={24}
+              >
+                edit
+              </AnchorLink>
+            </Grid>
+          </Grid>
+        </li>
+      );
     });
     return jsx_array;
   };
 
-  // <li className={breadcrumbCss}>
-  //   <AnchorLink
-  //     id={"breadcrumb1"}
-  //     href="#"
-  //     onClick={x => x}
-  //     fontSize={24}
-  //   >
-  //     Benefits for Veterans PL
-  //   </AnchorLink>
-  // </li>
-  // <li className={breadcrumbCss}>
-  //   <AnchorLink
-  //     id={"breadcrumb2"}
-  //     href="#"
-  //     onClick={x => x}
-  //     fontSize={24}
-  //   >
-  //     Canadian Armed Forces PL
-  //   </AnchorLink>
-  // </li>
-  // <li className={breadcrumbCss}>
-  //   <AnchorLink
-  //     id={"breadcrumb3"}
-  //     href="#"
-  //     onClick={x => x}
-  //     fontSize={24}
-  //   >
-  //     Has a service related health issue PL
-  //   </AnchorLink>
-  // </li>
-
   render() {
     // const { t, reduxState } = this.props;
-    console.log(this.props);
     return (
       <div className={outerDiv}>
-        <Grid container spacing={24}>
-          <ul className={breadcrumbList}>{this.breadcrumbs()}</ul>
-        </Grid>
+        <ul className={breadcrumbList}>{this.breadcrumbs()}</ul>
       </div>
     );
   }
@@ -124,6 +122,7 @@ const mapStateToProps = reduxState => {
 
 GuidedExperienceSummary.propTypes = {
   reduxState: PropTypes.object.isRequired,
+  url: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   store: PropTypes.object
 };

--- a/components/guided_experience_summary.js
+++ b/components/guided_experience_summary.js
@@ -52,18 +52,42 @@ export class GuidedExperienceSummary extends Component {
     }
   };
 
+  getLiElement = (content, section, key) => {
+    return (
+      <li className={breadcrumbCss} key={key}>
+        <Grid container>
+          <Grid item xs={9}>
+            {content}
+          </Grid>
+          <Grid item xs={3} className={rightAlign}>
+            <AnchorLink
+              href={mutateUrl(this.props.url, "/index", { section: section })}
+              fontSize={24}
+            >
+              edit
+            </AnchorLink>
+          </Grid>
+        </Grid>
+      </li>
+    );
+  };
+
   breadcrumbs = () => {
     const { t, reduxState, url } = this.props;
-    const questionVariableNames = reduxState.questions
-      .map(x => x.variable_name)
-      .filter(x => x != "needs");
+    const questionVariableNames = reduxState.questions.map(
+      x => x.variable_name
+    );
+    // .filter(x => x != "needs");
     let jsx_array = questionVariableNames.map((k, i) => {
       const question = reduxState.questions.filter(
         x => x.variable_name === k
       )[0];
-      let content;
-      if (!reduxState[k]) {
-        content = (
+      let crumb;
+      if (
+        !reduxState[k] ||
+        (k === "needs" && Object.keys(reduxState.selectedNeeds).length == 0)
+      ) {
+        crumb = (
           <div>
             {this.getQuestionBreadcrumbText(question) +
               " " +
@@ -71,41 +95,37 @@ export class GuidedExperienceSummary extends Component {
           </div>
         );
       } else {
-        let option = reduxState.multipleChoiceOptions.filter(
-          x => x.variable_name === reduxState[k]
-        )[0];
-        content = (
+        let breadcrumbText;
+        if (k === "needs") {
+          const selectedNeeds = reduxState.needs
+            .filter(
+              x => Object.keys(reduxState.selectedNeeds).indexOf(x.id) > -1
+            )
+            .map(x => {
+              return t("current-language-code") === "en" ? x.nameEn : x.nameFr;
+            });
+          breadcrumbText = selectedNeeds.join(", ");
+        } else {
+          let option = reduxState.multipleChoiceOptions.filter(
+            x => x.variable_name === reduxState[k]
+          )[0];
+          breadcrumbText = this.getOptionBreadcrumbText(option);
+        }
+        crumb = (
           <AnchorLink
             href={mutateUrl(url, "/index", { section: k })}
             fontSize={24}
           >
-            {this.getOptionBreadcrumbText(option)}
+            {breadcrumbText}
           </AnchorLink>
         );
       }
-      return (
-        <li className={breadcrumbCss} key={i}>
-          <Grid container>
-            <Grid item xs={9}>
-              {content}
-            </Grid>
-            <Grid item xs={3} className={rightAlign}>
-              <AnchorLink
-                href={mutateUrl(url, "/index", { section: k })}
-                fontSize={24}
-              >
-                edit
-              </AnchorLink>
-            </Grid>
-          </Grid>
-        </li>
-      );
+      return this.getLiElement(crumb, k, i);
     });
     return jsx_array;
   };
 
   render() {
-    // const { t, reduxState } = this.props;
     return (
       <div className={outerDiv}>
         <ul className={breadcrumbList}>{this.breadcrumbs()}</ul>

--- a/components/guided_experience_summary.js
+++ b/components/guided_experience_summary.js
@@ -4,6 +4,7 @@ import { Grid } from "@material-ui/core";
 import { css } from "react-emotion";
 import { globalTheme } from "../theme";
 import AnchorLink from "./typography/anchor_link";
+import { connect } from "react-redux";
 
 const outerDiv = css`
   padding: 12px;
@@ -22,54 +23,108 @@ const breadcrumbCss = css`
 const breadcrumbList = css`
   border-bottom: 1px solid ${globalTheme.colour.warmGrey};
   padding-left: 0;
-  @media (max-width: 599px);
+  width: 100%;
 `;
 
 export class GuidedExperienceSummary extends Component {
+  // breadcrumbs = (reduxState) => {
+  //   console.log(this.props)
+  //   const questionVariableNames = reduxState.questions
+  //     .map(x => x.variable_name)
+  //     .filter(x => x != "needs");
+  //   let jsx_array = questionVariableNames.map((k, i) => {
+  //     if (!reduxState[k]) {
+  //       return (
+  //         <li className={breadcrumbCss}>
+  //           Not answered
+  //         </li>
+  //       );
+  //     } else {
+  //       let option = reduxState.multipleChoiceOptions.filter(
+  //         x => x.variable_name === reduxState[k]
+  //       )[0];
+  //       let text;
+  //       if (t("current-language-code") === "en") {
+  //         text = option.ge_breadcrumb_english
+  //           ? option.ge_breadcrumb_english
+  //           : option.display_text_english;
+  //       } else {
+  //         text = option.ge_breadcrumb_french
+  //           ? option.ge_breadcrumb_french
+  //           : option.display_text_french;
+  //       }
+  //
+  //       return (
+  //         <li className={breadcrumbCss}>
+  //           <AnchorLink
+  //             id={"breadcrumbs" + i}
+  //             href="#"
+  //             // onClick={() => this.props.setSection(k)}
+  //           >
+  //             {text}
+  //           </AnchorLink>
+  //         </li>
+  //
+  //       );
+  //     }
+  //   });
+  //   return jsx_array;
+  // };
+
+  // <li className={breadcrumbCss}>
+  //   <AnchorLink
+  //     id={"breadcrumb1"}
+  //     href="#"
+  //     onClick={x => x}
+  //     fontSize={24}
+  //   >
+  //     Benefits for Veterans PL
+  //   </AnchorLink>
+  // </li>
+  // <li className={breadcrumbCss}>
+  //   <AnchorLink
+  //     id={"breadcrumb2"}
+  //     href="#"
+  //     onClick={x => x}
+  //     fontSize={24}
+  //   >
+  //     Canadian Armed Forces PL
+  //   </AnchorLink>
+  // </li>
+  // <li className={breadcrumbCss}>
+  //   <AnchorLink
+  //     id={"breadcrumb3"}
+  //     href="#"
+  //     onClick={x => x}
+  //     fontSize={24}
+  //   >
+  //     Has a service related health issue PL
+  //   </AnchorLink>
+  // </li>
+
   render() {
+    // const { t, reduxState } = this.props;
+    console.log(this.props);
     return (
       <div className={outerDiv}>
         <Grid container spacing={24}>
-          <ul className={breadcrumbList}>
-            <li className={breadcrumbCss}>
-              <AnchorLink
-                id={"breadcrumb1"}
-                href="#"
-                onClick={x => x}
-                fontSize={24}
-              >
-                Benefits for Veterans PL
-              </AnchorLink>
-            </li>
-            <li className={breadcrumbCss}>
-              <AnchorLink
-                id={"breadcrumb2"}
-                href="#"
-                onClick={x => x}
-                fontSize={24}
-              >
-                Canadian Armed Forces PL
-              </AnchorLink>
-            </li>
-            <li className={breadcrumbCss}>
-              <AnchorLink
-                id={"breadcrumb3"}
-                href="#"
-                onClick={x => x}
-                fontSize={24}
-              >
-                Has a service related health issue PL
-              </AnchorLink>
-            </li>
-          </ul>
+          <ul className={breadcrumbList}>"abc"</ul>
         </Grid>
       </div>
     );
   }
 }
 
+const mapStateToProps = reduxState => {
+  return {
+    reduxState: reduxState
+  };
+};
+
 GuidedExperienceSummary.propTypes = {
+  reduxState: PropTypes.object.isRequired,
+  t: PropTypes.func.isRequired,
   store: PropTypes.object
 };
 
-export default GuidedExperienceSummary;
+export default connect(mapStateToProps)(GuidedExperienceSummary);

--- a/components/guided_experience_summary.js
+++ b/components/guided_experience_summary.js
@@ -27,49 +27,50 @@ const breadcrumbList = css`
 `;
 
 export class GuidedExperienceSummary extends Component {
-  // breadcrumbs = (reduxState) => {
-  //   console.log(this.props)
-  //   const questionVariableNames = reduxState.questions
-  //     .map(x => x.variable_name)
-  //     .filter(x => x != "needs");
-  //   let jsx_array = questionVariableNames.map((k, i) => {
-  //     if (!reduxState[k]) {
-  //       return (
-  //         <li className={breadcrumbCss}>
-  //           Not answered
-  //         </li>
-  //       );
-  //     } else {
-  //       let option = reduxState.multipleChoiceOptions.filter(
-  //         x => x.variable_name === reduxState[k]
-  //       )[0];
-  //       let text;
-  //       if (t("current-language-code") === "en") {
-  //         text = option.ge_breadcrumb_english
-  //           ? option.ge_breadcrumb_english
-  //           : option.display_text_english;
-  //       } else {
-  //         text = option.ge_breadcrumb_french
-  //           ? option.ge_breadcrumb_french
-  //           : option.display_text_french;
-  //       }
-  //
-  //       return (
-  //         <li className={breadcrumbCss}>
-  //           <AnchorLink
-  //             id={"breadcrumbs" + i}
-  //             href="#"
-  //             // onClick={() => this.props.setSection(k)}
-  //           >
-  //             {text}
-  //           </AnchorLink>
-  //         </li>
-  //
-  //       );
-  //     }
-  //   });
-  //   return jsx_array;
-  // };
+  breadcrumbs = () => {
+    const { t, reduxState } = this.props;
+    // console.log(this.props)
+    const questionVariableNames = reduxState.questions
+      .map(x => x.variable_name)
+      .filter(x => x != "needs");
+    let jsx_array = questionVariableNames.map((k, i) => {
+      if (!reduxState[k]) {
+        return (
+          <li className={breadcrumbCss} key={i}>
+            Not answered
+          </li>
+        );
+      } else {
+        let option = reduxState.multipleChoiceOptions.filter(
+          x => x.variable_name === reduxState[k]
+        )[0];
+        let text;
+        if (t("current-language-code") === "en") {
+          text = option.ge_breadcrumb_english
+            ? option.ge_breadcrumb_english
+            : option.display_text_english;
+        } else {
+          text = option.ge_breadcrumb_french
+            ? option.ge_breadcrumb_french
+            : option.display_text_french;
+        }
+
+        return (
+          <li className={breadcrumbCss} key={i}>
+            <AnchorLink
+              id={"breadcrumbs" + i}
+              href="#"
+              fontSize={24}
+              // onClick={() => this.props.setSection(k)}
+            >
+              {text}
+            </AnchorLink>
+          </li>
+        );
+      }
+    });
+    return jsx_array;
+  };
 
   // <li className={breadcrumbCss}>
   //   <AnchorLink
@@ -108,7 +109,7 @@ export class GuidedExperienceSummary extends Component {
     return (
       <div className={outerDiv}>
         <Grid container spacing={24}>
-          <ul className={breadcrumbList}>"abc"</ul>
+          <ul className={breadcrumbList}>{this.breadcrumbs()}</ul>
         </Grid>
       </div>
     );

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -13,8 +13,9 @@ import { css } from "react-emotion";
 import { globalTheme } from "../theme";
 import { mutateUrl } from "../utils/common";
 import { connect } from "react-redux";
-import { GuidedExperienceSummary } from "../components/guided_experience_summary";
+import GuidedExperienceSummary from "../components/guided_experience_summary";
 import Body from "../components/typography/body";
+import { getFilteredBenefits } from "../selectors/benefits";
 
 const box = css`
   padding: 25px 63px 63px 63px;
@@ -33,12 +34,16 @@ const questions = css`
 `;
 
 export class Summary extends Component {
+  countString = (x, t) => {
+    return t("B3.x benefits to consider", { x: x.length });
+  };
+
   render() {
-    const { t, i18n, url, reduxState, store } = this.props;
-    console.log(reduxState);
+    const { t, i18n, url, reduxState, store, filteredBenefits } = this.props;
     const prevSection =
       reduxState.patronType === "organization" ? "patronType" : "needs";
     const backUrl = mutateUrl(url, "/index", { section: prevSection });
+    const benefitsToConsider = this.countString(filteredBenefits, t);
     return (
       <Layout
         i18n={i18n}
@@ -68,7 +73,7 @@ export class Summary extends Component {
                 <div>
                   <GuidedExperienceSummary t={t} store={store} />
                   <Header size="md_lg" headingLevel="h3" paddingTop="40">
-                    {"Benefits to consider PL"}
+                    {benefitsToConsider}
                   </Header>
                   <Body>
                     <p>{t("B3.check eligibility")}</p>
@@ -95,13 +100,15 @@ export class Summary extends Component {
   }
 }
 
-const mapStateToProps = reduxState => {
+const mapStateToProps = (reduxState, props) => {
   return {
-    reduxState: reduxState
+    reduxState: reduxState,
+    filteredBenefits: getFilteredBenefits(reduxState, props)
   };
 };
 
 Summary.propTypes = {
+  filteredBenefits: PropTypes.array.isRequired,
   reduxState: PropTypes.object.isRequired,
   i18n: PropTypes.object.isRequired,
   url: PropTypes.object.isRequired,

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -71,7 +71,7 @@ export class Summary extends Component {
                   <p>{t("ge.summary_tooltip")}</p>
                 </Body>
                 <div>
-                  <GuidedExperienceSummary t={t} store={store} />
+                  <GuidedExperienceSummary t={t} url={url} store={store} />
                   <Header size="md_lg" headingLevel="h3" paddingTop="40">
                     {benefitsToConsider}
                   </Header>

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -35,6 +35,7 @@ const questions = css`
 export class Summary extends Component {
   render() {
     const { t, i18n, url, reduxState, store } = this.props;
+    console.log(reduxState);
     const prevSection =
       reduxState.patronType === "organization" ? "patronType" : "needs";
     const backUrl = mutateUrl(url, "/index", { section: prevSection });


### PR DESCRIPTION
Closes #1487, closes #1488

The tests leave something to be desired. And I didn't implement the edit icon yet. But the functionality is there. 

Also I found a bug where if you make a selection that includes needs, and then click the breadcrumb to go back to patron type from the summary page and select organization, you don't have any benefits. This tells me the needs aren't being cleared correctly in this case. I'll file a bug for that.