### PR TITLE
added option to anonymize IPs collected by google analytics

### DIFF
--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -13,6 +13,7 @@ export const initGA = () => {
     ]
     // , { debug: true }
   );
+  ReactGA.set({ anonymizeIp: true });
 };
 
 export const logPageView = () => {


### PR DESCRIPTION
Closes #1687 

I'm not sure if it's possible to verify that this is working, because IPs are not visible in the Google Analytics dashboard. But I did verify that location data is unaffected by this change. 