### PR TITLE
Fix for see more bug

### DIFF
--- a/components/example_bullets.js
+++ b/components/example_bullets.js
@@ -24,7 +24,12 @@ export class ExampleBullets extends React.Component {
     const { benefitExamples, benefit, t } = this.props;
     const lang = t("current-language-code") === "en" ? "english" : "french";
     return benefitExamples
-      .filter(x => x.linked_benefits.indexOf(benefit.vacNameEn) > -1)
+      .filter(x => {
+        if ("linked_benefits" in x) {
+          return x.linked_benefits.indexOf(benefit.vacNameEn) > -1;
+        }
+        return false;
+      })
       .map((x, i) => {
         return <li key={i}>{x[lang]}</li>;
       });


### PR DESCRIPTION
Closes #1664 

Added a check that the linked_benefits key exists on the example content returned from airtable

I tested this by adding in a row to benefitExamples with missing linked benefits. I deleted the row so that see more would not be broken in master.