### PR TITLE
Fix ios zoom in on select

### DIFF
--- a/components/share_modal.js
+++ b/components/share_modal.js
@@ -65,7 +65,7 @@ const URLInputBox = styled("input")({
   fontFamily: globalTheme.fontFamily,
   fontWeight: 400,
   textTransform: "none",
-  fontSize: "14px",
+  fontSize: "1em",
   lineHeight: "1.5",
   background: globalTheme.colour.white,
   borderRadius: 0,


### PR DESCRIPTION
Resolves #1500 

See: https://blog.osmosys.asia/2017/01/05/prevent-ios-from-zooming-in-on-input-fields/

Font size in a selected input needs to be 1em or higher to prevent the zoom in.