### PR TITLE
GE Edit navigation

### DIFF
--- a/__tests__/components/guided_experience_test.js
+++ b/__tests__/components/guided_experience_test.js
@@ -122,4 +122,26 @@ describe("GuidedExperience", () => {
       "/index?lng=en&patronType=veteran&section=needs"
     );
   });
+
+  it("clears only hidden questions if the next button is pressed", () => {
+    props.statusAndVitals = "blah";
+    mounted_GuidedExperience()
+      .find("#nextButton")
+      .first()
+      .simulate("click");
+    expect(Router.push).toBeCalledWith(
+      "/index?lng=en&patronType=veteran&serviceType=RCMP&section=serviceHealthIssue"
+    );
+  });
+
+  it("clears only hidden questions if the back button is pressed", () => {
+    props.statusAndVitals = "blah";
+    mounted_GuidedExperience()
+      .find("#prevButton")
+      .first()
+      .simulate("click");
+    expect(Router.push).toBeCalledWith(
+      "/?lng=en&patronType=veteran&serviceType=RCMP&section=patronType"
+    );
+  });
 });

--- a/__tests__/components/guided_experience_test.js
+++ b/__tests__/components/guided_experience_test.js
@@ -34,7 +34,6 @@ describe("GuidedExperience", () => {
   beforeEach(() => {
     props = {
       t: translate,
-      setSection: jest.fn(),
       id: "serviceType",
       prevSection: "patronType",
       stepNumber: 1,
@@ -45,6 +44,7 @@ describe("GuidedExperience", () => {
         route: "/summary"
       },
       saveQuestionResponse: jest.fn(),
+      sectionOrder: questionsFixture.map(x => x.variable_name),
       reduxState: {
         patronType: "veteran",
         serviceType: "RCMP",
@@ -63,22 +63,6 @@ describe("GuidedExperience", () => {
   it("passes axe tests", async () => {
     let html = mounted_GuidedExperience().html();
     expect(await axe(html)).toHaveNoViolations();
-  });
-
-  it("calls setSection if the Next button is pressed", () => {
-    mounted_GuidedExperience()
-      .find("Button")
-      .last()
-      .simulate("click");
-    expect(Router.push).toBeCalled();
-  });
-
-  it("calls setSection if the Back button is pressed", () => {
-    mounted_GuidedExperience()
-      .find("#prevButton")
-      .first()
-      .simulate("click");
-    expect(props.setSection).toBeCalledWith("patronType");
   });
 
   it("renders children", () => {

--- a/__tests__/pages/index_test.js
+++ b/__tests__/pages/index_test.js
@@ -18,7 +18,7 @@ expect.extend(toHaveNoViolations);
 
 jest.mock("react-ga");
 
-describe("Guided", () => {
+describe("Index", () => {
   let props;
   let _mountedGuided;
   let mockStore, reduxState;
@@ -85,23 +85,6 @@ describe("Guided", () => {
 
   it("componentWillMount sets state correctly from empty url", () => {
     expect(mountedGuided().state().section).toEqual("patronType");
-  });
-
-  describe("setSection", () => {
-    it("returns correct section when passed as argument", () => {
-      props.sectionOrder.forEach(section => {
-        let guidedInstance = mountedGuided().instance();
-        guidedInstance.setSection(section);
-        expect(guidedInstance.state.section).toEqual(section);
-      });
-    });
-
-    it("clears redux data for future questions", () => {
-      let guidedInstance = mountedGuided().instance();
-      guidedInstance.setSection("patronType");
-      expect(props.saveQuestionResponse).toBeCalledWith("serviceType", "");
-      expect(props.saveQuestionResponse).toBeCalledWith("selectedNeeds", {});
-    });
   });
 
   it("getNextSection returns the correct next section", () => {

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -38,6 +38,11 @@ export class GuidedExperience extends Component {
   returnGoToNextSection = clearCurrentQuestion => {
     let goToNextSection = () => {
       const { id, reduxState, url, saveQuestionResponse } = this.props;
+      let params = {};
+      this.queryParamsToClear().forEach(x => {
+        params[x.key] = x.value;
+      });
+
       // modifiedReduxState exists so we are sure the redux state updates before we do Router push
       let modifiedReduxState = JSON.parse(JSON.stringify(reduxState));
       if (clearCurrentQuestion) {
@@ -58,22 +63,23 @@ export class GuidedExperience extends Component {
       if (dynamicStepNumber + 1 >= displayable_sections.length) {
         nextSection = "summary";
         if (clearCurrentQuestion && id === "needs") {
-          const newUrl = mutateUrl(url, "/summary", {
-            section: "",
-            selectedNeeds: {}
-          });
+          params.section = "";
+          params.selectedNeeds = {};
+          const newUrl = mutateUrl(url, "/summary", params);
           window.location.href = newUrl;
           document.body.focus();
         } else {
-          Router.push(mutateUrl(url, "/summary", { section: "" }));
+          params.section = "";
+          Router.push(mutateUrl(url, "/summary", params));
           document.body.focus();
         }
       } else {
         nextSection = displayable_sections[dynamicStepNumber + 1];
-        const queryParams = clearCurrentQuestion
-          ? { section: nextSection, [id]: "" }
-          : { section: nextSection };
-        Router.push(mutateUrl(url, "/index", queryParams));
+        params.section = nextSection;
+        if (clearCurrentQuestion) {
+          params[id] = "";
+        }
+        Router.push(mutateUrl(url, "/index", params));
         document.body.focus();
       }
     };
@@ -86,15 +92,15 @@ export class GuidedExperience extends Component {
       .filter((x, i) => showQuestion(x, i, reduxState));
   };
 
-  clearQuestionsNotDisplayable() {
-    this.props.reduxState.questions
+  queryParamsToClear() {
+    return this.props.reduxState.questions
       .map(x => x.variable_name)
       .filter((x, i) => !showQuestion(x, i, this.props.reduxState))
-      .forEach(x => {
+      .map(x => {
         if (x === "needs") {
-          this.props.saveQuestionResponse("selectedNeeds", {});
+          return { key: "selectedNeeds", value: {} };
         } else {
-          this.props.saveQuestionResponse(x, "");
+          return { key: x, value: "" };
         }
       });
   }
@@ -117,8 +123,11 @@ export class GuidedExperience extends Component {
           <HeaderButton
             id="prevButton"
             onClick={() => {
-              this.clearQuestionsNotDisplayable();
-              Router.push(mutateUrl(url, "/", { section: prevSection }));
+              let params = { section: prevSection };
+              this.queryParamsToClear().forEach(x => {
+                params[x.key] = x.value;
+              });
+              Router.push(mutateUrl(url, "/", params));
               document.body.focus();
             }}
             className={prevButton}

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -63,8 +63,10 @@ export class GuidedExperience extends Component {
             selectedNeeds: {}
           });
           window.location.href = newUrl;
+          document.body.focus();
         } else {
           Router.push(mutateUrl(url, "/summary", { section: "" }));
+          document.body.focus();
         }
       } else {
         nextSection = displayable_sections[dynamicStepNumber + 1];
@@ -72,6 +74,7 @@ export class GuidedExperience extends Component {
           ? { section: nextSection, [id]: "" }
           : { section: nextSection };
         Router.push(mutateUrl(url, "/index", queryParams));
+        document.body.focus();
       }
     };
     return goToNextSection;
@@ -83,8 +86,21 @@ export class GuidedExperience extends Component {
       .filter((x, i) => showQuestion(x, i, reduxState));
   };
 
+  clearQuestionsNotDisplayable() {
+    this.props.reduxState.questions
+      .map(x => x.variable_name)
+      .filter((x, i) => !showQuestion(x, i, this.props.reduxState))
+      .forEach(x => {
+        if (x === "needs") {
+          this.props.saveQuestionResponse("selectedNeeds", {});
+        } else {
+          this.props.saveQuestionResponse(x, "");
+        }
+      });
+  }
+
   render() {
-    const { t, prevSection, subtitle, setSection, helperText } = this.props;
+    const { t, prevSection, subtitle, helperText, url } = this.props;
 
     return (
       <Container id="guidedExperience">
@@ -101,7 +117,9 @@ export class GuidedExperience extends Component {
           <HeaderButton
             id="prevButton"
             onClick={() => {
-              setSection(prevSection);
+              this.clearQuestionsNotDisplayable();
+              Router.push(mutateUrl(url, "/", { section: prevSection }));
+              document.body.focus();
             }}
             className={prevButton}
             arrow="back"
@@ -177,10 +195,11 @@ GuidedExperience.propTypes = {
   id: PropTypes.string.isRequired,
   url: PropTypes.object.isRequired,
   reduxState: PropTypes.object.isRequired,
+  sectionOrder: PropTypes.array.isRequired,
   saveQuestionResponse: PropTypes.func.isRequired,
   prevSection: PropTypes.string,
   t: PropTypes.func.isRequired,
-  setSection: PropTypes.func.isRequired,
+  // setSection: PropTypes.func.isRequired,
   subtitle: PropTypes.string.isRequired,
   helperText: PropTypes.string,
   stepNumber: PropTypes.number.isRequired,

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -199,7 +199,6 @@ GuidedExperience.propTypes = {
   saveQuestionResponse: PropTypes.func.isRequired,
   prevSection: PropTypes.string,
   t: PropTypes.func.isRequired,
-  // setSection: PropTypes.func.isRequired,
   subtitle: PropTypes.string.isRequired,
   helperText: PropTypes.string,
   stepNumber: PropTypes.number.isRequired,

--- a/pages/index.js
+++ b/pages/index.js
@@ -65,21 +65,6 @@ export class Guided extends Component {
     Router.replace(href);
   };
 
-  setSection = section => {
-    this.setState({ section: section });
-    const current_index = this.props.sectionOrder.indexOf(section);
-    this.props.sectionOrder
-      .filter((x, i) => i > current_index)
-      .forEach(x => {
-        if (x === "needs") {
-          this.props.saveQuestionResponse("selectedNeeds", {});
-        } else {
-          this.props.saveQuestionResponse(x, "");
-        }
-      });
-    document.body.focus(); // this removes focus from the next/back buttons
-  };
-
   getNextSection = (displayable_sections, dynamicStepNumber) => {
     if (dynamicStepNumber + 1 >= displayable_sections.length) {
       return "summary";
@@ -140,7 +125,6 @@ export class Guided extends Component {
             displayable_sections,
             dynamicStepNumber
           )}
-          setSection={this.setSection}
           subtitle={this.getSubtitle(question)}
           helperText={this.getTooltip(question)}
           t={t}


### PR DESCRIPTION
Closes #1529 

I changed the clear questions behaviour so that only un-displayable questions are cleared (whenever you click back/next/skip). This prevents bad eligibility paths from being saved in redux. This now happens by modifying the url that is navigated to, by getting query params for questions we want to clear, then adding in the existing logic on top of that. Convoluted but I think it works.