### PR TITLE
Refactor eligibility paths

### DIFF
--- a/__tests__/components/BB_test.js
+++ b/__tests__/components/BB_test.js
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import { BB } from "../../components/BB";
 import benefitsFixture from "../fixtures/benefits";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
+import benefitEligibilityFixture from "../fixtures/benefitEligibility";
 import needsFixture from "../fixtures/needs";
 import areaOfficesFixture from "../fixtures/area_offices";
 import questionsFixture from "../fixtures/questions";
@@ -64,6 +65,7 @@ describe("BB", () => {
       benefits: benefitsFixture,
       favouriteBenefits: [],
       eligibilityPaths: eligibilityPathsFixture,
+      benefitEligibility: benefitEligibilityFixture,
       filteredBenefits: benefitsFixture,
       needs: needsFixture,
       serviceType: "",

--- a/__tests__/components/benefit_card_test.js
+++ b/__tests__/components/benefit_card_test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { mount, shallow } from "enzyme";
 import configureStore from "redux-mock-store";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
+import benefitEligibilityFixture from "../fixtures/benefitEligibility";
 import { BenefitCard } from "../../components/benefit_cards";
 import benefitsFixture from "../fixtures/benefits";
 import benefitExamplesFixture from "../fixtures/benefitExamples";
@@ -54,6 +55,7 @@ describe("BenefitCard", () => {
       benefits: benefitsFixture,
       favouriteBenefits: [],
       eligibilityPaths: eligibilityPathsFixture,
+      benefitEligibility: benefitEligibilityFixture,
       multipleChoiceOptions: multipleChoiceOptionsFixture,
       benefitExamples: benefitExamplesFixture,
       questions: questionsFixture

--- a/__tests__/components/benefit_expansion_test.js
+++ b/__tests__/components/benefit_expansion_test.js
@@ -20,7 +20,7 @@ describe("BenefitExpansion", () => {
     props = {
       t: () => "en",
       benefit: benefitsFixture.filter(
-        x => x.vacNameEn === "Disability Pension"
+        x => x.vacNameEn === "Disability Benefits"
       )[0]
     };
     mockStore = configureStore();
@@ -76,9 +76,11 @@ describe("BenefitExpansion", () => {
           .map(x => x.vacNameEn)
       ).toEqual([
         "Attendance Allowance",
+        "Career Impact Allowance",
         "Clothing Allowance",
         "Exceptional Incapacity Allowance",
-        "Health Care Benefits"
+        "Treatment Benefits",
+        "Veterans Independence Program"
       ]);
     });
 

--- a/__tests__/components/benefit_expansion_test.js
+++ b/__tests__/components/benefit_expansion_test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import configureStore from "redux-mock-store";
 import eligibilityPathsFixture from "../fixtures/eligibility_paths_complex";
+import benefitEligibilityFixture from "../fixtures/benefitEligibility_complex";
 import multipleChoiceOptionsFixture from "../fixtures/multiple_choice_options_complex";
 import { BenefitExpansion } from "../../components/benefit_expansion";
 import benefitExamplesFixture from "../fixtures/benefitExamples";
@@ -27,6 +28,7 @@ describe("BenefitExpansion", () => {
     reduxData = {
       benefits: benefitsFixture,
       eligibilityPaths: eligibilityPathsFixture,
+      benefitEligibility: benefitEligibilityFixture,
       multipleChoiceOptions: multipleChoiceOptionsFixture,
       benefitExamples: benefitExamplesFixture,
       needs: needsFixture,

--- a/__tests__/fixtures/benefitEligibility.js
+++ b/__tests__/fixtures/benefitEligibility.js
@@ -1,0 +1,43 @@
+const benefitEligibilityFixture = [
+  {
+    id: "0",
+    benefit: ["benefit_0"],
+    patronType: ["mco_p1"],
+    serviceType: ["mco_s1"]
+  },
+  {
+    id: "1",
+    benefit: ["benefit_2"],
+    patronType: ["mco_p2"]
+  },
+  {
+    id: "2",
+    benefit: ["benefit_2"],
+    patronType: ["mco_p1"],
+    serviceType: ["mco_s1"]
+  },
+  {
+    id: "3",
+    benefit: ["benefit_1"],
+    patronType: ["mco_p3"]
+  },
+  {
+    id: "4",
+    benefit: ["benefit_3"],
+    patronType: ["mco_p3"]
+  },
+  {
+    id: "5",
+    benefit: ["benefit_1"],
+    patronType: ["mco_p1"],
+    serviceType: ["mco_s2"]
+  },
+  {
+    id: "6",
+    benefit: ["benefit_3"],
+    patronType: ["mco_p1"],
+    serviceType: ["mco_s2"]
+  }
+];
+
+export default benefitEligibilityFixture;

--- a/__tests__/fixtures/benefitEligibility_complex.js
+++ b/__tests__/fixtures/benefitEligibility_complex.js
@@ -1,0 +1,438 @@
+const benefitEligibilityFixture = [
+  {
+    benefit: ["rec7vYqDWYPQnDcRK"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    Name: "recfWHf1YmVfz0ppj",
+    path: "veteran + WSV (WWII or Korea)"
+  },
+  {
+    benefit: ["recNsVtmotVHzDhAB"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "rec6ejmokDXrYAUqT",
+    path: "veteran + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recMguNzAXgdpEDOJ"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recOVWkhp1IfbFnRU",
+    path: "family + CAF + deceased + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recMguNzAXgdpEDOJ"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "recGR0KBNakgQbLG5",
+    path: "veteran + CAF"
+  },
+  {
+    benefit: ["rece4vwRrORpYznkw"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recR4crMdLtxDz0cf",
+    path: "veteran, servingMember + CAF + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["rec45xfsf1ijZzXqM"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "recl8EQBaoPvkUs1y",
+    path: "veteran, servingMember + CAF"
+  },
+  {
+    benefit: ["recL63epbxypNYRjL"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "rec3LMYRHMRfFdc2E",
+    path: "veteran + CAF"
+  },
+  {
+    benefit: ["recL63epbxypNYRjL"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["rec3vCJImDFrRIaFl"],
+    Name: "recC1BOsrEwQQT7Tr",
+    path: "family + CAF + releasedAlive"
+  },
+  {
+    benefit: ["recEHxSnVLcMvYnbS"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    statusAndVitals: ["rec3vCJImDFrRIaFl"],
+    Name: "recXSg015decd4TOq",
+    path: "family + releasedAlive"
+  },
+  {
+    benefit: ["recVKse8WgvLYcfgP"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    statusAndVitals: ["rec3vCJImDFrRIaFl"],
+    Name: "recWmF49cJ0evYv0F",
+    path: "family + releasedAlive"
+  },
+  {
+    benefit: ["recVKse8WgvLYcfgP"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    Name: "recxyzl32f531NaOr",
+    path: "veteran"
+  },
+  {
+    benefit: ["rec6osa4YoZNwJcNW"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recBwJVJsjz3KF2kz",
+    path: "veteran + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recowlPz6lmqcbp7F"],
+    patronType: ["rec2pB1RcV3BvyjPX"],
+    Name: "recgFx9UqPwqSW6hO",
+    path: "organization"
+  },
+  {
+    benefit: ["recmFhBkztEyJtm5R"],
+    patronType: ["rec2pB1RcV3BvyjPX"],
+    Name: "recbbyAFXpnjEAmZ9",
+    path: "organization"
+  },
+  {
+    benefit: ["recH5vAKgnu56IwlS"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recoWEBTf2fHKxO8T",
+    path: "veteran, servingMember + CAF + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recMM2R9Dh1WUKxx6"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "reclYWjGKy8oabUkO",
+    path: "family + CAF + deceased + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recDU2iSRQ300ixBt"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "recNbQZ8omQdO5FhH",
+    path: "veteran, servingMember + CAF"
+  },
+  {
+    benefit: ["recOJ3P1wiacWA5jr"],
+    patronType: ["recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recPwgIAvnOrF9CZE",
+    path: "servingMember + CAF + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recOJ3P1wiacWA5jr"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "rechaKl1wJhKe0lnF",
+    path: "family + CAF + deceased"
+  },
+  {
+    benefit: ["recOJ3P1wiacWA5jr"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recmsrOwzHKCsUNl6",
+    path: "veteran + CAF + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recukRMcsAVvBpDJi"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "recQBzCRl2D8B7lxu",
+    path: "veteran + CAF"
+  },
+  {
+    benefit: ["recg5zjkXaddMWQEf"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recpCQ81MXjUrrerT",
+    path: "family + CAF + deceased"
+  },
+  {
+    benefit: ["recCkQL77l0KZ2u7Y"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recgi1wg3Z0xhI0KC",
+    path: "veteran + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recYOyXOqqSSCUVcN"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recdtaTP1HL6hgId7",
+    path: "family + CAF + deceased"
+  },
+  {
+    benefit: ["recEW4yF4GE4V1lTS"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recIKNddEHsrPobsJ",
+    path: "family + WSV (WWII or Korea) + deceased"
+  },
+  {
+    benefit: ["recEW4yF4GE4V1lTS"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recvSEet4Pf5xm2Ng",
+    path: "family + CAF + deceased"
+  },
+  {
+    benefit: ["rec3l8XwdR85xWNJ2"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "rec9M3lN0KwS8CJmj",
+    path: "veteran, servingMember + CAF + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["reczzwPrtckHy81oY"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["recIMgfjrCozH9eVW"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "rechEoLL5pBxeHcGN",
+    path: "family + RCMP + deceased"
+  },
+  {
+    benefit: ["reczzwPrtckHy81oY"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recoztJkT5J9MYX2G",
+    path: "family + WSV (WWII or Korea) + deceased"
+  },
+  {
+    benefit: ["reczzwPrtckHy81oY"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recRligLod0I0IhcP",
+    path: "family + CAF + deceased"
+  },
+  {
+    benefit: ["recaa4nxdJnSV3NrJ"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "recAz6FLY6qy3GkHd",
+    path: "veteran, servingMember + CAF"
+  },
+  {
+    benefit: ["recKZD7EgawQUTf98"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    Name: "recyyVwXzhgcX14IC",
+    path: "veteran + WSV (WWII or Korea)"
+  },
+  {
+    benefit: ["recKZD7EgawQUTf98"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "recJDGon9UpIRv1C6",
+    path: "veteran, servingMember + CAF"
+  },
+  {
+    benefit: ["rechnadMxMHp86vv8"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    Name: "recg7V3k3ol4FLAMh",
+    path: "veteran, servingMember"
+  },
+  {
+    benefit: ["rechnadMxMHp86vv8"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec3vCJImDFrRIaFl"],
+    Name: "rece3ZFiriZxO63e4",
+    path: "family + releasedAlive"
+  },
+  {
+    benefit: ["recVgcA6MDGMBFjzH"],
+    patronType: ["recuWkVDSEWc1K0eU", "recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY", "rec3hFX4SlnBMPl7W"],
+    Name: "recxq80Dbs1ijRlaE",
+    path: "family, veteran + CAF, WSV (WWII or Korea)"
+  },
+  {
+    benefit: ["reccTUqI8ybL1aHQR"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    statusAndVitals: ["rec3vCJImDFrRIaFl"],
+    Name: "rec0AZCo8gx3HzLy1",
+    path: "family + WSV (WWII or Korea) + releasedAlive"
+  },
+  {
+    benefit: ["reccTUqI8ybL1aHQR"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    Name: "recaVVZzKjrd2Duj8",
+    path: "veteran + WSV (WWII or Korea)"
+  },
+  {
+    benefit: ["recPUSdA7VeaZGUGh"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recBr3SAQU0GijleA",
+    path: "family + CAF + deceased + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recPUSdA7VeaZGUGh"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recGkh4BgTTH4ibVq",
+    path: "veteran, servingMember + CAF + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recjDkgdzzzNS6i5A"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recDSeANhF5XrVRcr",
+    path: "family + CAF + deceased"
+  },
+  {
+    benefit: ["recjDkgdzzzNS6i5A"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "recxc6T4F7Ft3bF0t",
+    path: "veteran + CAF"
+  },
+  {
+    benefit: ["recTJGH8uGpz9FIcl"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    Name: "recmRtb7mI9XaukBw",
+    path: "veteran + CAF"
+  },
+  {
+    benefit: ["recTJGH8uGpz9FIcl"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recgsVRR5F96KoQvT",
+    path: "family + CAF + deceased + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recBSXP6pYDS8xJJH"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: [
+      "rec6sKyG0dMJ7HLhY",
+      "rec3hFX4SlnBMPl7W",
+      "recIMgfjrCozH9eVW"
+    ],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recGSaT5q7VLKIDtA",
+    path: "family + CAF, WSV (WWII or Korea), RCMP + deceased"
+  },
+  {
+    benefit: ["recewrfxHbTWEVPig"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recEfRVYLpvWvqISx",
+    path: "veteran + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recpq5tKJOXWZ3JCS"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    Name: "recs1qwbmkLwDiA7Z",
+    path: "veteran"
+  },
+  {
+    benefit: ["recpq5tKJOXWZ3JCS"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "receBHaEdQ29Qid3n",
+    path: "family + deceased"
+  },
+  {
+    benefit: ["recnTqWEj6jCEF8h7"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recdzam05SfCt5PqJ",
+    path: "family + CAF + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recnTqWEj6jCEF8h7"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    Name: "recefz1kpLFu7Vkxh",
+    path: "veteran, servingMember + CAF + hasServiceHealthIssue"
+  },
+  {
+    benefit: ["recFMnhGVbQT8de27"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY", "rec3hFX4SlnBMPl7W"],
+    statusAndVitals: ["rec3vCJImDFrRIaFl"],
+    Name: "rec6vIdu4K8xl1nxi",
+    path: "veteran + CAF, WSV (WWII or Korea) + releasedAlive"
+  },
+  {
+    benefit: ["recFMnhGVbQT8de27"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec3hFX4SlnBMPl7W", "rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["rec3vCJImDFrRIaFl", "recDW9csGX2ekiwXb"],
+    Name: "recwtgBef5LIpUifM",
+    path: "family + WSV (WWII or Korea), CAF + releasedAlive, deceased"
+  },
+  {
+    benefit: ["recqpTIM3UcQkeRh0"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY", "rec3hFX4SlnBMPl7W"],
+    Name: "recnz9qP2cSNgBzE8",
+    path: "veteran + CAF, WSV (WWII or Korea)"
+  },
+  {
+    benefit: ["recqpTIM3UcQkeRh0"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "rechrkjJpnl8ZEamI",
+    path: "family + WSV (WWII or Korea) + deceased"
+  },
+  {
+    benefit: ["recO8NVH2tWIjNpDA"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: [
+      "recM3T55J3Xf1qP16",
+      "rec3vCJImDFrRIaFl",
+      "recDW9csGX2ekiwXb"
+    ],
+    Name: "recQKuvUeQib6xDlk",
+    path: "family + CAF + stillServing, releasedAlive, deceased"
+  },
+  {
+    benefit: ["recDRPu2NF4UIximU"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    Name: "recxiPnxu1B8Xq1HX",
+    path: "family + WSV (WWII or Korea) + deceased"
+  },
+  {
+    benefit: ["recDRPu2NF4UIximU"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    Name: "recqM9VdRHwdy35Xf",
+    path: "veteran + WSV (WWII or Korea)"
+  }
+];
+export default benefitEligibilityFixture;

--- a/__tests__/fixtures/benefitEligibility_complex.js
+++ b/__tests__/fixtures/benefitEligibility_complex.js
@@ -433,6 +433,58 @@ const benefitEligibilityFixture = [
     serviceType: ["rec3hFX4SlnBMPl7W"],
     Name: "recqM9VdRHwdy35Xf",
     path: "veteran + WSV (WWII or Korea)"
+  },
+  {
+    path: "veteran, servingMember + CAF, RCMP + hasServiceHealthIssue",
+    Name: "recu4sFexY13tk9En",
+    benefit: ["rec0jzif5VceIWKh3"],
+    patronType: ["recu6xP62BL9yFbWN", "recC9OodJNCqbnGy2"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"],
+    serviceType: ["rec6sKyG0dMJ7HLhY", "recIMgfjrCozH9eVW"]
+  },
+  {
+    path: "veteran + WSV (WWII or Korea) + hasServiceHealthIssue",
+    Name: "reccSZsLXT8Xond4j",
+    benefit: ["rec0jzif5VceIWKh3"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec3hFX4SlnBMPl7W"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"]
+  },
+  {
+    path: "organization",
+    Name: "recPFXxlCxvWwpgJo",
+    benefit: ["recZv71nHMgCoX93h"],
+    patronType: ["rec2pB1RcV3BvyjPX"]
+  },
+  {
+    path: "family + CAF + deceased + hasServiceHealthIssue",
+    Name: "rec20oclQcDExORJ8",
+    benefit: ["recXrrmxgZ66BoiK3"],
+    patronType: ["recuWkVDSEWc1K0eU"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    statusAndVitals: ["recDW9csGX2ekiwXb"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"]
+  },
+  {
+    path: "servingMember",
+    Name: "recCwYo9TbCnPBa7y",
+    benefit: ["recoqXJ7Tx3XaDdFE"],
+    patronType: ["recC9OodJNCqbnGy2"]
+  },
+  {
+    path: "organization",
+    Name: "recckWh09Jtsuk3YK",
+    benefit: ["rec8GCHaN2UirvW8H"],
+    patronType: ["rec2pB1RcV3BvyjPX"]
+  },
+  {
+    path: "veteran + CAF + hasServiceHealthIssue",
+    Name: "recTh0JLYM6omz07j",
+    benefit: ["recR3CLbZSRlbGQJV"],
+    patronType: ["recu6xP62BL9yFbWN"],
+    serviceType: ["rec6sKyG0dMJ7HLhY"],
+    serviceHealthIssue: ["recxVaqj0O8BPKyeD"]
   }
 ];
+
 export default benefitEligibilityFixture;

--- a/__tests__/fixtures/benefits_complex.js
+++ b/__tests__/fixtures/benefits_complex.js
@@ -1,4 +1,25 @@
-let benefits = [
+const benefits = [
+  {
+    vacNameEn: "Assistance Fund ",
+    vacNameFr: "Fonds de secours",
+    benefitPageEn:
+      "http://www.veterans.gc.ca/eng/services/financial/war-veterans-allowance/assistance-fund",
+    benefitPageFr:
+      "http://www.veterans.gc.ca/fra/services/financial/war-veterans-allowance/assistance-fund",
+    eligibilityPaths: ["recsOdDx7CWAftWIR"],
+    needs: ["recpN4AgAGiH3x7KZ", "recEahND3kwnUPTHx"],
+    oneLineDescriptionEn:
+      "Quick access to funds for urgent needs such as food, shelter or medical expenses.",
+    oneLineDescriptionFr:
+      "(fra)Quick access to funds for urgent needs such as food, shelter or medical expenses",
+    availableIndependently: "Requires Gateway Benefit",
+    benefitPolicyEn:
+      "http://www.veterans.gc.ca/eng/about-us/policy/document/1042",
+    benefitPolicyFR:
+      "http://www.veterans.gc.ca/fra/about-us/policy/document/1042",
+    benefitEligibility: ["recfWHf1YmVfz0ppj"],
+    id: "rec7vYqDWYPQnDcRK"
+  },
   {
     vacNameEn: "Attendance Allowance",
     vacNameFr: "Allocation pour soins",
@@ -9,17 +30,17 @@ let benefits = [
     eligibilityPaths: ["recQerwEMBUU3TlRO"],
     needs: ["recpN4AgAGiH3x7KZ", "recXfW6phH2FFcE3T"],
     oneLineDescriptionEn:
-      "Monthly benefit for disability pensioner whose significant health needs require personal care support.",
+      "Monthly payments if your health needs require personal care support.",
     oneLineDescriptionFr:
-      "Versements mensuels pour les vétérans qui ont besoin d'aide avec les activitées quotidiennes en raison d'un handicap grave. ",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Versements mensuels pour les v\u00e9t\u00e9rans qui ont besoin d'aide avec les activit\u00e9es quotidiennes en raison d'un handicap grave. ",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/1931#anchor57065",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/1931#anchor57065",
-    id: "recNsVtmotVHzDhAB",
-    sortingNumber: 3
+    benefitEligibility: ["rec6ejmokDXrYAUqT"],
+    id: "recNsVtmotVHzDhAB"
   },
   {
     vacNameEn: "Canadian Forces Income Support",
@@ -31,20 +52,21 @@ let benefits = [
     eligibilityPaths: ["rec8azbXzu0MLVs3y", "rec6usTRT8JfBWYBC"],
     needs: ["recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Monthly benefit to help low-income CAF Veterans, survivors and dependent children.",
+      "Monthly payments if you have\u00a0a low household income.",
     oneLineDescriptionFr:
-      "Versements mensuels pour les vétérans et familles sans emploi ou ayant un faible revenu.",
+      "Versements mensuels pour les v\u00e9t\u00e9rans et familles sans emploi ou ayant un faible revenu.",
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/1243",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/1243",
-    id: "recMguNzAXgdpEDOJ",
-    sortingNumber: 3
+    sortingPriority: "medium",
+    benefitEligibility: ["recOVWkhp1IfbFnRU", "recGR0KBNakgQbLG5"],
+    id: "recMguNzAXgdpEDOJ"
   },
   {
     vacNameEn: "Career Impact Allowance",
-    vacNameFr: "Allocation pour incidence sur la carrière",
+    vacNameFr: "Allocation pour incidence sur la carri\u00e8re",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/transition/rehabilitation/career-impact-allowance",
     benefitPageFr:
@@ -52,43 +74,27 @@ let benefits = [
     eligibilityPaths: ["recU1DU5vDT8h3sOX"],
     needs: ["recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Monthly benefit for a CAF Veteran who has limited career options due to their service-related injury. ",
+      "Monthly payments if your career options are limited due to your service-related injury.",
     oneLineDescriptionFr:
-      "Versement mensuels pour les vétérans ayant un problème de santé grave qui affecte leur revenu.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
-    childBenefits: ["receQA3URlp00lwE9"],
+      "Versement mensuels pour les v\u00e9t\u00e9rans ayant un probl\u00e8me de sant\u00e9 grave qui affecte leur revenu.",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/2126",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/2126",
-    id: "rece4vwRrORpYznkw",
-    sortingNumber: 3
-  },
-  {
-    vacNameEn: "Career Impact Allowance Supplement ",
-    vacNameFr: "Supplément à l’AIC",
-    benefitPageEn:
-      "http://www.veterans.gc.ca/eng/services/transition/rehabilitation/career-impact-allowance",
-    benefitPageFr:
-      "http://www.veterans.gc.ca/fra/services/transition/rehabilitation/career-impact-allowance",
-    eligibilityPaths: ["recU1DU5vDT8h3sOX"],
-    oneLineDescriptionEn:
-      "Extra monthly payments in addition to the Career Impact Allowance.",
-    oneLineDescriptionFr:
-      "Versement mensuels qui s'ajoutent à l'Allocation pour incidence sur la carrière.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
-    availableIndependently: "Requires Gateway Benefit",
-    benefitPolicyEn:
-      "http://www.veterans.gc.ca/eng/about-us/policy/document/2126",
-    benefitPolicyFR:
-      "http://www.veterans.gc.ca/fra/about-us/policy/document/2126",
-    id: "receQA3URlp00lwE9",
-    sortingNumber: 3
+    sortingPriority: "medium",
+    benefitExamples: [
+      "recBhkHDsiHl8YC3z",
+      "rechDjxKaLvgxzzxK",
+      "recsKq5LuDw0TcjWa"
+    ],
+    benefitEligibility: ["recR4crMdLtxDz0cf"],
+    id: "rece4vwRrORpYznkw"
   },
   {
     vacNameEn: "Career Transition Services",
-    vacNameFr: "Services de réorientation professionnelle",
+    vacNameFr: "Services de r\u00e9orientation professionnelle",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/transition/career-transition-services",
     benefitPageFr:
@@ -96,16 +102,22 @@ let benefits = [
     eligibilityPaths: ["recxsl5L3LLGIT9rt"],
     needs: ["recFX7O3dYwg44kpM"],
     oneLineDescriptionEn:
-      "Job finding assistance, such as career counselling and interview skills, to help start a civilian career.",
+      "Access to a career counselor for Veterans who want to find a new job. ",
     oneLineDescriptionFr:
-      "Accès à un conseiller en orientation professionnelle pour les vétérans qui veulent trouver une nouvelle carrière.",
-    "categories DO NOT USE": ["recDYAiBEPn2JUtX9"],
+      "Acc\u00e8s \u00e0 un conseiller en orientation professionnelle pour les v\u00e9t\u00e9rans qui veulent trouver une nouvelle carri\u00e8re.",
+    "categories DO NOT USE": "Education and jobs",
     availableIndependently: "Independent",
     benefitPolicyEn: "http://www.veterans.gc.ca/eng/about-us/policy/category/5",
     benefitPolicyFR: "http://www.veterans.gc.ca/fra/about-us/policy/category/5",
-    sortingPriority: "low",
-    id: "rec45xfsf1ijZzXqM",
-    sortingNumber: 3
+    sortingPriority: "medium",
+    benefitExamples: [
+      "rec1ohbwEbWeuXS1x",
+      "recYXSi4ixhJ54Yat",
+      "recD1n2klEGVSNPiT",
+      "recmmMpVXLmP914l3"
+    ],
+    benefitEligibility: ["recl8EQBaoPvkUs1y"],
+    id: "rec45xfsf1ijZzXqM"
   },
   {
     vacNameEn: "Caregiver Recognition Benefit",
@@ -117,17 +129,85 @@ let benefits = [
     eligibilityPaths: ["recJxCbyWEnhFHJvj", "rec8azbXzu0MLVs3y"],
     needs: ["recpN4AgAGiH3x7KZ", "recXfW6phH2FFcE3T"],
     oneLineDescriptionEn:
-      "Monthly benefit for the informal caregiver of a seriously-injured CAF Veteran.",
+      "Monthly payment for the unpaid caregiver of an ill or injured Veteran.",
     oneLineDescriptionFr:
-      "Versements mensuels pour la famille ou les amis qui prennent soin des vétérans malades ou handicapés.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC", "receAbpIThPLRxDHE"],
+      "Versements mensuels pour la famille ou les amis qui prennent soin des v\u00e9t\u00e9rans malades ou handicap\u00e9s.",
+    "categories DO NOT USE": "Financial assistance, Family support",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/72",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/72",
     sortingPriority: "medium",
+    benefitExamples: [
+      "recdmNVy13VEipj0q",
+      "recasyXJlnd25e20M",
+      "recehnQq4Xvec79b5",
+      "rec0Hviw5cBvsU3sT",
+      "recADhtQYuvlHswFb",
+      "recZPfT7Z6ZbRS11q",
+      "recdbhSW7rFNUP3x1",
+      "rech8jBTAKZTskOGB",
+      "reci5GzywxsSD11Wf"
+    ],
+    benefitEligibility: ["rec3LMYRHMRfFdc2E", "recC1BOsrEwQQT7Tr"],
     id: "recL63epbxypNYRjL",
+    sortingNumber: 2
+  },
+  {
+    vacNameEn: "Caregiver Zone",
+    vacNameFr: "Espace aidants",
+    benefitPageEn: "https://caregiverzone.ca/",
+    benefitPageFr: "https://caregiverzone.ca/",
+    eligibilityPaths: ["rec7YU77wS3rAEu3s"],
+    needs: ["recmmMZPP4DI6Nq0a"],
+    oneLineDescriptionEn:
+      "An online community for caregivers who want to share their story, ask questions or learn more about caregiving.",
+    oneLineDescriptionFr:
+      "(fra)An online community for caregivers who want to share their story, ask questions or learn more about caregiving.",
+    availableIndependently: "Independent",
+    benefitPolicyEn:
+      "https://www.canada.ca/en/veterans-affairs-canada/news/2018/03/veterans-affairs-canada-and-saint-elizabeth-to-launch-online-tool-caregiver-zone.html",
+    benefitPolicyFR:
+      "https://www.canada.ca/fr/anciens-combattants-canada/nouvelles/2018/03/anciens-combattants-canada-et-saint-elizabeth-health-care-lancent-un-outil-en-ligne-lespace-aidants.html",
+    benefitExamples: [
+      "recClBs2BxPqjIJrf",
+      "rec1ovh1no4EEQs76",
+      "recjaWGaINIGZpXfX",
+      "recgytggFDctN4PpF"
+    ],
+    benefitEligibility: ["recXSg015decd4TOq"],
+    id: "recEHxSnVLcMvYnbS",
+    sortingNumber: 3
+  },
+  {
+    vacNameEn: "Case management",
+    vacNameFr: "Gestion de cas",
+    benefitPageEn:
+      "http://www.veterans.gc.ca/eng/services/transition/case-management",
+    benefitPageFr:
+      "http://www.veterans.gc.ca/fra/services/transition/case-management",
+    eligibilityPaths: ["recmKzJ6y5K1TgEiI", "rec7YU77wS3rAEu3s"],
+    needs: [
+      "recFX7O3dYwg44kpM",
+      "recpN4AgAGiH3x7KZ",
+      "recmmMZPP4DI6Nq0a",
+      "recjTEL7xK4196TE7"
+    ],
+    oneLineDescriptionEn:
+      "A case manager can help you get the right programs and services for you and your family.",
+    oneLineDescriptionFr:
+      "(fra)One-on-one support to help with a significant challenge such as a serious injury.",
+    childBenefits: ["recR3CLbZSRlbGQJV"],
+    availableIndependently: "Independent",
+    sortingPriority: "medium",
+    benefitExamples: [
+      "recrRLd69mSWLCXQn",
+      "recClYBnnWxRoWDyS",
+      "recPicBinTyDFxVqb"
+    ],
+    benefitEligibility: ["recWmF49cJ0evYv0F", "recxyzl32f531NaOr"],
+    id: "recVKse8WgvLYcfgP",
     sortingNumber: 2
   },
   {
@@ -138,22 +218,22 @@ let benefits = [
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/after-injury/disability-benefits/related-allowances",
     eligibilityPaths: ["recQerwEMBUU3TlRO"],
-    needs: ["recGvrfrW7njPwsbk"],
+    needs: ["recGvrfrW7njPwsbk", "recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Monthly benefit for disability pensioner whose injury causes wear and tear on clothing or requires specially-made clothing.",
+      "Monthly payments if you need new or specialized clothing due to your health issues.",
     oneLineDescriptionFr:
-      "Versement mensuel aux les vétérans qui ont besoin de vêtements neufs ou spéciaux en raison de leur état de santé.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Versement mensuel aux les v\u00e9t\u00e9rans qui ont besoin de v\u00eatements neufs ou sp\u00e9ciaux en raison de leur \u00e9tat de sant\u00e9.",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/1931#anchor57064",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/1931#anchor57064",
-    id: "rec6osa4YoZNwJcNW",
-    sortingNumber: 3
+    benefitEligibility: ["recBwJVJsjz3KF2kz"],
+    id: "rec6osa4YoZNwJcNW"
   },
   {
-    vacNameEn: "Community Engagement",
+    vacNameEn: "Community Engagement Fund",
     vacNameFr: "Engagement communautaire",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/remembrance/funding-programs/commemorative-partnership/engagement",
@@ -161,36 +241,51 @@ let benefits = [
       "http://www.veterans.gc.ca/fra/remembrance/funding-programs/commemorative-partnership/engagement",
     eligibilityPaths: ["rec04iKWngFVunoHt"],
     oneLineDescriptionEn:
-      "Funding to support commemorative activities or the development of commemorative materials.",
+      "A fund for community projects and events that honour Canadian Veterans.",
     oneLineDescriptionFr:
-      "Une subvention pour les projets qui rendent hommage aux vétérans canadiens.",
-    "categories DO NOT USE": ["recmhbCvQAByME8g9"],
+      "Une subvention pour les projets qui rendent hommage aux v\u00e9t\u00e9rans canadiens.",
+    "categories DO NOT USE": "Community funding",
     availableIndependently: "Requires Gateway Benefit",
     sortingPriority: "low",
-    id: "recowlPz6lmqcbp7F",
-    sortingNumber: 3
+    benefitExamples: [
+      "recX6dSojaR2I9EmN",
+      "rec5lqCt4ZNI0pIqV",
+      "recvRAqG7bQJ1rqdr",
+      "recFehWD45uwhBuUE",
+      "recFRUaXFP8wikP7T",
+      "reciEhBM9L10qOmix",
+      "recApHjwONYCPf2E8"
+    ],
+    benefitEligibility: ["recgFx9UqPwqSW6hO"],
+    id: "recowlPz6lmqcbp7F"
   },
   {
-    vacNameEn: "Community War Memorial",
-    vacNameFr: "Monuments commémoratifs",
+    vacNameEn: "Community War Memorial Fund",
+    vacNameFr: "Monuments comm\u00e9moratifs",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/remembrance/funding-programs/commemorative-partnership/community-war-memorial",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/remembrance/funding-programs/commemorative-partnership/community-war-memorial",
     eligibilityPaths: ["rec04iKWngFVunoHt"],
     oneLineDescriptionEn:
-      "Funding to support the construction, restoration, or expansion of a community war memorial.",
+      "A fund for the construction, restoration or expansion of war memorials.",
     oneLineDescriptionFr:
-      "Une subvention pour la construction, la restauration ou l'expansion de monuments commémoratifs.",
-    "categories DO NOT USE": ["recmhbCvQAByME8g9"],
+      "Une subvention pour la construction, la restauration ou l'expansion de monuments comm\u00e9moratifs.",
+    "categories DO NOT USE": "Community funding",
     availableIndependently: "Requires Gateway Benefit",
     sortingPriority: "low",
-    id: "recmFhBkztEyJtm5R",
-    sortingNumber: 3
+    benefitExamples: [
+      "recMUPa3rIgiJqWRK",
+      "rectdc01JTHqIqfE2",
+      "recoEsbGcRkDQ3Gdl",
+      "rec9a51tKgrjFth1A"
+    ],
+    benefitEligibility: ["recbbyAFXpnjEAmZ9"],
+    id: "recmFhBkztEyJtm5R"
   },
   {
     vacNameEn: "Critical Injury Benefit",
-    vacNameFr: "Indemnité pour blessure grave",
+    vacNameFr: "Indemnit\u00e9 pour blessure grave",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/after-injury/critical-injury-benefit",
     benefitPageFr:
@@ -198,133 +293,98 @@ let benefits = [
     eligibilityPaths: ["recU1DU5vDT8h3sOX"],
     needs: ["recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "A lump-sum payment for a CAF member who had a severe and traumatic service-related injury.",
+      "A one-time payment if you are suddenly and critically injured while serving.",
     oneLineDescriptionFr:
-      "Prestation ponctuelle versée aux vétérans ayant subi une blessure grave au cours de leur service. ",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Prestation ponctuelle vers\u00e9e aux v\u00e9t\u00e9rans ayant subi une blessure grave au cours de leur service. ",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/2231",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/2231",
-    id: "recH5vAKgnu56IwlS",
-    sortingNumber: 3
+    sortingPriority: "medium",
+    benefitEligibility: ["recoWEBTf2fHKxO8T"],
+    id: "recH5vAKgnu56IwlS"
   },
   {
     vacNameEn: "Death Benefit",
-    vacNameFr: "Indemnité de décès",
+    vacNameFr: "Indemnit\u00e9 de d\u00e9c\u00e8s",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/financial/death-benefit",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/financial/death-benefit",
-    eligibilityPaths: ["rec1dXWxOfzFZ6zKL", "rec4zJqrgvVa7Rf4c"],
+    eligibilityPaths: ["rec6usTRT8JfBWYBC"],
     needs: ["recjTEL7xK4196TE7"],
     oneLineDescriptionEn:
-      "Lump-sum compensation for the family of a CAF member who died in service.",
+      "Lump-sum compensation for the family of a military member who died in service.",
     oneLineDescriptionFr:
-      "Prestation ponctuelle versée aux familles des militaires morts en raison de leur service militaire.",
-    "categories DO NOT USE": ["receAbpIThPLRxDHE", "recVAt7jHcjJFlCTC"],
+      "Prestation ponctuelle vers\u00e9e aux familles des militaires morts en raison de leur service militaire.",
+    "categories DO NOT USE": "Family support, Financial assistance",
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/11",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/11",
-    id: "recMM2R9Dh1WUKxx6",
-    sortingNumber: 3
+    benefitEligibility: ["reclYWjGKy8oabUkO"],
+    id: "recMM2R9Dh1WUKxx6"
   },
   {
     vacNameEn: "Detention Benefits",
-    vacNameFr: "Indemnité de captivité",
+    vacNameFr: "Indemnit\u00e9 de captivit\u00e9",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/financial/detention-benefits",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/financial/detention-benefits",
-    eligibilityPaths: ["recxsl5L3LLGIT9rt", "rec1dXWxOfzFZ6zKL"],
+    eligibilityPaths: ["recxsl5L3LLGIT9rt"],
     needs: ["recjTEL7xK4196TE7", "recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Lump-sum compensation to CAF Veterans who were detained by an enemy, opposing force or person or group carrying out a terrorist activity. ",
+      "Lump-sum compensation if you were detained by an enemy, opposing force or group carrying out a terrorist activity. ",
     oneLineDescriptionFr:
-      "Prestation ponctuelle versée aux militaires qui ont été détenus, se sont échappés ou ont évité la capture.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Prestation ponctuelle vers\u00e9e aux militaires qui ont \u00e9t\u00e9 d\u00e9tenus, se sont \u00e9chapp\u00e9s ou ont \u00e9vit\u00e9 la capture.",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/903",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/903",
-    id: "recDU2iSRQ300ixBt",
-    sortingNumber: 3
+    sortingPriority: "low",
+    benefitEligibility: ["recNbQZ8omQdO5FhH"],
+    id: "recDU2iSRQ300ixBt"
   },
   {
-    vacNameEn: "Disability Award",
-    vacNameFr: "L'indemnité d'invalidité",
+    vacNameEn: "Disability Benefits",
+    vacNameFr: "Prestations d'invalidit\u00e9",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/after-injury/disability-benefits/disability-award",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/after-injury/prestations-invalidite/disability-award",
-    eligibilityPaths: ["recU1DU5vDT8h3sOX", "rec6usTRT8JfBWYBC"],
-    needs: ["recpN4AgAGiH3x7KZ", "recGvrfrW7njPwsbk"],
-    oneLineDescriptionEn:
-      "Financial payments to Veterans who have a service-related injury or illness.",
-    oneLineDescriptionFr:
-      "Une indemnité pour les vétérans ayant des problèmes de santé causés ou aggravés par leur service.",
-    "categories DO NOT USE": ["recD0EVQMeQtlrnwC", "recVAt7jHcjJFlCTC"],
-    childBenefits: [
-      "rece4vwRrORpYznkw",
-      "recL63epbxypNYRjL",
-      "rec6osa4YoZNwJcNW",
-      "recEW4yF4GE4V1lTS",
-      "recewrfxHbTWEVPig",
-      "recqpTIM3UcQkeRh0"
-    ],
-    availableIndependently: "Independent",
-    benefitPolicyEn:
-      "http://www.veterans.gc.ca/eng/about-us/policy/category/13",
-    benefitPolicyFR:
-      "http://www.veterans.gc.ca/fra/about-us/policy/category/13",
-    sortingPriority: "high",
-    noteEn: "Will be replaced by Pension for Life on April 1st 2019.",
-    noteFr: "Sera remplacé par Pension à vie le 1er avril 2019.",
-    id: "recSb075Hz2383F75",
-    sortingNumber: 1
-  },
-  {
-    vacNameEn: "Disability Pension",
-    vacNameFr: "Pension d'invalidité",
-    benefitPageEn:
-      "http://www.veterans.gc.ca/eng/services/after-injury/disability-benefits/disability-pension",
-    benefitPageFr:
-      "http://www.veterans.gc.ca/fra/services/after-injury/prestations-invalidite/pension-invalidite",
     eligibilityPaths: [
-      "recHYNXwAm2ncw4Ov",
+      "recU1DU5vDT8h3sOX",
       "rec55z5R3yz8JMv23",
-      "recGN6WlSHpAw3tt6"
+      "recHYNXwAm2ncw4Ov"
     ],
     needs: ["recpN4AgAGiH3x7KZ", "recGvrfrW7njPwsbk"],
     oneLineDescriptionEn:
-      "Financial payments to Veterans who have a service-related injury or illness.",
+      "Compensation for your service-related injury or illness.",
     oneLineDescriptionFr:
-      "Versements mensuels pour les vétérans ayant des problèmes de santé causés ou aggravés par leur service.",
-    "categories DO NOT USE": ["recD0EVQMeQtlrnwC", "recVAt7jHcjJFlCTC"],
+      "Une indemnit\u00e9 pour les v\u00e9t\u00e9rans ayant des probl\u00e8mes de sant\u00e9 caus\u00e9s ou aggrav\u00e9s par leur service.",
     childBenefits: [
       "recCkQL77l0KZ2u7Y",
-      "recEW4yF4GE4V1lTS",
-      "recBSXP6pYDS8xJJH",
-      "recewrfxHbTWEVPig",
       "recNsVtmotVHzDhAB",
-      "rec6osa4YoZNwJcNW"
+      "recqpTIM3UcQkeRh0",
+      "recewrfxHbTWEVPig",
+      "rec6osa4YoZNwJcNW",
+      "rece4vwRrORpYznkw"
     ],
     availableIndependently: "Independent",
-    benefitPolicyEn:
-      "http://www.veterans.gc.ca/eng/about-us/policy/category/14",
-    benefitPolicyFR:
-      "http://www.veterans.gc.ca/fra/about-us/policy/category/14",
     sortingPriority: "high",
-    noteEn:
-      "Available to military members who applied before April 1st 2006. WWII, Korean War Veterans, and RCMP can apply at anytime.",
-    noteFr:
-      " Disponible pour les militaires qui ont postulé avant le 1er avril 2006. Les vétérans de la Seconde Guerre mondiale, de la guerre de Corée et les membres de la GRC peuvent appliquer en tout temps.",
-    id: "recWJsoHvIkparQGd",
-    sortingNumber: 1
+    benefitExamples: [
+      "recFDy0mEU3iwpNts",
+      "recmEHstjDfM5EH46",
+      "reckFzdNEd82iPjH0",
+      "rechRf4ZEGrnR6o3i"
+    ],
+    id: "rec0jzif5VceIWKh3"
   },
   {
     vacNameEn: "Earnings Loss Benefit",
@@ -333,28 +393,51 @@ let benefits = [
       "http://www.veterans.gc.ca/eng/services/transition/rehabilitation/earnings-loss",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/transition/rehabilitation/earnings-loss",
-    eligibilityPaths: [
-      "recGN6WlSHpAw3tt6",
-      "rec6usTRT8JfBWYBC",
-      "rec7iymBcLBwnkd20"
-    ],
+    eligibilityPaths: ["recGN6WlSHpAw3tt6", "rec7iymBcLBwnkd20"],
     needs: ["recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Monthly benefit to ensure your total income will be at least 90% of gross pre-release military salary.",
+      "Monthly payments to maintain your income while you are in the rehabilitation program.",
     oneLineDescriptionFr:
-      "Versements mensuels pour les anciens combattants ayant un problème de santé grave qui affecte leur revenu.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Versements mensuels pour les anciens combattants ayant un probl\u00e8me de sant\u00e9 grave qui affecte leur revenu.",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/15",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/15",
-    id: "recOJ3P1wiacWA5jr",
-    sortingNumber: 3
+    benefitExamples: [
+      "recsQ9vouBKSPS4Fz",
+      "recPlAHuD9j9nOjNp",
+      "recJbj91Bd4Uv4B6O",
+      "recwh6gKg5tqNQfbB",
+      "recrp0YG8k55oG2FP"
+    ],
+    benefitEligibility: [
+      "recPwgIAvnOrF9CZE",
+      "rechaKl1wJhKe0lnF",
+      "recmsrOwzHKCsUNl6"
+    ],
+    id: "recOJ3P1wiacWA5jr"
+  },
+  {
+    vacNameEn: "Earnings Loss Benefit for survivors or children",
+    vacNameFr:
+      "Allocation pour perte de revenus accord\u00e9e aux survivants ou aux orphelins",
+    benefitPageEn:
+      "http://www.veterans.gc.ca/eng/services/information-for/families-and-survivors/earnings-loss",
+    benefitPageFr:
+      "http://www.veterans.gc.ca/fra/services/information-for/families-and-survivors/earnings-loss",
+    eligibilityPaths: ["rec6usTRT8JfBWYBC"],
+    needs: ["recpN4AgAGiH3x7KZ"],
+    oneLineDescriptionEn:
+      "Monthly payments if your spouse or parent's death was a result of their military service.",
+    oneLineDescriptionFr:
+      "(fra)Monthly payments if your spouse or parent's death was a result of their military service.",
+    id: "recXrrmxgZ66BoiK3"
   },
   {
     vacNameEn: "Education and Training Benefit",
-    vacNameFr: "Allocation pour études et formation",
+    vacNameFr: "Allocation pour \u00e9tudes et formation",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/transition/education-training-benefit",
     benefitPageFr:
@@ -362,22 +445,33 @@ let benefits = [
     eligibilityPaths: ["rec8azbXzu0MLVs3y"],
     needs: ["rec1pKJ7uJYwqVOLx", "recFX7O3dYwg44kpM"],
     oneLineDescriptionEn:
-      "A grant to help Veterans achieve their education and career goals after the military.",
+      "A grant to help you achieve your education and career goals after your military career.",
     oneLineDescriptionFr:
-      "Une subvention pour aider les vétérans à atteindre leurs objectifs d'éducation et de carrière.",
-    "categories DO NOT USE": ["recDYAiBEPn2JUtX9", "recVAt7jHcjJFlCTC"],
+      "Une subvention pour aider les v\u00e9t\u00e9rans \u00e0 atteindre leurs objectifs d'\u00e9ducation et de carri\u00e8re.",
+    "categories DO NOT USE": "Education and jobs, Financial assistance",
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/2685",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/2685",
     sortingPriority: "medium",
-    id: "recukRMcsAVvBpDJi",
-    sortingNumber: 2
+    benefitExamples: [
+      "recAipD7lXyrGFtsR",
+      "recACA9yEfIAxuXXh",
+      "recRAfiZXHvN9Vj1f",
+      "recsVlvrGtZvxwNp9",
+      "recnyHLPOezWPNOiG",
+      "recc3xtehT2x8QvoR",
+      "recoZV5O2f7Ghn2ZV",
+      "rec0EC3r8QhCix0N8",
+      "recQYymXSVw8CfLtk"
+    ],
+    benefitEligibility: ["recQBzCRl2D8B7lxu"],
+    id: "recukRMcsAVvBpDJi"
   },
   {
-    vacNameEn: "Education Assistance Program",
-    vacNameFr: "Aide à l'éducation",
+    vacNameEn: "Educational Assistance for children",
+    vacNameFr: "Aide \u00e0 l'\u00e9ducation",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/information-for/families-and-survivors/education-assistance",
     benefitPageFr:
@@ -385,25 +479,22 @@ let benefits = [
     eligibilityPaths: ["rec1dXWxOfzFZ6zKL"],
     needs: ["rec1pKJ7uJYwqVOLx", "recjTEL7xK4196TE7"],
     oneLineDescriptionEn:
-      "Monthly benefit for the children of a deceased CAF Veteran, whose death was service-related, to help with tuition and related post-secondary educations costs.",
+      "Monthly payments and funding for tuition and other post-secondary expenses.",
     oneLineDescriptionFr:
-      "Paiements mensuels pour financer l'éducation des enfants dont le parent est décédé en raison du service militaire.",
-    "categories DO NOT USE": [
-      "recDYAiBEPn2JUtX9",
-      "receAbpIThPLRxDHE",
-      "recVAt7jHcjJFlCTC"
-    ],
+      "Paiements mensuels pour financer l'\u00e9ducation des enfants dont le parent est d\u00e9c\u00e9d\u00e9 en raison du service militaire.",
+    "categories DO NOT USE":
+      "Education and jobs, Family support, Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/1188",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/1188",
-    id: "recg5zjkXaddMWQEf",
-    sortingNumber: 3
+    benefitEligibility: ["recpCQ81MXjUrrerT"],
+    id: "recg5zjkXaddMWQEf"
   },
   {
     vacNameEn: "Exceptional Incapacity Allowance",
-    vacNameFr: "Allocation d'incapacité exceptionnelle",
+    vacNameFr: "Allocation d'incapacit\u00e9 exceptionnelle",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/after-injury/disability-benefits/exceptional-incapacity-allowance",
     benefitPageFr:
@@ -411,21 +502,38 @@ let benefits = [
     eligibilityPaths: ["recj4U5sS1GYwJJjq"],
     needs: ["recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Monthly benefit for disability pensioner whose quality of life was negatively impacted by their illness or injury.",
+      "Monthly payments if your illness or injury impacts your quality of life.",
     oneLineDescriptionFr:
-      "Versement mensuels pour les vétérans ayant un handicap grave qui affecte leur revenu.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Versement mensuels pour les v\u00e9t\u00e9rans ayant un handicap grave qui affecte leur revenu.",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/1931#anchor57066",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/1931#anchor57066",
-    id: "recCkQL77l0KZ2u7Y",
-    sortingNumber: 3
+    benefitEligibility: ["recgi1wg3Z0xhI0KC"],
+    id: "recCkQL77l0KZ2u7Y"
+  },
+  {
+    vacNameEn: "Family Peer Support (OSISS)",
+    vacNameFr: "Soutien par les pairs pour les familles (SSBSO)",
+    benefitPageEn:
+      "https://www.cfmws.com/en/AboutUs/DCSM/OSISS/Pages/Families.aspx",
+    benefitPageFr:
+      "https://www.cfmws.com/en/AboutUs/DCSM/OSISS/Pages/Families.aspx",
+    eligibilityPaths: ["rec1dXWxOfzFZ6zKL"],
+    needs: ["recmmMZPP4DI6Nq0a", "recjTEL7xK4196TE7"],
+    oneLineDescriptionEn:
+      "Peer support for the families of Veterans living with mental health issues.",
+    oneLineDescriptionFr:
+      "(fra)Peer support for the families of Veterans living with mental health issues.",
+    availableIndependently: "Independent",
+    benefitEligibility: ["recdtaTP1HL6hgId7"],
+    id: "recYOyXOqqSSCUVcN"
   },
   {
     vacNameEn: "Funeral and Burial Assistance",
-    vacNameFr: "Programme de frais de funérailles et d'inhumations",
+    vacNameFr: "Programme de frais de fun\u00e9railles et d'inhumations",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/financial/funeral-burial",
     benefitPageFr:
@@ -433,17 +541,38 @@ let benefits = [
     eligibilityPaths: ["rec1dXWxOfzFZ6zKL", "rec4zJqrgvVa7Rf4c"],
     needs: ["recjTEL7xK4196TE7"],
     oneLineDescriptionEn:
-      "Financial support to the estate of an eligible Veteran to help pay for funeral costs.",
+      "A reimbursement of costs to ensure Veterans have a dignified funeral and burial. ",
     oneLineDescriptionFr:
-      "Un remboursement des frais funéraires et d'inhumation liés à la mort d'un vétéran.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC", "receAbpIThPLRxDHE"],
+      "Un remboursement des frais fun\u00e9raires et d'inhumation li\u00e9s \u00e0 la mort d'un v\u00e9t\u00e9ran.",
+    "categories DO NOT USE": "Financial assistance, Family support",
     availableIndependently: "Independent",
-    id: "recEW4yF4GE4V1lTS",
-    sortingNumber: 3
+    benefitExamples: [
+      "recf6c8GEt20V456b",
+      "recJb7mKQwMywgty7",
+      "recp5oJKUFhNoilhw"
+    ],
+    benefitEligibility: ["recIKNddEHsrPobsJ", "recvSEet4Pf5xm2Ng"],
+    id: "recEW4yF4GE4V1lTS"
+  },
+  {
+    vacNameEn: "Grave Marker Maintenance",
+    vacNameFr: "Entretien des st\u00e8les fun\u00e9raires",
+    benefitPageEn:
+      "http://www.veterans.gc.ca/eng/services/financial/grave-marker",
+    benefitPageFr:
+      "http://www.veterans.gc.ca/fra/services/financial/grave-marker",
+    eligibilityPaths: ["rec04iKWngFVunoHt"],
+    needs: ["recjTEL7xK4196TE7"],
+    oneLineDescriptionEn:
+      "Maintenance of all markers and grave sites that were provided by the Government of Canada.",
+    oneLineDescriptionFr:
+      "(fra)Maintenance of all markers and grave sites that were provided by the Government of Canada.",
+    availableIndependently: "Independent",
+    id: "recZv71nHMgCoX93h"
   },
   {
     vacNameEn: "Group Health Insurance",
-    vacNameFr: "Assurance collective des soins de santé",
+    vacNameFr: "Assurance collective des soins de sant\u00e9",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/health/group-health-insurance",
     benefitPageFr:
@@ -453,37 +582,16 @@ let benefits = [
     oneLineDescriptionEn:
       "Health coverage for you and your family through the Public Service Health Care Plan. ",
     oneLineDescriptionFr:
-      "Accès à l’assurance-santé collective au titre du Régime de soins de santé de la fonction publique.",
-    "categories DO NOT USE": ["recD0EVQMeQtlrnwC"],
+      "Acc\u00e8s \u00e0 l\u2019assurance-sant\u00e9 collective au titre du R\u00e9gime de soins de sant\u00e9 de la fonction publique.",
+    "categories DO NOT USE": "Health",
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/21",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/21",
-    id: "rec3l8XwdR85xWNJ2",
-    sortingNumber: 3
-  },
-  {
-    vacNameEn: "Health Care Benefits",
-    vacNameFr: "Avantages pour soins de santé",
-    benefitPageEn:
-      "http://www.veterans.gc.ca/eng/services/health/treatment-benefits",
-    benefitPageFr:
-      "http://www.veterans.gc.ca/fra/services/health/treatment-benefits",
-    eligibilityPaths: ["recQerwEMBUU3TlRO"],
-    needs: ["recGvrfrW7njPwsbk"],
-    oneLineDescriptionEn:
-      "Access to a wide variety of healthcare services using your VAC health card.",
-    oneLineDescriptionFr: "Un remboursement des frais médicaux des vétérans.",
-    "categories DO NOT USE": ["recD0EVQMeQtlrnwC"],
-    availableIndependently: "Requires Gateway Benefit",
-    benefitPolicyEn:
-      "http://www.veterans.gc.ca/eng/about-us/policy/category/29",
-    benefitPolicyFR:
-      "http://www.veterans.gc.ca/fra/about-us/policy/category/29",
-    sortingPriority: "high",
-    id: "recewrfxHbTWEVPig",
-    sortingNumber: 1
+    benefitExamples: ["recyHsIVPMOqmLiBx"],
+    benefitEligibility: ["rec9M3lN0KwS8CJmj"],
+    id: "rec3l8XwdR85xWNJ2"
   },
   {
     vacNameEn: "HOPE Program",
@@ -494,20 +602,55 @@ let benefits = [
       "https://www.connexionfac.ca/Nationale/Programmes-et-Services/Pour-les-familles-endeuillees/Cote-a-cote/Soutien-par-les-pairs/ESPOIR.aspx",
     eligibilityPaths: [
       "rec1dXWxOfzFZ6zKL",
-      "recOsAgDhtvcoR4UD",
-      "rec4zJqrgvVa7Rf4c"
+      "rec4zJqrgvVa7Rf4c",
+      "recXaPbzM7H7UoZn5"
     ],
     needs: ["recjTEL7xK4196TE7"],
     oneLineDescriptionEn:
       "Peer support program for military families who have lost a loved one.",
     oneLineDescriptionFr:
-      "Soutien social aux familles militaires qui sont touchées par la perte d’un être cher.",
-    id: "reczzwPrtckHy81oY",
-    sortingNumber: 3
+      "Soutien social aux familles militaires qui sont touch\u00e9es par la perte d\u2019un \u00eatre cher.",
+    benefitEligibility: [
+      "rechEoLL5pBxeHcGN",
+      "recoztJkT5J9MYX2G",
+      "recRligLod0I0IhcP"
+    ],
+    id: "reczzwPrtckHy81oY"
+  },
+  {
+    vacNameEn: "Jobs in the federal government",
+    vacNameFr: "Priorit\u00e9 d\u2019embauche",
+    benefitPageEn:
+      "http://www.veterans.gc.ca/eng/services/transition/ps-hiring/before-you-start",
+    benefitPageFr:
+      "http://www.veterans.gc.ca/fra/services/transition/ps-hiring/before-you-start",
+    eligibilityPaths: ["recxsl5L3LLGIT9rt"],
+    needs: ["recFX7O3dYwg44kpM"],
+    oneLineDescriptionEn:
+      "You get priority when applying for jobs in the federal government",
+    oneLineDescriptionFr:
+      "Les v\u00e9t\u00e9rans ont la priorit\u00e9 pour les postes vacants dans la fonction publique f\u00e9d\u00e9rale.",
+    "categories DO NOT USE": "Education and jobs",
+    availableIndependently: "Independent",
+    benefitPolicyEn:
+      "http://www.veterans.gc.ca/eng/about-us/policy/category/75",
+    benefitPolicyFR:
+      "http://www.veterans.gc.ca/fra/about-us/policy/category/75",
+    sortingPriority: "medium",
+    benefitExamples: [
+      "recqLHY6bKc0uwQaO",
+      "rec8JKlAqIgxcbB7y",
+      "recRPx5hsvZBlgTEp",
+      "rec4K0C1SXIEvZ2y2",
+      "recHvq4ZWB9gsQVLI",
+      "recReJAmeTOdw6BHL"
+    ],
+    benefitEligibility: ["recAz6FLY6qy3GkHd"],
+    id: "recaa4nxdJnSV3NrJ"
   },
   {
     vacNameEn: "Long Term Care",
-    vacNameFr: "Soins de longue durée",
+    vacNameFr: "Soins de longue dur\u00e9e",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/health/long-term-care",
     benefitPageFr:
@@ -515,33 +658,47 @@ let benefits = [
     eligibilityPaths: ["recxsl5L3LLGIT9rt", "recsOdDx7CWAftWIR"],
     needs: ["recXfW6phH2FFcE3T", "recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Financial assistance to contribute to the cost of long term care for qualifying Veterans. ",
+      "Monthly payments to cover the cost of your long-term care.",
     oneLineDescriptionFr:
-      "Versement mensuels pour les vétérans qui ont besoin de soins de longue durée.",
-    "categories DO NOT USE": ["recD0EVQMeQtlrnwC", "recVAt7jHcjJFlCTC"],
+      "Versement mensuels pour les v\u00e9t\u00e9rans qui ont besoin de soins de longue dur\u00e9e.",
+    "categories DO NOT USE": "Health, Financial assistance",
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/22",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/22",
-    id: "recKZD7EgawQUTf98",
-    sortingNumber: 3
+    sortingPriority: "medium",
+    benefitEligibility: ["recyyVwXzhgcX14IC", "recJDGon9UpIRv1C6"],
+    id: "recKZD7EgawQUTf98"
   },
   {
     vacNameEn: "Operational Stress Injury clinics",
-    vacNameFr: "Cliniques pour traumatismes liés au stress opérationnel ",
+    vacNameFr:
+      "Cliniques pour traumatismes li\u00e9s au stress op\u00e9rationnel ",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/health/mental-health/understanding-mental-health/clinics",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/health/mental-health/understanding-mental-health/clinics",
-    eligibilityPaths: ["recc8tZtc94wRhgxt"],
+    eligibilityPaths: [
+      "recc8tZtc94wRhgxt",
+      "recmKzJ6y5K1TgEiI",
+      "recR03cJel83BGYSD"
+    ],
     needs: ["recmmMZPP4DI6Nq0a"],
     oneLineDescriptionEn:
-      "Outpatient facilities to receive assessment and treatment of an operational stress injury (e.g. PTSD).",
+      "An outpatient facility that treats mental health issues caused by your service (e.g. PTSD).",
     oneLineDescriptionFr:
-      "Traitements pour anxiété, insomnie, colère et autres aspects de santé mentale.",
+      "Traitements pour anxi\u00e9t\u00e9, insomnie, col\u00e8re et autres aspects de sant\u00e9 mentale.",
+    sortingPriority: "medium",
+    benefitExamples: [
+      "recHaX4XKETPQKhHp",
+      "recqOsqicgzAjHlnQ",
+      "reci867uYWvWwd0s0",
+      "rec5NTV684Cme1ir0"
+    ],
+    benefitEligibility: ["recg7V3k3ol4FLAMh", "rece3ZFiriZxO63e4"],
     id: "rechnadMxMHp86vv8",
-    sortingNumber: 3
+    sortingNumber: 2
   },
   {
     vacNameEn: "Pastoral Outreach ",
@@ -557,70 +714,49 @@ let benefits = [
       "recyyiggvT1GyQj45"
     ],
     needs: ["recjTEL7xK4196TE7", "recmmMZPP4DI6Nq0a"],
-    oneLineDescriptionEn: "Spiritual support for Veterans or their families.",
+    oneLineDescriptionEn: "Religious and spiritual support when you need it.",
     oneLineDescriptionFr:
-      "Soutien religieux offert aux vétérans et à leur famille.",
-    "categories DO NOT USE": ["receAbpIThPLRxDHE", "recD0EVQMeQtlrnwC"],
+      "Soutien religieux offert aux v\u00e9t\u00e9rans et \u00e0 leur famille.",
+    "categories DO NOT USE": "Family support, Health",
     availableIndependently: "Independent",
+    benefitEligibility: ["recxq80Dbs1ijRlaE"],
     id: "recVgcA6MDGMBFjzH",
     sortingNumber: 3
   },
   {
-    vacNameEn: "Priority Hiring",
-    vacNameFr: "Priorité d’embauche",
-    benefitPageEn:
-      "http://www.veterans.gc.ca/eng/services/transition/ps-hiring/before-you-start",
-    benefitPageFr:
-      "http://www.veterans.gc.ca/fra/services/transition/ps-hiring/before-you-start",
-    eligibilityPaths: ["recxsl5L3LLGIT9rt"],
-    needs: ["recFX7O3dYwg44kpM"],
-    oneLineDescriptionEn:
-      "Register to receive CAF Veterans' preference, for five years following your release date, when applying for jobs in the federal public service.",
-    oneLineDescriptionFr:
-      "Les vétérans ont la priorité pour les postes vacants dans la fonction publique fédérale.",
-    "categories DO NOT USE": ["recDYAiBEPn2JUtX9"],
-    availableIndependently: "Independent",
-    benefitPolicyEn:
-      "http://www.veterans.gc.ca/eng/about-us/policy/category/75",
-    benefitPolicyFR:
-      "http://www.veterans.gc.ca/fra/about-us/policy/category/75",
-    id: "recaa4nxdJnSV3NrJ",
-    sortingNumber: 3
-  },
-  {
     vacNameEn: "Prisoner of War Compensation",
-    vacNameFr: "Indemnité des prisonnier de guerre",
+    vacNameFr: "Indemnit\u00e9 des prisonnier de guerre",
     benefitPageEn: "http://www.veterans.gc.ca/eng/services/financial/pow",
     benefitPageFr: "http://www.veterans.gc.ca/fra/services/financial/pow",
-    eligibilityPaths: [
-      "recsOdDx7CWAftWIR",
-      "rec1dXWxOfzFZ6zKL",
-      "rec4zJqrgvVa7Rf4c",
-      "rec8azbXzu0MLVs3y"
-    ],
+    eligibilityPaths: ["recsOdDx7CWAftWIR", "recTg173gsbgdSMmx"],
     needs: ["recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Monthly compensation for Second World War or Korean War Veterans who were prisoners of war. ",
+      "Monthly compensation if you were taken prisoner or detained by enemy forces.",
     oneLineDescriptionFr:
-      "Prestation ponctuelle versée aux militaires qui ont été détenus, se sont échappés ou ont évité la capture.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC", "receAbpIThPLRxDHE"],
+      "Prestation ponctuelle vers\u00e9e aux militaires qui ont \u00e9t\u00e9 d\u00e9tenus, se sont \u00e9chapp\u00e9s ou ont \u00e9vit\u00e9 la capture.",
+    "categories DO NOT USE": "Financial assistance, Family support",
     childBenefits: ["recNsVtmotVHzDhAB"],
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/25",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/25",
-    id: "reccTUqI8ybL1aHQR",
-    sortingNumber: 3
+    sortingPriority: "low",
+    benefitEligibility: ["rec0AZCo8gx3HzLy1", "recaVVZzKjrd2Duj8"],
+    id: "reccTUqI8ybL1aHQR"
   },
   {
     vacNameEn: "Rehabilitation Services",
-    vacNameFr: "Services de réadaptation",
+    vacNameFr: "Services de r\u00e9adaptation",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/transition/rehabilitation/services",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/transition/rehabilitation/services",
-    eligibilityPaths: ["recU1DU5vDT8h3sOX", "recGN6WlSHpAw3tt6"],
+    eligibilityPaths: [
+      "recU1DU5vDT8h3sOX",
+      "recGN6WlSHpAw3tt6",
+      "rec6usTRT8JfBWYBC"
+    ],
     needs: [
       "rec1pKJ7uJYwqVOLx",
       "recFX7O3dYwg44kpM",
@@ -628,10 +764,10 @@ let benefits = [
       "recmmMZPP4DI6Nq0a"
     ],
     oneLineDescriptionEn:
-      "Services to help you improve your health to the fullest extent possible and adjust to life at home, in your community or at work.",
+      "Services to help Veterans restore their health and build a new life after the military.",
     oneLineDescriptionFr:
-      "Services pour aider les vétérans à retrouver leur santé et à se bâtir une nouvelle vie après l'armée.",
-    "categories DO NOT USE": ["recDYAiBEPn2JUtX9", "recD0EVQMeQtlrnwC"],
+      "Services pour aider les v\u00e9t\u00e9rans \u00e0 retrouver leur sant\u00e9 et \u00e0 se b\u00e2tir une nouvelle vie apr\u00e8s l'arm\u00e9e.",
+    "categories DO NOT USE": "Education and jobs, Health",
     childBenefits: [
       "rece4vwRrORpYznkw",
       "recOJ3P1wiacWA5jr",
@@ -643,14 +779,22 @@ let benefits = [
       "http://www.veterans.gc.ca/eng/about-us/policy/category/26",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/26",
-    examples: ["recCkWkJIklpp5ADr", "reculYbazzbP3dxpA", "reccED7sXf2ViIt47"],
+    examples: "recCkWkJIklpp5ADr, reculYbazzbP3dxpA, reccED7sXf2ViIt47",
     sortingPriority: "high",
-    id: "recPUSdA7VeaZGUGh",
-    sortingNumber: 1
+    benefitExamples: [
+      "rec2ilLgjyvzhCg4j",
+      "recEL3EeIDWcMGQY1",
+      "rectyrbPJgyQcopAf",
+      "recOb43U6nq2XfTPY",
+      "recoHO14c52zMfji6",
+      "recRXSmuoya3orbZe"
+    ],
+    benefitEligibility: ["recBr3SAQU0GijleA", "recGkh4BgTTH4ibVq"],
+    id: "recPUSdA7VeaZGUGh"
   },
   {
     vacNameEn: "Retirement Income Security Benefit",
-    vacNameFr: "Allocation de sécurité du revenu retraite",
+    vacNameFr: "Allocation de s\u00e9curit\u00e9 du revenu retraite",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/financial/retirement-income-security-benefit",
     benefitPageFr:
@@ -658,21 +802,28 @@ let benefits = [
     eligibilityPaths: ["rec8azbXzu0MLVs3y", "rec1dXWxOfzFZ6zKL"],
     needs: ["recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Monthly benefit, beginning at age 65, to those who were in receipt of Earnings Loss and have a disability benefit.",
+      "Monthly payments that replace the Earnings Loss Benefit at retirement (age 65).",
     oneLineDescriptionFr:
-      "Versement mensuels qui remplacent l'Allocation pour perte de revenus pour les vétérans ayant plus de 65 ans. ",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Versement mensuels qui remplacent l'Allocation pour perte de revenus pour les v\u00e9t\u00e9rans ayant plus de 65 ans. ",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/73",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/73",
-    id: "recjDkgdzzzNS6i5A",
-    sortingNumber: 3
+    sortingPriority: "medium",
+    benefitExamples: [
+      "rec0jMSCYhROh5cxJ",
+      "recb7Ryq93KZRo36n",
+      "recXuxCWe427EvwHV",
+      "recQq9zXwiErrpP65"
+    ],
+    benefitEligibility: ["recDSeANhF5XrVRcr", "recxc6T4F7Ft3bF0t"],
+    id: "recjDkgdzzzNS6i5A"
   },
   {
     vacNameEn: "Supplementary Retirement Benefit",
-    vacNameFr: "Prestation de retraite supplémentaire",
+    vacNameFr: "Prestation de retraite suppl\u00e9mentaire",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/transition/rehabilitation/retirement-benefit",
     benefitPageFr:
@@ -680,17 +831,23 @@ let benefits = [
     eligibilityPaths: ["rec6usTRT8JfBWYBC", "rec8azbXzu0MLVs3y"],
     needs: ["recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Lump-sum payment, at age 65, to those in receipt of Earnings Loss Benefit on a long term basis.",
+      "One-time payment if you're receiving Earnings Loss Benefit at age 65 on a long-term basis.",
     oneLineDescriptionFr:
-      "Prestation ponctuelle versée aux vétérans ou familles qui ont reçu l’Allocation pour perte de revenus.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Prestation ponctuelle vers\u00e9e aux v\u00e9t\u00e9rans ou familles qui ont re\u00e7u l\u2019Allocation pour perte de revenus.",
+    "categories DO NOT USE": "Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/27",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/27",
-    id: "recTJGH8uGpz9FIcl",
-    sortingNumber: 3
+    sortingPriority: "medium",
+    benefitExamples: [
+      "recqlQq0KOrNFBnmh",
+      "recdLbqTMFcl4xbQG",
+      "recZKXMI9POi90Smo"
+    ],
+    benefitEligibility: ["recmRtb7mI9XaukBw", "recgsVRR5F96KoQvT"],
+    id: "recTJGH8uGpz9FIcl"
   },
   {
     vacNameEn: "Survivor's Pension",
@@ -702,59 +859,117 @@ let benefits = [
     eligibilityPaths: [
       "recXaPbzM7H7UoZn5",
       "rec4zJqrgvVa7Rf4c",
-      "reckiJxHt31Ql0vAw"
+      "rec1dXWxOfzFZ6zKL"
     ],
     needs: ["recjTEL7xK4196TE7", "recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Monthly benefit for the survivor of a disability pensioner.",
+      "Monthly income support to the survivor of a disability pensioner.",
     oneLineDescriptionFr:
-      "Versement mensuels pour les conjoints des vétérans décédés, qui recevaient la Pension d'invalidité.",
-    "categories DO NOT USE": ["receAbpIThPLRxDHE", "recVAt7jHcjJFlCTC"],
+      "Versement mensuels pour les conjoints des v\u00e9t\u00e9rans d\u00e9c\u00e9d\u00e9s, qui recevaient la Pension d'invalidit\u00e9.",
+    "categories DO NOT USE": "Family support, Financial assistance",
     availableIndependently: "Requires Gateway Benefit",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/1131",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/1131",
-    id: "recBSXP6pYDS8xJJH",
-    sortingNumber: 3
+    benefitEligibility: ["recGSaT5q7VLKIDtA"],
+    id: "recBSXP6pYDS8xJJH"
+  },
+  {
+    vacNameEn: "Transition Interview",
+    vacNameFr: "Entrevue de transition",
+    benefitPageEn:
+      "http://www.veterans.gc.ca/eng/services/transition/interview",
+    benefitPageFr:
+      "http://www.veterans.gc.ca/fra/services/transition/interview",
+    eligibilityPaths: ["recvv3CfQZ7HTWxdA"],
+    needs: ["recmmMZPP4DI6Nq0a"],
+    oneLineDescriptionEn:
+      "Meet with a Veterans Affairs employee before you release from the military to see what we can do for you.",
+    oneLineDescriptionFr:
+      "(fra)Meet with a Veterans Affairs employee before you release from the military to see what we can do for you.",
+    availableIndependently: "Independent",
+    sortingPriority: "high",
+    id: "recoqXJ7Tx3XaDdFE"
+  },
+  {
+    vacNameEn: "Treatment Benefits",
+    vacNameFr: "Avantages pour soins de sant\u00e9",
+    benefitPageEn:
+      "http://www.veterans.gc.ca/eng/services/health/treatment-benefits",
+    benefitPageFr:
+      "http://www.veterans.gc.ca/fra/services/health/treatment-benefits",
+    eligibilityPaths: ["recQerwEMBUU3TlRO"],
+    needs: ["recGvrfrW7njPwsbk", "recmmMZPP4DI6Nq0a"],
+    oneLineDescriptionEn: "Coverage for medical and healthcare services.",
+    oneLineDescriptionFr:
+      "Un remboursement des frais m\u00e9dicaux des v\u00e9t\u00e9rans.",
+    "categories DO NOT USE": "Health",
+    availableIndependently: "Requires Gateway Benefit",
+    benefitPolicyEn:
+      "http://www.veterans.gc.ca/eng/about-us/policy/category/29",
+    benefitPolicyFR:
+      "http://www.veterans.gc.ca/fra/about-us/policy/category/29",
+    sortingPriority: "high",
+    benefitExamples: [
+      "recSx73zdrq3qA9TE",
+      "rectK00K9ynNhArvX",
+      "rec3Yk0ryqvzGfx6I",
+      "recb6704tARekC7qo",
+      "recN5ujktoeWAG7vI",
+      "rec2OjnY0unewonmE",
+      "reczfqhXhc0KsOFnE",
+      "recL6FCCN8ck7mgHD",
+      "rec3twOHhN9Nzhe3R",
+      "recgL1nwcpWlnI0Bn",
+      "recaL225QdlxwhudM",
+      "reckmNpzzaTJbZIHj"
+    ],
+    benefitEligibility: ["recEfRVYLpvWvqISx"],
+    id: "recewrfxHbTWEVPig"
   },
   {
     vacNameEn: "VAC Assistance Service",
-    vacNameFr: "Service d’aide d’ACC",
+    vacNameFr: "Service d\u2019aide d\u2019ACC",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/contact/vac-assistance-service",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/contact/vac-assistance-service",
-    eligibilityPaths: ["recc8tZtc94wRhgxt"],
-    needs: ["recmmMZPP4DI6Nq0a", "recjTEL7xK4196TE7"],
+    eligibilityPaths: ["recrvk509oay9Vqd2", "recmKzJ6y5K1TgEiI"],
+    needs: ["recmmMZPP4DI6Nq0a", "recjTEL7xK4196TE7", "recGvrfrW7njPwsbk"],
     oneLineDescriptionEn:
-      "Mental health support available 24 hours a day, 365 days a year by calling 1-800-268-7708.",
+      "Get support right now from a mental health professional by calling 1-800-268-7708.",
     oneLineDescriptionFr:
-      "Ligne de soutien psychologique.  Accessible gratuitement 24 heures par jour, 365 jours par année.",
-    id: "recpq5tKJOXWZ3JCS",
-    sortingNumber: 3
+      "Ligne de soutien psychologique.  Accessible gratuitement 24 heures par jour, 365 jours par ann\u00e9e.",
+    benefitExamples: [
+      "recnuBwbg7KwPxSTX",
+      "recz55tP4BW2G2MEV",
+      "rechN330EynEXgpLT"
+    ],
+    benefitEligibility: ["recs1qwbmkLwDiA7Z", "receBHaEdQ29Qid3n"],
+    id: "recpq5tKJOXWZ3JCS"
   },
   {
     vacNameEn: "Veteran and Family Well-Being Fund",
-    vacNameFr: "Le Fonds pour le bien-être des vétérans et de leur famille",
+    vacNameFr:
+      "Le Fonds pour le bien-\u00eatre des v\u00e9t\u00e9rans et de leur famille",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/information-for/families-and-survivors/well-being-fund",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/information-for/families-and-survivors/well-being-fund",
-    eligibilityPaths: ["recc8tZtc94wRhgxt", "rec04iKWngFVunoHt"],
+    eligibilityPaths: ["rec04iKWngFVunoHt"],
     oneLineDescriptionEn:
-      "Funding to organizations for research or initiatives that improve the well-being of Veterans or their families.",
+      "A fund for research or initiatives that improve the well-being of Veterans and their families.",
     oneLineDescriptionFr:
-      "Une subvention pour les projets qui amélioreront le bien-être des vétérans ou de leurs familles.",
-    "categories DO NOT USE": ["recmhbCvQAByME8g9"],
+      "Une subvention pour les projets qui am\u00e9lioreront le bien-\u00eatre des v\u00e9t\u00e9rans ou de leurs familles.",
+    "categories DO NOT USE": "Community funding",
     availableIndependently: "Independent",
     sortingPriority: "low",
-    id: "rec8GCHaN2UirvW8H",
-    sortingNumber: 3
+    id: "rec8GCHaN2UirvW8H"
   },
   {
     vacNameEn: "Veteran Family Program",
-    vacNameFr: "Programme pour les familles des vétérans",
+    vacNameFr: "Programme pour les familles des v\u00e9t\u00e9rans",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/information-for/families-and-survivors/veteran-family-program",
     benefitPageFr:
@@ -762,71 +977,84 @@ let benefits = [
     eligibilityPaths: ["recU1DU5vDT8h3sOX", "recBlSOo6diB5tkwc"],
     needs: ["recmmMZPP4DI6Nq0a"],
     oneLineDescriptionEn:
-      "Continued access to Military Family Resource Centres for medically-releasing CAF members and their families.",
+      "Continued access to services and support from Military Family Resource Centres for medically-released Veterans and families.",
     oneLineDescriptionFr:
-      "Conseillers et soutien disponible aux vétérans libérés pour des raisons médicales et leurs familles.",
-    "categories DO NOT USE": ["recD0EVQMeQtlrnwC", "receAbpIThPLRxDHE"],
+      "Conseillers et soutien disponible aux v\u00e9t\u00e9rans lib\u00e9r\u00e9s pour des raisons m\u00e9dicales et leurs familles.",
+    "categories DO NOT USE": "Health, Family support",
     availableIndependently: "Independent",
     sortingPriority: "medium",
+    benefitEligibility: ["recdzam05SfCt5PqJ", "recefz1kpLFu7Vkxh"],
     id: "recnTqWEj6jCEF8h7",
     sortingNumber: 2
   },
   {
     vacNameEn: "Veterans Emergency Fund",
-    vacNameFr: "Fonds d'urgence pour les vétérans",
+    vacNameFr: "Fonds d'urgence pour les v\u00e9t\u00e9rans",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/financial/veterans-emergency-fund",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/financial/veterans-emergency-fund",
     eligibilityPaths: [
       "recyyiggvT1GyQj45",
-      "recm2WbUjqAQPxbmB",
-      "reckiJxHt31Ql0vAw",
-      "recrvk509oay9Vqd2"
+      "rec8azbXzu0MLVs3y",
+      "rec1dXWxOfzFZ6zKL",
+      "recJxCbyWEnhFHJvj"
     ],
     needs: ["recEahND3kwnUPTHx", "recpN4AgAGiH3x7KZ"],
     oneLineDescriptionEn:
-      "Emergency financial support available to CAF Veterans, their families or their survivors.",
+      "Quick access to funds for urgent needs such as food, shelter or medical expenses.",
     oneLineDescriptionFr:
-      "Accès rapide à une allocation pour des besoins urgents tels que la nourriture, le logement ou les frais médicaux.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC", "receAbpIThPLRxDHE"],
+      "Acc\u00e8s rapide \u00e0 une allocation pour des besoins urgents tels que la nourriture, le logement ou les frais m\u00e9dicaux.",
+    "categories DO NOT USE": "Financial assistance, Family support",
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/document/2690",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/document/2690",
     sortingPriority: "high",
+    benefitEligibility: ["rec6vIdu4K8xl1nxi", "recwtgBef5LIpUifM"],
     id: "recFMnhGVbQT8de27",
     sortingNumber: 1
   },
   {
     vacNameEn: "Veterans Independence Program",
-    vacNameFr: "Programme pour l’autonomie des anciens combattants",
+    vacNameFr: "Programme pour l\u2019autonomie des anciens combattants",
     benefitPageEn:
       "http://www.veterans.gc.ca/eng/services/health/veterans-independence-program",
     benefitPageFr:
       "http://www.veterans.gc.ca/fra/services/health/veterans-independence-program",
-    eligibilityPaths: [
-      "recsOdDx7CWAftWIR",
-      "rec1dXWxOfzFZ6zKL",
-      "rec4zJqrgvVa7Rf4c",
-      "rec8azbXzu0MLVs3y"
-    ],
+    eligibilityPaths: ["recsOdDx7CWAftWIR", "rec8azbXzu0MLVs3y"],
     needs: ["recXfW6phH2FFcE3T", "recmmMZPP4DI6Nq0a"],
     oneLineDescriptionEn:
-      "Financial assistance to obtain services that help you remain independent in your home and your community.",
+      "Payments for home and health care services that you need to remain independent at home. ",
     oneLineDescriptionFr:
-      "Une subvention pour aider les vétérans âgés et leur famille avec la vie quotidienne à la maison.",
-    "categories DO NOT USE": ["recD0EVQMeQtlrnwC", "recVAt7jHcjJFlCTC"],
+      "Une subvention pour aider les v\u00e9t\u00e9rans \u00e2g\u00e9s et leur famille avec la vie quotidienne \u00e0 la maison.",
+    "categories DO NOT USE": "Health, Financial assistance",
     childBenefits: ["recKZD7EgawQUTf98"],
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/30",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/30",
-    sortingPriority: "high",
-    id: "recqpTIM3UcQkeRh0",
-    sortingNumber: 1
+    sortingPriority: "medium",
+    benefitExamples: [
+      "recXqo0FON7xdMoGp",
+      "recNVQuFqKLEZAXqw",
+      "rec1B02lGuz2OUNhd",
+      "recIu6SaDlpj2umfO",
+      "recAovIDQYHjM6iEq",
+      "recFBbpiH7fNdNGcm",
+      "recCT60JoRN4Wjwcr",
+      "recO7otShjA34voCB",
+      "recda00Z69P91ZS2J",
+      "recYXxdED4LRoWVpP",
+      "recTqZ7TSZ3ZkX15x",
+      "rec1Citq1HUCOR6Yk",
+      "recrizW089wnsS0Ut",
+      "recjkAt3LrkWidOhe"
+    ],
+    benefitEligibility: ["recnz9qP2cSNgBzE8", "rechrkjJpnl8ZEamI"],
+    id: "recqpTIM3UcQkeRh0"
   },
   {
     vacNameEn: "Vocational Assistance",
@@ -841,14 +1069,45 @@ let benefits = [
       "recJxCbyWEnhFHJvj"
     ],
     needs: ["rec1pKJ7uJYwqVOLx", "recFX7O3dYwg44kpM", "recjTEL7xK4196TE7"],
-    oneLineDescriptionEn:
-      "Support to help a survivor or spouse of an injured CAF Veteran get skills and education to start a career.",
+    oneLineDescriptionEn: "Education or training to help launch your career.",
     oneLineDescriptionFr:
-      "Un programme pour aider les conjoints de vétérans malades ou décédés à poursuivre des études ou à trouver un nouvel emploi.",
-    "categories DO NOT USE": ["recDYAiBEPn2JUtX9", "receAbpIThPLRxDHE"],
+      "Un programme pour aider les conjoints de v\u00e9t\u00e9rans malades ou d\u00e9c\u00e9d\u00e9s \u00e0 poursuivre des \u00e9tudes ou \u00e0 trouver un nouvel emploi.",
+    "categories DO NOT USE": "Education and jobs, Family support",
     availableIndependently: "Requires Gateway Benefit",
+    benefitExamples: [
+      "recBGbxw8UfXwyMvg",
+      "reclQ96AyDzo02Xcf",
+      "recQBVX7fadbwlGFm",
+      "rec8BPLJ05SiqJiha",
+      "recAkxRRshSNT1HBP",
+      "recibWB2A7hftKiGE",
+      "rec8IccP8xx2XkQC6"
+    ],
+    benefitEligibility: ["recQKuvUeQib6xDlk"],
     id: "recO8NVH2tWIjNpDA",
     sortingNumber: 3
+  },
+  {
+    vacNameEn: "Vocational Rehabilitation",
+    vacNameFr: "R\u00e9adaptation professionnelle",
+    benefitPageEn: "http://www.cvvrs.com/",
+    benefitPageFr: "http://www.cvvrs.com/",
+    eligibilityPaths: ["recGN6WlSHpAw3tt6"],
+    needs: ["recFX7O3dYwg44kpM", "rec1pKJ7uJYwqVOLx"],
+    oneLineDescriptionEn:
+      "Coaching, support and any other training you need to return to work or find a new job after an injury.",
+    oneLineDescriptionFr:
+      "(fra)Coaching, support and any other training you need to return to work or find a new job after an injury.",
+    availableIndependently: "Requires Gateway Benefit",
+    sortingPriority: "medium",
+    benefitExamples: [
+      "rec8BPLJ05SiqJiha",
+      "reclQ96AyDzo02Xcf",
+      "recYXSi4ixhJ54Yat",
+      "recuMqBFQf4jfvus7",
+      "receSNHPSpksOUznT"
+    ],
+    id: "recR3CLbZSRlbGQJV"
   },
   {
     vacNameEn: "War Veterans Allowance",
@@ -860,17 +1119,30 @@ let benefits = [
     eligibilityPaths: ["recsOdDx7CWAftWIR", "rec4zJqrgvVa7Rf4c"],
     needs: ["recpN4AgAGiH3x7KZ", "recXfW6phH2FFcE3T"],
     oneLineDescriptionEn:
-      "Monthly benefit to help low-income Veterans or their survivors meet their basic needs.",
+      "Monthly payments if you have a low household income.",
     oneLineDescriptionFr:
-      "Versements mensuels pour les vétérans et familles ayant un faible revenu.",
-    "categories DO NOT USE": ["recVAt7jHcjJFlCTC"],
+      "Versements mensuels pour les v\u00e9t\u00e9rans et familles ayant un faible revenu.",
+    "categories DO NOT USE": "Financial assistance",
+    childBenefits: [
+      "recqpTIM3UcQkeRh0",
+      "recKZD7EgawQUTf98",
+      "recEW4yF4GE4V1lTS",
+      "rec7vYqDWYPQnDcRK"
+    ],
     availableIndependently: "Independent",
     benefitPolicyEn:
       "http://www.veterans.gc.ca/eng/about-us/policy/category/31",
     benefitPolicyFR:
       "http://www.veterans.gc.ca/fra/about-us/policy/category/31",
-    id: "recDRPu2NF4UIximU",
-    sortingNumber: 3
+    sortingPriority: "high",
+    benefitExamples: [
+      "reciSsalX6LLPOxSj",
+      "reckhYxwXu57HTlNB",
+      "recHEQf2NMMwiHtjk",
+      "recJclfjOkUJhJx7e"
+    ],
+    benefitEligibility: ["recxiPnxu1B8Xq1HX", "recqM9VdRHwdy35Xf"],
+    id: "recDRPu2NF4UIximU"
   }
 ];
 

--- a/__tests__/fixtures/eligibility_paths_complex.js
+++ b/__tests__/fixtures/eligibility_paths_complex.js
@@ -1,5 +1,12 @@
 const eligibilityPaths = [
   {
+    benefits: ["recVgcA6MDGMBFjzH"],
+    requirements: ["recuWkVDSEWc1K0eU", "rec6sKyG0dMJ7HLhY"],
+    "key DO NOT EDIT": "family, CAF",
+    id: "recEkGEXb6BiUT4Ke",
+    admin_display: "patronType = family, serviceType = CAF"
+  },
+  {
     benefits: [
       "rec45xfsf1ijZzXqM",
       "recKZD7EgawQUTf98",
@@ -11,7 +18,6 @@ const eligibilityPaths = [
       "recC9OodJNCqbnGy2",
       "rec6sKyG0dMJ7HLhY"
     ],
-    nextSteps: ["recp2EOCHfUhGU2jq"],
     "key DO NOT EDIT": "veteran, servingMember, CAF",
     id: "recxsl5L3LLGIT9rt",
     admin_display:
@@ -19,32 +25,10 @@ const eligibilityPaths = [
   },
   {
     benefits: [
-      "recSb075Hz2383F75",
-      "recnTqWEj6jCEF8h7",
-      "receQA3URlp00lwE9",
-      "rec3l8XwdR85xWNJ2",
-      "recH5vAKgnu56IwlS",
-      "rece4vwRrORpYznkw",
-      "recPUSdA7VeaZGUGh"
-    ],
-    requirements: [
-      "recu6xP62BL9yFbWN",
-      "recC9OodJNCqbnGy2",
-      "rec6sKyG0dMJ7HLhY",
-      "recxVaqj0O8BPKyeD"
-    ],
-    "key DO NOT EDIT": "veteran, servingMember, CAF, hasServiceHealthIssue",
-    id: "recU1DU5vDT8h3sOX",
-    admin_display:
-      "patronType = veteran, patronType = servingMember, serviceType = CAF, serviceHealthIssue = hasServiceHealthIssue"
-  },
-  {
-    benefits: [
       "recMguNzAXgdpEDOJ",
       "recjDkgdzzzNS6i5A",
       "recukRMcsAVvBpDJi",
       "recVgcA6MDGMBFjzH",
-      "reccTUqI8ybL1aHQR",
       "recTJGH8uGpz9FIcl",
       "recqpTIM3UcQkeRh0",
       "recL63epbxypNYRjL",
@@ -56,76 +40,15 @@ const eligibilityPaths = [
     admin_display: "patronType = veteran, serviceType = CAF"
   },
   {
-    benefits: ["recOJ3P1wiacWA5jr", "recWJsoHvIkparQGd", "recPUSdA7VeaZGUGh"],
-    requirements: [
-      "recu6xP62BL9yFbWN",
-      "rec6sKyG0dMJ7HLhY",
-      "recxVaqj0O8BPKyeD"
-    ],
-    "key DO NOT EDIT": "veteran, CAF, hasServiceHealthIssue",
-    id: "recGN6WlSHpAw3tt6",
-    admin_display:
-      "patronType = veteran, serviceType = CAF, serviceHealthIssue = hasServiceHealthIssue"
-  },
-  {
-    benefits: ["rec6osa4YoZNwJcNW", "recNsVtmotVHzDhAB", "recewrfxHbTWEVPig"],
-    requirements: ["recu6xP62BL9yFbWN", "recxVaqj0O8BPKyeD"],
-    "key DO NOT EDIT": "veteran, hasServiceHealthIssue",
-    id: "recQerwEMBUU3TlRO",
-    admin_display:
-      "patronType = veteran, serviceHealthIssue = hasServiceHealthIssue"
-  },
-  {
-    benefits: ["recWJsoHvIkparQGd"],
-    requirements: [
-      "recu6xP62BL9yFbWN",
-      "recC9OodJNCqbnGy2",
-      "recIMgfjrCozH9eVW",
-      "recxVaqj0O8BPKyeD"
-    ],
-    "key DO NOT EDIT": "veteran, servingMember, RCMP, hasServiceHealthIssue",
-    id: "recHYNXwAm2ncw4Ov",
-    admin_display:
-      "patronType = veteran, patronType = servingMember, serviceType = RCMP, serviceHealthIssue = hasServiceHealthIssue"
-  },
-  {
-    benefits: [
-      "recKZD7EgawQUTf98",
-      "recqpTIM3UcQkeRh0",
-      "recVgcA6MDGMBFjzH",
-      "reccTUqI8ybL1aHQR",
-      "recDRPu2NF4UIximU"
-    ],
-    requirements: ["recu6xP62BL9yFbWN", "rec3hFX4SlnBMPl7W"],
-    "key DO NOT EDIT": "veteran, WSV (WWII or Korea)",
-    id: "recsOdDx7CWAftWIR",
-    admin_display: "patronType = veteran, serviceType = WSV (WWII or Korea)"
-  },
-  {
-    benefits: ["recWJsoHvIkparQGd"],
-    requirements: [
-      "recu6xP62BL9yFbWN",
-      "rec3hFX4SlnBMPl7W",
-      "recxVaqj0O8BPKyeD"
-    ],
-    "key DO NOT EDIT": "veteran, WSV (WWII or Korea), hasServiceHealthIssue",
-    id: "rec55z5R3yz8JMv23",
-    admin_display:
-      "patronType = veteran, serviceType = WSV (WWII or Korea), serviceHealthIssue = hasServiceHealthIssue"
-  },
-  {
     benefits: [
       "recg5zjkXaddMWQEf",
       "recEW4yF4GE4V1lTS",
       "recjDkgdzzzNS6i5A",
-      "recqpTIM3UcQkeRh0",
       "recO8NVH2tWIjNpDA",
-      "reccTUqI8ybL1aHQR",
-      "recDU2iSRQ300ixBt",
-      "recMM2R9Dh1WUKxx6",
       "reczzwPrtckHy81oY",
       "recBSXP6pYDS8xJJH",
-      "recFMnhGVbQT8de27"
+      "recFMnhGVbQT8de27",
+      "recYOyXOqqSSCUVcN"
     ],
     requirements: [
       "recuWkVDSEWc1K0eU",
@@ -136,67 +59,6 @@ const eligibilityPaths = [
     id: "rec1dXWxOfzFZ6zKL",
     admin_display:
       "patronType = family, serviceType = CAF, statusAndVitals = deceased"
-  },
-  {
-    benefits: [
-      "recSb075Hz2383F75",
-      "recMguNzAXgdpEDOJ",
-      "recOJ3P1wiacWA5jr",
-      "recTJGH8uGpz9FIcl"
-    ],
-    requirements: [
-      "recuWkVDSEWc1K0eU",
-      "rec6sKyG0dMJ7HLhY",
-      "recDW9csGX2ekiwXb",
-      "recxVaqj0O8BPKyeD"
-    ],
-    "key DO NOT EDIT": "family, CAF, deceased, hasServiceHealthIssue",
-    id: "rec6usTRT8JfBWYBC",
-    admin_display:
-      "patronType = family, serviceType = CAF, statusAndVitals = deceased, serviceHealthIssue = hasServiceHealthIssue"
-  },
-  {
-    benefits: ["recVgcA6MDGMBFjzH"],
-    requirements: ["recuWkVDSEWc1K0eU", "rec6sKyG0dMJ7HLhY"],
-    "key DO NOT EDIT": "family, CAF",
-    id: "recEkGEXb6BiUT4Ke",
-    admin_display: "patronType = family, serviceType = CAF"
-  },
-  {
-    benefits: ["recnTqWEj6jCEF8h7"],
-    requirements: [
-      "recuWkVDSEWc1K0eU",
-      "rec6sKyG0dMJ7HLhY",
-      "recxVaqj0O8BPKyeD"
-    ],
-    "key DO NOT EDIT": "family, CAF, hasServiceHealthIssue",
-    id: "recBlSOo6diB5tkwc",
-    admin_display:
-      "patronType = family, serviceType = CAF, serviceHealthIssue = hasServiceHealthIssue"
-  },
-  {
-    benefits: ["recL63epbxypNYRjL", "recO8NVH2tWIjNpDA", "recFMnhGVbQT8de27"],
-    requirements: [
-      "recuWkVDSEWc1K0eU",
-      "rec6sKyG0dMJ7HLhY",
-      "rec3vCJImDFrRIaFl"
-    ],
-    "key DO NOT EDIT": "family, CAF, releasedAlive",
-    id: "recJxCbyWEnhFHJvj",
-    admin_display:
-      "patronType = family, serviceType = CAF, statusAndVitals = releasedAlive"
-  },
-  {
-    benefits: ["recO8NVH2tWIjNpDA"],
-    requirements: [
-      "recuWkVDSEWc1K0eU",
-      "rec6sKyG0dMJ7HLhY",
-      "recM3T55J3Xf1qP16"
-    ],
-    "key DO NOT EDIT": "family, CAF, stillServing",
-    id: "recdSQlq9CZ7DFnqH",
-    admin_display:
-      "patronType = family, serviceType = CAF, statusAndVitals = stillServing"
   },
   {
     benefits: ["recBSXP6pYDS8xJJH", "reczzwPrtckHy81oY"],
@@ -213,10 +75,7 @@ const eligibilityPaths = [
   {
     benefits: [
       "recEW4yF4GE4V1lTS",
-      "recqpTIM3UcQkeRh0",
       "recBSXP6pYDS8xJJH",
-      "reccTUqI8ybL1aHQR",
-      "recMM2R9Dh1WUKxx6",
       "reczzwPrtckHy81oY",
       "recDRPu2NF4UIximU"
     ],
@@ -231,32 +90,17 @@ const eligibilityPaths = [
       "patronType = family, serviceType = WSV (WWII or Korea), statusAndVitals = deceased"
   },
   {
-    benefits: ["recVgcA6MDGMBFjzH", "recFMnhGVbQT8de27"],
-    requirements: ["recuWkVDSEWc1K0eU", "rec3hFX4SlnBMPl7W"],
-    "key DO NOT EDIT": "family, WSV (WWII or Korea)",
-    id: "recyyiggvT1GyQj45",
-    admin_display: "patronType = family, serviceType = WSV (WWII or Korea)"
-  },
-  {
-    benefits: ["rechnadMxMHp86vv8"],
-    nextSteps: ["recdLLujXxdXQEzXC", "recEPLn1bUc5ejFVP"],
-    "key DO NOT EDIT": "no eligibility requirements",
-    id: "recc8tZtc94wRhgxt"
-  },
-  {
-    benefits: ["recmFhBkztEyJtm5R", "recowlPz6lmqcbp7F", "rec8GCHaN2UirvW8H"],
-    requirements: ["rec2pB1RcV3BvyjPX"],
-    nextSteps: ["recKyNwxKXQQGcokF"],
-    "key DO NOT EDIT": "organization",
-    id: "rec04iKWngFVunoHt",
-    admin_display: "patronType = organization"
-  },
-  {
-    benefits: ["recpq5tKJOXWZ3JCS"],
-    requirements: ["recu6xP62BL9yFbWN"],
-    "key DO NOT EDIT": "veteran",
-    id: "recrvk509oay9Vqd2",
-    admin_display: "patronType = veteran"
+    benefits: ["recnTqWEj6jCEF8h7"],
+    requirements: [
+      "recuWkVDSEWc1K0eU",
+      "rec6sKyG0dMJ7HLhY",
+      "recxVaqj0O8BPKyeD"
+    ],
+    nextSteps: ["recp2EOCHfUhGU2jq"],
+    "key DO NOT EDIT": "family, CAF, hasServiceHealthIssue",
+    id: "recBlSOo6diB5tkwc",
+    admin_display:
+      "patronType = family, serviceType = CAF, serviceHealthIssue = hasServiceHealthIssue"
   },
   {
     benefits: ["recOJ3P1wiacWA5jr"],
@@ -271,6 +115,78 @@ const eligibilityPaths = [
       "patronType = servingMember, serviceType = CAF, serviceHealthIssue = hasServiceHealthIssue"
   },
   {
+    benefits: [
+      "recnTqWEj6jCEF8h7",
+      "rec3l8XwdR85xWNJ2",
+      "recH5vAKgnu56IwlS",
+      "rece4vwRrORpYznkw",
+      "recPUSdA7VeaZGUGh",
+      "rec0jzif5VceIWKh3"
+    ],
+    requirements: [
+      "recu6xP62BL9yFbWN",
+      "recC9OodJNCqbnGy2",
+      "rec6sKyG0dMJ7HLhY",
+      "recxVaqj0O8BPKyeD"
+    ],
+    "key DO NOT EDIT": "veteran, servingMember, CAF, hasServiceHealthIssue",
+    id: "recU1DU5vDT8h3sOX",
+    admin_display:
+      "patronType = veteran, patronType = servingMember, serviceType = CAF, serviceHealthIssue = hasServiceHealthIssue"
+  },
+  {
+    benefits: ["recOJ3P1wiacWA5jr", "recPUSdA7VeaZGUGh", "recR3CLbZSRlbGQJV"],
+    requirements: [
+      "recu6xP62BL9yFbWN",
+      "rec6sKyG0dMJ7HLhY",
+      "recxVaqj0O8BPKyeD"
+    ],
+    "key DO NOT EDIT": "veteran, CAF, hasServiceHealthIssue",
+    id: "recGN6WlSHpAw3tt6",
+    admin_display:
+      "patronType = veteran, serviceType = CAF, serviceHealthIssue = hasServiceHealthIssue"
+  },
+  {
+    benefits: [
+      "recMguNzAXgdpEDOJ",
+      "recTJGH8uGpz9FIcl",
+      "recPUSdA7VeaZGUGh",
+      "recMM2R9Dh1WUKxx6",
+      "recXrrmxgZ66BoiK3"
+    ],
+    requirements: [
+      "recuWkVDSEWc1K0eU",
+      "rec6sKyG0dMJ7HLhY",
+      "recDW9csGX2ekiwXb",
+      "recxVaqj0O8BPKyeD"
+    ],
+    "key DO NOT EDIT": "family, CAF, deceased, hasServiceHealthIssue",
+    id: "rec6usTRT8JfBWYBC",
+    admin_display:
+      "patronType = family, serviceType = CAF, statusAndVitals = deceased, serviceHealthIssue = hasServiceHealthIssue"
+  },
+  {
+    benefits: ["rec0jzif5VceIWKh3"],
+    requirements: [
+      "recu6xP62BL9yFbWN",
+      "recC9OodJNCqbnGy2",
+      "recIMgfjrCozH9eVW",
+      "recxVaqj0O8BPKyeD"
+    ],
+    "key DO NOT EDIT": "veteran, servingMember, RCMP, hasServiceHealthIssue",
+    id: "recHYNXwAm2ncw4Ov",
+    admin_display:
+      "patronType = veteran, patronType = servingMember, serviceType = RCMP, serviceHealthIssue = hasServiceHealthIssue"
+  },
+  {
+    benefits: ["rec6osa4YoZNwJcNW", "recNsVtmotVHzDhAB", "recewrfxHbTWEVPig"],
+    requirements: ["recu6xP62BL9yFbWN", "recxVaqj0O8BPKyeD"],
+    "key DO NOT EDIT": "veteran, hasServiceHealthIssue",
+    id: "recQerwEMBUU3TlRO",
+    admin_display:
+      "patronType = veteran, serviceHealthIssue = hasServiceHealthIssue"
+  },
+  {
     benefits: ["recCkQL77l0KZ2u7Y"],
     requirements: ["recu6xP62BL9yFbWN", "recxVaqj0O8BPKyeD"],
     "key DO NOT EDIT": "veteran, hasServiceHealthIssue",
@@ -279,18 +195,133 @@ const eligibilityPaths = [
       "patronType = veteran, serviceHealthIssue = hasServiceHealthIssue"
   },
   {
-    benefits: ["recVKse8WgvLYcfgP"],
+    benefits: ["rec0jzif5VceIWKh3"],
+    requirements: [
+      "recu6xP62BL9yFbWN",
+      "rec3hFX4SlnBMPl7W",
+      "recxVaqj0O8BPKyeD"
+    ],
+    "key DO NOT EDIT": "veteran, WSV (WWII or Korea), hasServiceHealthIssue",
+    id: "rec55z5R3yz8JMv23",
+    admin_display:
+      "patronType = veteran, serviceType = WSV (WWII or Korea), serviceHealthIssue = hasServiceHealthIssue"
+  },
+  {
+    benefits: [
+      "recmFhBkztEyJtm5R",
+      "recowlPz6lmqcbp7F",
+      "rec8GCHaN2UirvW8H",
+      "recZv71nHMgCoX93h"
+    ],
+    requirements: ["rec2pB1RcV3BvyjPX"],
+    "key DO NOT EDIT": "organization",
+    id: "rec04iKWngFVunoHt",
+    admin_display: "patronType = organization"
+  },
+  {
+    benefits: ["recL63epbxypNYRjL", "recO8NVH2tWIjNpDA", "recFMnhGVbQT8de27"],
+    requirements: [
+      "recuWkVDSEWc1K0eU",
+      "rec6sKyG0dMJ7HLhY",
+      "rec3vCJImDFrRIaFl"
+    ],
+    "key DO NOT EDIT": "family, CAF, releasedAlive",
+    id: "recJxCbyWEnhFHJvj",
+    admin_display:
+      "patronType = family, serviceType = CAF, statusAndVitals = releasedAlive"
+  },
+  {
+    benefits: ["recVKse8WgvLYcfgP", "recEHxSnVLcMvYnbS"],
+    requirements: ["recuWkVDSEWc1K0eU", "rec3vCJImDFrRIaFl"],
+    "key DO NOT EDIT": "family, releasedAlive",
+    id: "rec7YU77wS3rAEu3s",
+    admin_display: "patronType = family, statusAndVitals = releasedAlive"
+  },
+  {
+    benefits: ["reccTUqI8ybL1aHQR"],
+    requirements: [
+      "rec3hFX4SlnBMPl7W",
+      "recuWkVDSEWc1K0eU",
+      "rec3vCJImDFrRIaFl"
+    ],
+    "key DO NOT EDIT": "WSV (WWII or Korea), family, releasedAlive",
+    id: "recTg173gsbgdSMmx",
+    admin_display:
+      "serviceType = WSV (WWII or Korea), patronType = family, statusAndVitals = releasedAlive"
+  },
+  {
+    benefits: ["rechnadMxMHp86vv8"],
+    requirements: ["recuWkVDSEWc1K0eU", "rec3vCJImDFrRIaFl"],
+    "key DO NOT EDIT": "family, releasedAlive",
+    id: "recc8tZtc94wRhgxt",
+    admin_display: "patronType = family, statusAndVitals = releasedAlive"
+  },
+  {
+    benefits: ["recO8NVH2tWIjNpDA"],
+    requirements: [
+      "recuWkVDSEWc1K0eU",
+      "rec6sKyG0dMJ7HLhY",
+      "recM3T55J3Xf1qP16"
+    ],
+    "key DO NOT EDIT": "family, CAF, stillServing",
+    id: "recdSQlq9CZ7DFnqH",
+    admin_display:
+      "patronType = family, serviceType = CAF, statusAndVitals = stillServing"
+  },
+  {
+    benefits: ["recpq5tKJOXWZ3JCS"],
+    requirements: ["recuWkVDSEWc1K0eU", "recDW9csGX2ekiwXb"],
+    "key DO NOT EDIT": "family, deceased",
+    id: "recrvk509oay9Vqd2",
+    admin_display: "patronType = family, statusAndVitals = deceased"
+  },
+  {
+    benefits: ["recVKse8WgvLYcfgP", "recpq5tKJOXWZ3JCS", "rechnadMxMHp86vv8"],
     requirements: ["recu6xP62BL9yFbWN"],
     "key DO NOT EDIT": "veteran",
     id: "recmKzJ6y5K1TgEiI",
     admin_display: "patronType = veteran"
   },
   {
-    benefits: ["recVKse8WgvLYcfgP"],
-    requirements: ["recuWkVDSEWc1K0eU", "rec3vCJImDFrRIaFl"],
-    "key DO NOT EDIT": "family, releasedAlive",
-    id: "rec7YU77wS3rAEu3s",
-    admin_display: "patronType = family, statusAndVitals = releasedAlive"
+    benefits: ["recVgcA6MDGMBFjzH", "recFMnhGVbQT8de27"],
+    requirements: ["recuWkVDSEWc1K0eU", "rec3hFX4SlnBMPl7W"],
+    "key DO NOT EDIT": "family, WSV (WWII or Korea)",
+    id: "recyyiggvT1GyQj45",
+    admin_display: "patronType = family, serviceType = WSV (WWII or Korea)"
+  },
+  {
+    benefits: [
+      "recKZD7EgawQUTf98",
+      "recqpTIM3UcQkeRh0",
+      "recVgcA6MDGMBFjzH",
+      "reccTUqI8ybL1aHQR",
+      "recDRPu2NF4UIximU",
+      "rec7vYqDWYPQnDcRK"
+    ],
+    requirements: ["recu6xP62BL9yFbWN", "rec3hFX4SlnBMPl7W"],
+    "key DO NOT EDIT": "veteran, WSV (WWII or Korea)",
+    id: "recsOdDx7CWAftWIR",
+    admin_display: "patronType = veteran, serviceType = WSV (WWII or Korea)"
+  },
+  {
+    benefits: ["rechnadMxMHp86vv8"],
+    requirements: ["recC9OodJNCqbnGy2"],
+    nextSteps: ["recKyNwxKXQQGcokF", "recdLLujXxdXQEzXC"],
+    "key DO NOT EDIT": "servingMember",
+    id: "recR03cJel83BGYSD",
+    admin_display: "patronType = servingMember"
+  },
+  {
+    nextSteps: ["recDGuWEo84Pie18s", "recg5X7mEmlm4Qb2C", "recyxzgPs14QzD8uS"],
+    "key DO NOT EDIT": "no eligibility requirements",
+    id: "recDABExyenzg5QNw"
+  },
+  {
+    benefits: ["recoqXJ7Tx3XaDdFE"],
+    requirements: ["recC9OodJNCqbnGy2", "rec6sKyG0dMJ7HLhY"],
+    "key DO NOT EDIT": "servingMember, CAF",
+    id: "recvv3CfQZ7HTWxdA",
+    admin_display: "patronType = servingMember, serviceType = CAF"
   }
 ];
 

--- a/__tests__/fixtures/multiple_choice_options_complex.js
+++ b/__tests__/fixtures/multiple_choice_options_complex.js
@@ -1,40 +1,96 @@
 const multipleChoiceOptions = [
   {
     display_text_english: "Benefits for Veterans",
-    display_text_french: "Services pour les vétérans",
+    display_text_french: "Services pour les v\u00e9t\u00e9rans",
     linked_question: ["patronType"],
-    "question display logic": ["recn0zobKUhFIowAh", "recZjAnVF7NCwYo74"],
+    "question display logic": ["recn0zobKUhFIowAh"],
     questionClearLogic: ["recP2ZH4HWTMkutPu"],
     variable_name: "veteran",
     eligibilityPaths: [
-      "recxsl5L3LLGIT9rt",
-      "recU1DU5vDT8h3sOX",
       "rec8azbXzu0MLVs3y",
       "recGN6WlSHpAw3tt6",
       "recQerwEMBUU3TlRO",
-      "recHYNXwAm2ncw4Ov",
       "recsOdDx7CWAftWIR",
       "rec55z5R3yz8JMv23",
-      "recrvk509oay9Vqd2",
-      "recj4U5sS1GYwJJjq"
+      "recj4U5sS1GYwJJjq",
+      "recmKzJ6y5K1TgEiI",
+      "recxsl5L3LLGIT9rt",
+      "recU1DU5vDT8h3sOX",
+      "recHYNXwAm2ncw4Ov"
+    ],
+    benefits:
+      "Assistance Fund , Attendance Allowance, Career Transition Services, Career Impact Allowance, Clothing Allowance, Critical Injury Benefit, Detention Benefits, Disability Award, Education and Training Benefit, Exceptional Incapacity Allowance, Group Health Insurance, Jobs in the federal government, Treatment Benefits, Pastoral Outreach , Veteran Family Program, Disability Pension",
+    benefitEligibility:
+      "recfWHf1YmVfz0ppj, rec6ejmokDXrYAUqT, recGR0KBNakgQbLG5, recR4crMdLtxDz0cf, recl8EQBaoPvkUs1y, rec3LMYRHMRfFdc2E, recxyzl32f531NaOr, recBwJVJsjz3KF2kz, recoWEBTf2fHKxO8T, recNbQZ8omQdO5FhH, recLCU5pg8cn8v6cO, recmwLUgfMCQyfiDd, rece9Xkt73rx6IOOw, recI2JIvA0Mtvna2v, recmsrOwzHKCsUNl6, recQBzCRl2D8B7lxu, recgi1wg3Z0xhI0KC, rec9M3lN0KwS8CJmj, recAz6FLY6qy3GkHd, recyyVwXzhgcX14IC, recJDGon9UpIRv1C6, recg7V3k3ol4FLAMh, recxq80Dbs1ijRlaE, recaVVZzKjrd2Duj8, recGkh4BgTTH4ibVq, recxc6T4F7Ft3bF0t, recmRtb7mI9XaukBw, recEfRVYLpvWvqISx, recs1qwbmkLwDiA7Z, recefz1kpLFu7Vkxh, rec6vIdu4K8xl1nxi, recnz9qP2cSNgBzE8, recqM9VdRHwdy35Xf, recwtgBef5LIpUifM",
+    "benefitEligibility 2": [
+      "recfWHf1YmVfz0ppj",
+      "rec6ejmokDXrYAUqT",
+      "recGR0KBNakgQbLG5",
+      "recR4crMdLtxDz0cf",
+      "recl8EQBaoPvkUs1y",
+      "rec3LMYRHMRfFdc2E",
+      "recxyzl32f531NaOr",
+      "recBwJVJsjz3KF2kz",
+      "recoWEBTf2fHKxO8T",
+      "recNbQZ8omQdO5FhH",
+      "recmsrOwzHKCsUNl6",
+      "recQBzCRl2D8B7lxu",
+      "recgi1wg3Z0xhI0KC",
+      "rec9M3lN0KwS8CJmj",
+      "recAz6FLY6qy3GkHd",
+      "recyyVwXzhgcX14IC",
+      "recJDGon9UpIRv1C6",
+      "recg7V3k3ol4FLAMh",
+      "recxq80Dbs1ijRlaE",
+      "recaVVZzKjrd2Duj8",
+      "recGkh4BgTTH4ibVq",
+      "recxc6T4F7Ft3bF0t",
+      "recmRtb7mI9XaukBw",
+      "recEfRVYLpvWvqISx",
+      "recs1qwbmkLwDiA7Z",
+      "recefz1kpLFu7Vkxh",
+      "rec6vIdu4K8xl1nxi",
+      "recnz9qP2cSNgBzE8",
+      "recqM9VdRHwdy35Xf"
     ],
     "key (DO NOT EDIT)": "veteran",
-    id: "recu6xP62BL9yFbWN"
+    id: "recu6xP62BL9yFbWN",
+    admin_display: "patronType = veteran"
   },
   {
     display_text_english: "Benefits for currently serving members",
     display_text_french: "Services pour les membres en service actif",
     linked_question: ["patronType"],
-    "question display logic": ["recZjAnVF7NCwYo74", "recdXDG6qy8fOltJr"],
+    "question display logic": ["recdXDG6qy8fOltJr"],
     variable_name: "servingMember",
     eligibilityPaths: [
+      "rec7iymBcLBwnkd20",
       "recxsl5L3LLGIT9rt",
       "recU1DU5vDT8h3sOX",
       "recHYNXwAm2ncw4Ov",
-      "rec7iymBcLBwnkd20"
+      "recR03cJel83BGYSD",
+      "recvv3CfQZ7HTWxdA"
+    ],
+    benefits:
+      "Career Transition Services, Career Impact Allowance, Critical Injury Benefit, Detention Benefits, Disability Award, Group Health Insurance, Jobs in the federal government, Veteran Family Program, Disability Pension",
+    benefitEligibility:
+      "recR4crMdLtxDz0cf, recl8EQBaoPvkUs1y, recoWEBTf2fHKxO8T, recNbQZ8omQdO5FhH, recLCU5pg8cn8v6cO, recI2JIvA0Mtvna2v, recPwgIAvnOrF9CZE, rec9M3lN0KwS8CJmj, recAz6FLY6qy3GkHd, recJDGon9UpIRv1C6, recg7V3k3ol4FLAMh, recGkh4BgTTH4ibVq, recefz1kpLFu7Vkxh",
+    "benefitEligibility 2": [
+      "recR4crMdLtxDz0cf",
+      "recl8EQBaoPvkUs1y",
+      "recoWEBTf2fHKxO8T",
+      "recNbQZ8omQdO5FhH",
+      "recPwgIAvnOrF9CZE",
+      "rec9M3lN0KwS8CJmj",
+      "recAz6FLY6qy3GkHd",
+      "recJDGon9UpIRv1C6",
+      "recg7V3k3ol4FLAMh",
+      "recGkh4BgTTH4ibVq",
+      "recefz1kpLFu7Vkxh"
     ],
     "key (DO NOT EDIT)": "servingMember",
-    id: "recC9OodJNCqbnGy2"
+    id: "recC9OodJNCqbnGy2",
+    admin_display: "patronType = servingMember"
   },
   {
     display_text_english: "Benefits for family members",
@@ -42,97 +98,187 @@ const multipleChoiceOptions = [
     linked_question: ["patronType"],
     variable_name: "family",
     eligibilityPaths: [
-      "recdSQlq9CZ7DFnqH",
       "recJxCbyWEnhFHJvj",
       "rec1dXWxOfzFZ6zKL",
-      "reckiJxHt31Ql0vAw",
       "rec6usTRT8JfBWYBC",
       "recEkGEXb6BiUT4Ke",
       "recBlSOo6diB5tkwc",
-      "recm2WbUjqAQPxbmB",
+      "recdSQlq9CZ7DFnqH",
       "recXaPbzM7H7UoZn5",
-      "recOsAgDhtvcoR4UD",
       "rec4zJqrgvVa7Rf4c",
-      "recyyiggvT1GyQj45"
+      "recyyiggvT1GyQj45",
+      "rec7YU77wS3rAEu3s",
+      "recc8tZtc94wRhgxt",
+      "recTg173gsbgdSMmx",
+      "recrvk509oay9Vqd2"
     ],
-    ge_breadcrumb_english: "Family members",
-    ge_breadcrumb_french: "Membres de la famille",
+    benefits:
+      "Caregiver Zone, Death Benefit, Educational Assistance for children, Family Peer Support (OSISS), Pastoral Outreach , Survivor's Pension, Veteran Family Program, Vocational Assistance, Funeral and Burial Assistance",
+    benefitEligibility:
+      "recOVWkhp1IfbFnRU, recC1BOsrEwQQT7Tr, recXSg015decd4TOq, recWmF49cJ0evYv0F, reclYWjGKy8oabUkO, rechaKl1wJhKe0lnF, recpCQ81MXjUrrerT, recdtaTP1HL6hgId7, recIKNddEHsrPobsJ, recvSEet4Pf5xm2Ng, rechEoLL5pBxeHcGN, recoztJkT5J9MYX2G, recRligLod0I0IhcP, rece3ZFiriZxO63e4, recxq80Dbs1ijRlaE, rec0AZCo8gx3HzLy1, recBr3SAQU0GijleA, recDSeANhF5XrVRcr, recgsVRR5F96KoQvT, recGSaT5q7VLKIDtA, receBHaEdQ29Qid3n, recdzam05SfCt5PqJ, rec6vIdu4K8xl1nxi, rechrkjJpnl8ZEamI, recQKuvUeQib6xDlk, recxiPnxu1B8Xq1HX, recwtgBef5LIpUifM",
+    "benefitEligibility 2": [
+      "recOVWkhp1IfbFnRU",
+      "recC1BOsrEwQQT7Tr",
+      "recXSg015decd4TOq",
+      "recWmF49cJ0evYv0F",
+      "reclYWjGKy8oabUkO",
+      "rechaKl1wJhKe0lnF",
+      "recpCQ81MXjUrrerT",
+      "recdtaTP1HL6hgId7",
+      "recIKNddEHsrPobsJ",
+      "recvSEet4Pf5xm2Ng",
+      "rechEoLL5pBxeHcGN",
+      "recoztJkT5J9MYX2G",
+      "recRligLod0I0IhcP",
+      "rece3ZFiriZxO63e4",
+      "recxq80Dbs1ijRlaE",
+      "rec0AZCo8gx3HzLy1",
+      "recBr3SAQU0GijleA",
+      "recDSeANhF5XrVRcr",
+      "recgsVRR5F96KoQvT",
+      "recGSaT5q7VLKIDtA",
+      "receBHaEdQ29Qid3n",
+      "recdzam05SfCt5PqJ",
+      "recwtgBef5LIpUifM",
+      "rechrkjJpnl8ZEamI",
+      "recQKuvUeQib6xDlk",
+      "recxiPnxu1B8Xq1HX"
+    ],
     "key (DO NOT EDIT)": "family",
-    id: "recuWkVDSEWc1K0eU"
+    id: "recuWkVDSEWc1K0eU",
+    admin_display: "patronType = family"
   },
   {
     display_text_english: "Grants for organizations",
     display_text_french: "Subventions pour organisations",
     linked_question: ["patronType"],
-    "question display logic": ["rec99OzU3gXrs66zH"],
     questionClearLogic: ["rec7AIyz4BQjmGKT7"],
     variable_name: "organization",
     eligibilityPaths: ["rec04iKWngFVunoHt"],
-    ge_breadcrumb_english: "Organizations",
-    ge_breadcrumb_french: "Organisations",
+    benefits:
+      "Community Engagement Fund, Community War Memorial Fund, Veteran and Family Well-Being Fund",
+    benefitEligibility: "recgFx9UqPwqSW6hO, recbbyAFXpnjEAmZ9",
+    "benefitEligibility 2": ["recgFx9UqPwqSW6hO", "recbbyAFXpnjEAmZ9"],
     "key (DO NOT EDIT)": "organization",
-    id: "rec2pB1RcV3BvyjPX"
+    id: "rec2pB1RcV3BvyjPX",
+    admin_display: "patronType = organization"
   },
   {
     display_text_english: "Canadian Armed Forces",
-    display_text_french: "Forces Armées Canadiennes",
+    display_text_french: "Forces Arm\u00e9es Canadiennes",
     linked_question: ["serviceType"],
     variable_name: "CAF",
     eligibilityPaths: [
       "recxsl5L3LLGIT9rt",
-      "recdSQlq9CZ7DFnqH",
-      "recJxCbyWEnhFHJvj",
-      "rec1dXWxOfzFZ6zKL",
-      "reckiJxHt31Ql0vAw",
-      "rec6usTRT8JfBWYBC",
-      "recEkGEXb6BiUT4Ke",
-      "recBlSOo6diB5tkwc",
-      "recm2WbUjqAQPxbmB",
       "recU1DU5vDT8h3sOX",
       "rec8azbXzu0MLVs3y",
       "recGN6WlSHpAw3tt6",
-      "rec7iymBcLBwnkd20"
+      "rec1dXWxOfzFZ6zKL",
+      "rec6usTRT8JfBWYBC",
+      "recEkGEXb6BiUT4Ke",
+      "recBlSOo6diB5tkwc",
+      "recJxCbyWEnhFHJvj",
+      "recdSQlq9CZ7DFnqH",
+      "rec7iymBcLBwnkd20",
+      "recvv3CfQZ7HTWxdA"
     ],
-    ge_breadcrumb_english: "Canadian Armed Forces",
-    ge_breadcrumb_french: "Forces Armées Canadiennes",
+    "benefits 2":
+      "Career Transition Services, Career Impact Allowance, Critical Injury Benefit, Death Benefit, Detention Benefits, Disability Award, Education and Training Benefit, Educational Assistance for children, Family Peer Support (OSISS), Group Health Insurance, Jobs in the federal government, Pastoral Outreach , Survivor's Pension, Veteran Family Program, Vocational Assistance, Disability Pension, Funeral and Burial Assistance",
+    benefitEligibility:
+      "recOVWkhp1IfbFnRU, recGR0KBNakgQbLG5, recR4crMdLtxDz0cf, recl8EQBaoPvkUs1y, rec3LMYRHMRfFdc2E, recC1BOsrEwQQT7Tr, recoWEBTf2fHKxO8T, reclYWjGKy8oabUkO, recNbQZ8omQdO5FhH, recLCU5pg8cn8v6cO, recmwLUgfMCQyfiDd, recPwgIAvnOrF9CZE, rechaKl1wJhKe0lnF, recmsrOwzHKCsUNl6, recQBzCRl2D8B7lxu, recpCQ81MXjUrrerT, recdtaTP1HL6hgId7, recvSEet4Pf5xm2Ng, rec9M3lN0KwS8CJmj, recRligLod0I0IhcP, recAz6FLY6qy3GkHd, recJDGon9UpIRv1C6, recxq80Dbs1ijRlaE, recBr3SAQU0GijleA, recGkh4BgTTH4ibVq, recDSeANhF5XrVRcr, recxc6T4F7Ft3bF0t, recmRtb7mI9XaukBw, recgsVRR5F96KoQvT, recGSaT5q7VLKIDtA, recdzam05SfCt5PqJ, recefz1kpLFu7Vkxh, rec6vIdu4K8xl1nxi, recnz9qP2cSNgBzE8, recQKuvUeQib6xDlk, recwtgBef5LIpUifM",
+    "benefitEligibility 3": [
+      "recOVWkhp1IfbFnRU",
+      "recGR0KBNakgQbLG5",
+      "recR4crMdLtxDz0cf",
+      "recl8EQBaoPvkUs1y",
+      "rec3LMYRHMRfFdc2E",
+      "recC1BOsrEwQQT7Tr",
+      "recoWEBTf2fHKxO8T",
+      "reclYWjGKy8oabUkO",
+      "recNbQZ8omQdO5FhH",
+      "recPwgIAvnOrF9CZE",
+      "rechaKl1wJhKe0lnF",
+      "recmsrOwzHKCsUNl6",
+      "recQBzCRl2D8B7lxu",
+      "recpCQ81MXjUrrerT",
+      "recdtaTP1HL6hgId7",
+      "recvSEet4Pf5xm2Ng",
+      "rec9M3lN0KwS8CJmj",
+      "recRligLod0I0IhcP",
+      "recAz6FLY6qy3GkHd",
+      "recJDGon9UpIRv1C6",
+      "recxq80Dbs1ijRlaE",
+      "recBr3SAQU0GijleA",
+      "recGkh4BgTTH4ibVq",
+      "recDSeANhF5XrVRcr",
+      "recxc6T4F7Ft3bF0t",
+      "recmRtb7mI9XaukBw",
+      "recgsVRR5F96KoQvT",
+      "recGSaT5q7VLKIDtA",
+      "recdzam05SfCt5PqJ",
+      "recefz1kpLFu7Vkxh",
+      "rec6vIdu4K8xl1nxi",
+      "recwtgBef5LIpUifM",
+      "recnz9qP2cSNgBzE8",
+      "recQKuvUeQib6xDlk"
+    ],
     "key (DO NOT EDIT)": "CAF",
-    id: "rec6sKyG0dMJ7HLhY"
+    id: "rec6sKyG0dMJ7HLhY",
+    admin_display: "serviceType = CAF"
   },
   {
     display_text_english: "Royal Canadian Mounted Police",
     display_text_french: "Gendarmerie royale du Canada",
     linked_question: ["serviceType"],
     variable_name: "RCMP",
-    eligibilityPaths: [
-      "recXaPbzM7H7UoZn5",
-      "recOsAgDhtvcoR4UD",
-      "recHYNXwAm2ncw4Ov"
-    ],
-    ge_breadcrumb_english: "Royal Canadian Mounted Police",
-    ge_breadcrumb_french: "Gendarmerie royale du Canada",
+    eligibilityPaths: ["recHYNXwAm2ncw4Ov", "recXaPbzM7H7UoZn5"],
+    "benefits 2": "Survivor's Pension, Disability Pension",
+    benefitEligibility:
+      "recI2JIvA0Mtvna2v, rechEoLL5pBxeHcGN, recGSaT5q7VLKIDtA",
+    "benefitEligibility 3": ["rechEoLL5pBxeHcGN", "recGSaT5q7VLKIDtA"],
     "key (DO NOT EDIT)": "RCMP",
-    id: "recIMgfjrCozH9eVW"
+    id: "recIMgfjrCozH9eVW",
+    admin_display: "serviceType = RCMP"
   },
   {
     display_text_english: "WWII or Korean War Veterans",
     display_text_french:
-      "Vétérans de la Seconde Guerre mondiale ou la guerre de Corée",
+      "V\u00e9t\u00e9rans de la Seconde Guerre mondiale ou la guerre de Cor\u00e9e",
     linked_question: ["serviceType"],
-    "question display logic": ["reczEVuK0ipZkAIec", "recEqeZzL7EjJ7NZV"],
+    "question display logic": ["reczEVuK0ipZkAIec"],
     "question display logic 2": ["recdXDG6qy8fOltJr"],
     questionClearLogic: ["rec9DCmvkqeW06zqu"],
     variable_name: "WSV (WWII or Korea)",
     eligibilityPaths: [
+      "recsOdDx7CWAftWIR",
+      "rec55z5R3yz8JMv23",
       "rec4zJqrgvVa7Rf4c",
       "recyyiggvT1GyQj45",
-      "recsOdDx7CWAftWIR",
-      "rec55z5R3yz8JMv23"
+      "recTg173gsbgdSMmx"
     ],
-    ge_breadcrumb_english: "WWII or Korean War Veterans",
-    ge_breadcrumb_french:
-      "Vétérans de la Seconde Guerre mondiale ou la guerre de Corée",
+    "benefits 2":
+      "Assistance Fund , Pastoral Outreach , Survivor's Pension, Disability Pension, Funeral and Burial Assistance",
+    benefitEligibility:
+      "recfWHf1YmVfz0ppj, rece9Xkt73rx6IOOw, recIKNddEHsrPobsJ, recoztJkT5J9MYX2G, recyyVwXzhgcX14IC, recxq80Dbs1ijRlaE, rec0AZCo8gx3HzLy1, recaVVZzKjrd2Duj8, recGSaT5q7VLKIDtA, rec6vIdu4K8xl1nxi, recnz9qP2cSNgBzE8, rechrkjJpnl8ZEamI, recxiPnxu1B8Xq1HX, recqM9VdRHwdy35Xf, recwtgBef5LIpUifM",
+    "benefitEligibility 3": [
+      "recfWHf1YmVfz0ppj",
+      "recIKNddEHsrPobsJ",
+      "recoztJkT5J9MYX2G",
+      "recyyVwXzhgcX14IC",
+      "recxq80Dbs1ijRlaE",
+      "rec0AZCo8gx3HzLy1",
+      "recaVVZzKjrd2Duj8",
+      "recGSaT5q7VLKIDtA",
+      "rec6vIdu4K8xl1nxi",
+      "recwtgBef5LIpUifM",
+      "recnz9qP2cSNgBzE8",
+      "rechrkjJpnl8ZEamI",
+      "recxiPnxu1B8Xq1HX",
+      "recqM9VdRHwdy35Xf"
+    ],
     "key (DO NOT EDIT)": "WSV (WWII or Korea)",
-    id: "rec3hFX4SlnBMPl7W"
+    id: "rec3hFX4SlnBMPl7W",
+    admin_display: "serviceType = WSV (WWII or Korea)"
   },
   {
     display_text_english: "Still-serving",
@@ -142,40 +288,83 @@ const multipleChoiceOptions = [
     "questionClearLogic 2": ["rec9DCmvkqeW06zqu"],
     variable_name: "stillServing",
     eligibilityPaths: ["recdSQlq9CZ7DFnqH"],
-    ge_breadcrumb_english: "Still-serving",
-    ge_breadcrumb_french: "En service actif",
+    "benefits 3": "Vocational Assistance",
+    benefitEligibility: "recQKuvUeQib6xDlk",
+    "benefitEligibility 4": ["recQKuvUeQib6xDlk"],
     "key (DO NOT EDIT)": "stillServing",
-    id: "recM3T55J3Xf1qP16"
+    id: "recM3T55J3Xf1qP16",
+    admin_display: "statusAndVitals = stillServing"
   },
   {
     display_text_english: "Released",
-    display_text_french: "Libéré",
+    display_text_french: "Lib\u00e9r\u00e9",
     linked_question: ["statusAndVitals"],
     variable_name: "releasedAlive",
-    eligibilityPaths: ["recJxCbyWEnhFHJvj", "recm2WbUjqAQPxbmB"],
-    ge_breadcrumb_english: "Released",
-    ge_breadcrumb_french: "Libéré",
+    eligibilityPaths: [
+      "rec7YU77wS3rAEu3s",
+      "recJxCbyWEnhFHJvj",
+      "recc8tZtc94wRhgxt",
+      "recTg173gsbgdSMmx"
+    ],
+    "benefits 3": "Caregiver Zone, Vocational Assistance",
+    benefitEligibility:
+      "recC1BOsrEwQQT7Tr, recXSg015decd4TOq, recWmF49cJ0evYv0F, rece3ZFiriZxO63e4, rec0AZCo8gx3HzLy1, rec6vIdu4K8xl1nxi, recQKuvUeQib6xDlk, recwtgBef5LIpUifM",
+    "benefitEligibility 3": ["rece3ZFiriZxO63e4"],
+    "benefitEligibility 4": [
+      "recC1BOsrEwQQT7Tr",
+      "recXSg015decd4TOq",
+      "recWmF49cJ0evYv0F",
+      "rec0AZCo8gx3HzLy1",
+      "rec6vIdu4K8xl1nxi",
+      "recwtgBef5LIpUifM",
+      "recQKuvUeQib6xDlk"
+    ],
     "key (DO NOT EDIT)": "releasedAlive",
-    id: "rec3vCJImDFrRIaFl"
+    id: "rec3vCJImDFrRIaFl",
+    admin_display: "statusAndVitals = releasedAlive"
   },
   {
     display_text_english: "Deceased",
-    display_text_french: "Décédé",
+    display_text_french: "D\u00e9c\u00e9d\u00e9",
     linked_question: ["statusAndVitals"],
     "question display logic 2": ["recn0zobKUhFIowAh"],
     "questionClearLogic 2": ["recP2ZH4HWTMkutPu"],
     variable_name: "deceased",
     eligibilityPaths: [
       "rec1dXWxOfzFZ6zKL",
-      "reckiJxHt31Ql0vAw",
       "rec6usTRT8JfBWYBC",
       "recXaPbzM7H7UoZn5",
-      "rec4zJqrgvVa7Rf4c"
+      "rec4zJqrgvVa7Rf4c",
+      "recrvk509oay9Vqd2"
     ],
-    ge_breadcrumb_english: "Deceased",
-    ge_breadcrumb_french: "Décédé",
+    "benefits 3":
+      "Death Benefit, Educational Assistance for children, Family Peer Support (OSISS), Survivor's Pension, Vocational Assistance, Funeral and Burial Assistance",
+    benefitEligibility:
+      "recOVWkhp1IfbFnRU, reclYWjGKy8oabUkO, rechaKl1wJhKe0lnF, recpCQ81MXjUrrerT, recdtaTP1HL6hgId7, recIKNddEHsrPobsJ, recvSEet4Pf5xm2Ng, rechEoLL5pBxeHcGN, recoztJkT5J9MYX2G, recRligLod0I0IhcP, recBr3SAQU0GijleA, recDSeANhF5XrVRcr, recgsVRR5F96KoQvT, recGSaT5q7VLKIDtA, receBHaEdQ29Qid3n, rec6vIdu4K8xl1nxi, rechrkjJpnl8ZEamI, recQKuvUeQib6xDlk, recxiPnxu1B8Xq1HX, recwtgBef5LIpUifM",
+    "benefitEligibility 4": [
+      "recOVWkhp1IfbFnRU",
+      "reclYWjGKy8oabUkO",
+      "rechaKl1wJhKe0lnF",
+      "recpCQ81MXjUrrerT",
+      "recdtaTP1HL6hgId7",
+      "recIKNddEHsrPobsJ",
+      "recvSEet4Pf5xm2Ng",
+      "rechEoLL5pBxeHcGN",
+      "recoztJkT5J9MYX2G",
+      "recRligLod0I0IhcP",
+      "recBr3SAQU0GijleA",
+      "recDSeANhF5XrVRcr",
+      "recgsVRR5F96KoQvT",
+      "recGSaT5q7VLKIDtA",
+      "receBHaEdQ29Qid3n",
+      "recwtgBef5LIpUifM",
+      "rechrkjJpnl8ZEamI",
+      "recQKuvUeQib6xDlk",
+      "recxiPnxu1B8Xq1HX"
+    ],
     "key (DO NOT EDIT)": "deceased",
-    id: "recDW9csGX2ekiwXb"
+    id: "recDW9csGX2ekiwXb",
+    admin_display: "statusAndVitals = deceased"
   },
   {
     display_text_english: "Yes",
@@ -183,20 +372,44 @@ const multipleChoiceOptions = [
     linked_question: ["serviceHealthIssue"],
     variable_name: "hasServiceHealthIssue",
     eligibilityPaths: [
-      "rec6usTRT8JfBWYBC",
-      "recBlSOo6diB5tkwc",
       "recU1DU5vDT8h3sOX",
       "recGN6WlSHpAw3tt6",
       "recQerwEMBUU3TlRO",
       "recHYNXwAm2ncw4Ov",
       "rec55z5R3yz8JMv23",
+      "rec6usTRT8JfBWYBC",
+      "recBlSOo6diB5tkwc",
       "rec7iymBcLBwnkd20",
       "recj4U5sS1GYwJJjq"
     ],
     ge_breadcrumb_english: "Has service-related health issue",
-    ge_breadcrumb_french: "A un problème de santé lié au service",
+    ge_breadcrumb_french:
+      "A un probl\u00e8me de sant\u00e9 li\u00e9 au service",
+    "benefits 4":
+      "Attendance Allowance, Career Impact Allowance, Clothing Allowance, Critical Injury Benefit, Death Benefit, Disability Award, Exceptional Incapacity Allowance, Group Health Insurance, Treatment Benefits, Veteran Family Program, Disability Pension",
+    benefitEligibility:
+      "rec6ejmokDXrYAUqT, recOVWkhp1IfbFnRU, recR4crMdLtxDz0cf, recBwJVJsjz3KF2kz, recoWEBTf2fHKxO8T, reclYWjGKy8oabUkO, recLCU5pg8cn8v6cO, recmwLUgfMCQyfiDd, rece9Xkt73rx6IOOw, recI2JIvA0Mtvna2v, recPwgIAvnOrF9CZE, recmsrOwzHKCsUNl6, recgi1wg3Z0xhI0KC, rec9M3lN0KwS8CJmj, recBr3SAQU0GijleA, recGkh4BgTTH4ibVq, recgsVRR5F96KoQvT, recEfRVYLpvWvqISx, recdzam05SfCt5PqJ, recefz1kpLFu7Vkxh",
+    "benefitEligibility 5": [
+      "rec6ejmokDXrYAUqT",
+      "recOVWkhp1IfbFnRU",
+      "recR4crMdLtxDz0cf",
+      "recBwJVJsjz3KF2kz",
+      "recoWEBTf2fHKxO8T",
+      "reclYWjGKy8oabUkO",
+      "recPwgIAvnOrF9CZE",
+      "recmsrOwzHKCsUNl6",
+      "recgi1wg3Z0xhI0KC",
+      "rec9M3lN0KwS8CJmj",
+      "recBr3SAQU0GijleA",
+      "recGkh4BgTTH4ibVq",
+      "recgsVRR5F96KoQvT",
+      "recEfRVYLpvWvqISx",
+      "recdzam05SfCt5PqJ",
+      "recefz1kpLFu7Vkxh"
+    ],
     "key (DO NOT EDIT)": "hasServiceHealthIssue",
-    id: "recxVaqj0O8BPKyeD"
+    id: "recxVaqj0O8BPKyeD",
+    admin_display: "serviceHealthIssue = hasServiceHealthIssue"
   },
   {
     display_text_english: "No",
@@ -204,9 +417,11 @@ const multipleChoiceOptions = [
     linked_question: ["serviceHealthIssue"],
     variable_name: "noServiceHealthIssue",
     ge_breadcrumb_english: "No service-related health issue",
-    ge_breadcrumb_french: "Aucun problème de santé lié au service",
+    ge_breadcrumb_french:
+      "Aucun probl\u00e8me de sant\u00e9 li\u00e9 au service",
     "key (DO NOT EDIT)": "noServiceHealthIssue",
-    id: "recC0Rsw47ySCM1sS"
+    id: "recC0Rsw47ySCM1sS",
+    admin_display: "serviceHealthIssue = noServiceHealthIssue"
   }
 ];
 

--- a/__tests__/fixtures/nextSteps_complex.js
+++ b/__tests__/fixtures/nextSteps_complex.js
@@ -4,17 +4,17 @@ const nextSteps = [
     english:
       "Have you scheduled your [Transition Interview](http://www.veterans.gc.ca/eng/services/transition/interview) yet? Every currently serving member is eligible to talk to a VAC person to make transitioning out of the military as seamless as possible. ",
     french:
-      "[TRANS] Avez-vous déjà planifié votre [Entrevue de transition](http://www.veterans.gc.ca/fra/services/transition/interview)? Tous les membres en service actif sont admissibles à parler à une personne d'ACC afin de rendre la transition à la vie militaire aussi transparente que possible. ",
-    eligibilityPath: ["rec04iKWngFVunoHt"],
+      "Avez-vous planifi\u00e9 votre [entrevue de transition](http://www.veterans.gc.ca/fra/services/transition/interview)? Tout membre actif a droit \u00e0 un entretien avec un agent d\u2019ACC afin de s\u2019assurer que la transition de la vie militaire \u00e0 la vie civile se passe le mieux possible.",
+    eligibilityPath: ["recR03cJel83BGYSD"],
     id: "recKyNwxKXQQGcokF"
   },
   {
     bullet_name: "doctorsNote",
     english:
-      "Make sure you have a doctor’s note for your service-related health issue. This will make applying for these benefits go a lot smoother.",
+      "Make sure you have a doctor\u2019s note for your service-related health issue. This will make applying for these benefits go a lot smoother.",
     french:
-      "[TRANS] Assurez-vous d'avoir une note du médecin pour votre problème de santé lié au service. Cela facilitera grandement la présentation d'une demande de prestations.",
-    eligibilityPath: ["recxsl5L3LLGIT9rt"],
+      "Assurez-vous d\u2019avoir en main un billet du m\u00e9decin attestant de votre probl\u00e8me de sant\u00e9 reli\u00e9 au service. Votre processus de demande d\u2019avantages en sera grandement facilit\u00e9.",
+    eligibilityPath: ["recBlSOo6diB5tkwc"],
     id: "recp2EOCHfUhGU2jq"
   },
   {
@@ -22,18 +22,33 @@ const nextSteps = [
     english:
       "Attend a SCAN session to learn more about what VAC can do for you.",
     french:
-      "[TRANS] Assistez à une séance de SCAN pour en apprendre davantage sur ce qu'ACC peut faire pour vous.",
-    eligibilityPath: ["recc8tZtc94wRhgxt"],
+      "Assistez \u00e0 une s\u00e9ance du SPSC pour en apprendre davantage sur ce que l\u2019ACC peut faire pour vous.",
+    eligibilityPath: ["recR03cJel83BGYSD"],
     id: "recdLLujXxdXQEzXC"
   },
   {
-    bullet_name: "photoId",
+    bullet_name: "firstStep",
     english:
-      "Make sure you include a photo of a government-approved identification in your application. Check this list to see what documents are approved. ",
+      "If you are looking for more information please look at _See more_.",
+    french: "(fra)If you are looking for more information look at See more.",
+    eligibilityPath: ["recDABExyenzg5QNw"],
+    id: "recDGuWEo84Pie18s"
+  },
+  {
+    bullet_name: "secondStep",
+    english:
+      "If you wish to complete an application please see _Register for My VAC Account_.",
     french:
-      "[TRANS] Assurez-vous d'inclure une photo d'une pièce d'identité approuvée par le gouvernement dans votre demande. Consultez cette liste pour voir quels documents sont approuvés. ",
-    eligibilityPath: ["recc8tZtc94wRhgxt"],
-    id: "recEPLn1bUc5ejFVP"
+      "(fra)If you wish to complete an application please see _Register for My VAC Account_",
+    eligibilityPath: ["recDABExyenzg5QNw"],
+    id: "recg5X7mEmlm4Qb2C"
+  },
+  {
+    bullet_name: "thirdStep",
+    english: "If you saved a card to your list please look at _Saved list_.",
+    french: "(fra)If you saved a card to your list please look at Saved list.",
+    eligibilityPath: ["recDABExyenzg5QNw"],
+    id: "recyxzgPs14QzD8uS"
   }
 ];
 

--- a/__tests__/fixtures/questions_complex.js
+++ b/__tests__/fixtures/questions_complex.js
@@ -8,20 +8,17 @@ const questions = [
       "recC9OodJNCqbnGy2"
     ],
     display_text_english: "My selection:",
-    display_text_french: "Ma sélection:",
-    "question display logic": [
-      "recn0zobKUhFIowAh",
-      "rec99OzU3gXrs66zH",
-      "recZjAnVF7NCwYo74",
-      "recdXDG6qy8fOltJr"
-    ],
+    display_text_french: "Ma s\u00e9lection:",
+    "question display logic": ["recn0zobKUhFIowAh", "recdXDG6qy8fOltJr"],
     guided_experience_english: "Select who will be receiving the benefits.",
-    guided_experience_french: "Sélectionnez qui recevra les services.",
+    guided_experience_french: "S\u00e9lectionnez qui recevra les services.",
     questionClearLogic: ["rec7AIyz4BQjmGKT7", "recP2ZH4HWTMkutPu"],
     guided_experience_page_title_english:
       "Select who will be receiving the benefits.",
     guided_experience_page_title_french:
-      "Sélectionnez qui recevra les services.",
+      "S\u00e9lectionnez qui recevra les services.",
+    breadcrumb_english: "Benefit recipient",
+    breadcrumb_french: "Prestataire",
     id: "recwwXPBszQacaMsb"
   },
   {
@@ -33,15 +30,17 @@ const questions = [
     ],
     display_text_english: "Service type:",
     display_text_french: "Type de service:",
-    "question display logic": ["reczEVuK0ipZkAIec", "recEqeZzL7EjJ7NZV"],
-    "question display logic 2": ["rec99OzU3gXrs66zH"],
+    "question display logic": ["reczEVuK0ipZkAIec"],
     guided_experience_english: "Select the service type.",
-    guided_experience_french: "Sélectionnez le type de service.",
+    guided_experience_french: "S\u00e9lectionnez le type de service.",
     questionClearLogic: ["rec9DCmvkqeW06zqu"],
     "questionClearLogic 2": ["rec7AIyz4BQjmGKT7"],
     "questionClearLogic 2 copy": "Unnamed record",
     guided_experience_page_title_english: "Select the service type.",
-    guided_experience_page_title_french: "Sélectionnez le type de service.",
+    guided_experience_page_title_french:
+      "S\u00e9lectionnez le type de service.",
+    breadcrumb_english: "Service type",
+    breadcrumb_french: "Type de service",
     id: "recd9vxcm3gb3jkLE"
   },
   {
@@ -53,9 +52,8 @@ const questions = [
     ],
     display_text_english: "Veteran Service status:",
     display_text_french: "Statut du membre:",
-    "question display logic 2": ["rec99OzU3gXrs66zH", "recZjAnVF7NCwYo74"],
     guided_experience_english: "Select the service status.",
-    guided_experience_french: "Sélectionnez  le statut du membre.",
+    guided_experience_french: "S\u00e9lectionnez  le statut du membre.",
     "questionClearLogic 2": [
       "rec7AIyz4BQjmGKT7",
       "recP2ZH4HWTMkutPu",
@@ -64,43 +62,50 @@ const questions = [
     "questionClearLogic 2 copy":
       "Unnamed record, Unnamed record, Unnamed record",
     guided_experience_page_title_english: "Select the service status.",
-    guided_experience_page_title_french: "Sélectionnez  le statut du membre.",
+    guided_experience_page_title_french:
+      "S\u00e9lectionnez  le statut du membre.",
+    breadcrumb_english: "Status",
+    breadcrumb_french: "\u00c9tat",
     id: "recUrZvFSfHUMzii7"
   },
   {
     variable_name: "serviceHealthIssue",
     multiple_choice_options: ["recxVaqj0O8BPKyeD", "recC0Rsw47ySCM1sS"],
     display_text_english: "Is there a service-related health issue?",
-    display_text_french: "A-t-il un problème de santé lié au service?",
-    "question display logic 2": ["rec99OzU3gXrs66zH", "recEqeZzL7EjJ7NZV"],
+    display_text_french:
+      "A-t-il un probl\u00e8me de sant\u00e9 li\u00e9 au service?",
     guided_experience_english: "Is there a service-related health issue?",
-    guided_experience_french: "A-t-il un problème de santé lié au service?",
+    guided_experience_french:
+      "A-t-il un probl\u00e8me de sant\u00e9 li\u00e9 au service?",
     "questionClearLogic 2": ["rec7AIyz4BQjmGKT7"],
     "questionClearLogic 2 copy":
       "Unnamed record, Unnamed record, Unnamed record",
     tooltip_english:
-      "A service-related health issue is an illness or injury that was caused or worsened by military service. It must be medically diagnosed by a doctor. Examples include: tinnitus, depression, etc.",
+      "A service-related health issue is an illness or injury that was caused or worsened by military service. It must be medically diagnosed by a doctor. Examples include: hearing loss and tinnitus, depression.",
     tooltip_french:
-      "Un problème de santé lié au service militaire est une maladie ou une blessure qui a été causée ou aggravée par le service militaire. Il doit être diagnostiqué médicalement par un médecin. Exemples : acouphènes, dépression, etc.",
+      "Un probl\u00e8me de sant\u00e9 li\u00e9 au service militaire est une maladie ou une blessure qui a \u00e9t\u00e9 caus\u00e9e ou aggrav\u00e9e par le service militaire. Il doit \u00eatre diagnostiqu\u00e9 m\u00e9dicalement par un m\u00e9decin. Exemples : acouph\u00e8nes, d\u00e9pression.",
     guided_experience_page_title_english:
       "Is there a service-related health issue?",
     guided_experience_page_title_french:
-      "A-t-il un problème de santé lié au service?",
+      "A-t-il un probl\u00e8me de sant\u00e9 li\u00e9 au service?",
+    breadcrumb_english: "Health issue",
+    breadcrumb_french: "Enjeu de sant\u00e9",
     id: "reccsWjclog8m3Od1"
   },
   {
     variable_name: "needs",
     display_text_english: "Filter by category",
     display_text_french: "Filtrer par sujet",
-    "question display logic 2": ["rec99OzU3gXrs66zH"],
     guided_experience_english:
       "Select the categories of benefits you want to see.",
     guided_experience_french:
-      "Sélectionnez les types d'avantages que vous voulez consulter. ",
+      "S\u00e9lectionnez les types d'avantages que vous voulez consulter. ",
     guided_experience_page_title_english:
       "Select the categories of benefits you want to see.",
     guided_experience_page_title_french:
-      "Sélectionnez les types d'avantages que vous voulez consulter. ",
+      "S\u00e9lectionnez les types d'avantages que vous voulez consulter. ",
+    breadcrumb_english: "Category",
+    breadcrumb_french: "Cat\u00e9gorie",
     id: "recritlpywwyoGLtm"
   }
 ];

--- a/__tests__/pages/benefits_directory_test.js
+++ b/__tests__/pages/benefits_directory_test.js
@@ -9,6 +9,7 @@ import benefitsFixture from "../fixtures/benefits";
 import needsFixture from "../fixtures/needs";
 import configureStore from "redux-mock-store";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
+import benefitEligibilityFixture from "../fixtures/benefitEligibility";
 import areaOfficesFixture from "../fixtures/area_offices";
 import translate from "../fixtures/translate";
 import lunr from "lunr";
@@ -62,6 +63,7 @@ describe("BenefitsDirectory", () => {
       translations: [],
       benefits: benefitsFixture,
       eligibilityPaths: eligibilityPathsFixture,
+      benefitEligibility: benefitEligibilityFixture,
       enIdx: JSON.stringify({
         version: lunr.version,
         fields: ["vacNameEn", "oneLineDescriptionEn"],

--- a/__tests__/pages/favourites_page_test.js
+++ b/__tests__/pages/favourites_page_test.js
@@ -9,6 +9,7 @@ import benefitsFixture from "../fixtures/benefits";
 import needsFixture from "../fixtures/needs";
 import configureStore from "redux-mock-store";
 import eligibilityPathsFixture from "../fixtures/eligibilityPaths";
+import benefitEligibilityFixture from "../fixtures/benefitEligibility";
 import areaOfficesFixture from "../fixtures/area_offices";
 import questionsFixture from "../fixtures/questions";
 import multipleChoiceOptionsFixture from "../fixtures/multiple_choice_options";
@@ -47,6 +48,7 @@ describe("Favourites Page", () => {
       translations: [],
       benefits: benefitsFixture,
       eligibilityPaths: eligibilityPathsFixture,
+      benefitEligibility: benefitEligibilityFixture,
       multipleChoiceOptions: multipleChoiceOptionsFixture,
       enIdx: JSON.stringify({
         version: lunr.version,

--- a/__tests__/selectors/benefits_test.js
+++ b/__tests__/selectors/benefits_test.js
@@ -9,6 +9,7 @@ import {
 import questionsFixture from "../fixtures/questions_complex";
 import benefitsFixture from "../fixtures/benefits_complex";
 import eligibilityPathsFixture from "../fixtures/eligibility_paths_complex";
+import benefitEligibilityFixture from "../fixtures/benefitEligibility_complex";
 import multipleChoiceOptionsFixture from "../fixtures/multiple_choice_options_complex";
 import needsFixture from "../fixtures/needs_complex";
 import enIdx from "../fixtures/lunr_index_english";
@@ -27,6 +28,7 @@ describe("Benefits Selectors", () => {
       questions: questionsFixture,
       benefits: benefitsFixture,
       eligibilityPaths: eligibilityPathsFixture,
+      benefitEligibility: benefitEligibilityFixture,
       multipleChoiceOptions: multipleChoiceOptionsFixture,
       enIdx: enIdx,
       frIdx: frIdx,

--- a/__tests__/selectors/benefits_test.js
+++ b/__tests__/selectors/benefits_test.js
@@ -62,7 +62,7 @@ describe("Benefits Selectors", () => {
   describe("pathToDict function", () => {
     it("works as expected", () => {
       const actual = pathToDict(
-        state.eligibilityPaths[5],
+        state.eligibilityPaths[11],
         state.multipleChoiceOptions
       );
       expect(actual).toEqual({
@@ -136,7 +136,7 @@ describe("Benefits Selectors", () => {
         statusAndVitals: ""
       };
       const actual = eligibilityMatch(
-        state.eligibilityPaths[0],
+        state.eligibilityPaths[2],
         profileFilters,
         state.multipleChoiceOptions
       );
@@ -150,7 +150,7 @@ describe("Benefits Selectors", () => {
         statusAndVitals: ""
       };
       const actual = eligibilityMatch(
-        state.eligibilityPaths[0],
+        state.eligibilityPaths[2],
         profileFilters,
         state.multipleChoiceOptions
       );
@@ -177,10 +177,10 @@ describe("Benefits Selectors", () => {
     it("displays appropriate benefits if patronType is organization", () => {
       state.patronType = "organization";
       const nameEnList = [
-        "Community War Memorial",
-        "Community Engagement",
-        "Veteran and Family Well-Being Fund",
-        "Operational Stress Injury clinics"
+        "Community Engagement Fund",
+        "Community War Memorial Fund",
+        "Grave Marker Maintenance",
+        "Veteran and Family Well-Being Fund"
       ];
       const relevant_benefits = state.benefits.filter(x => {
         return nameEnList.indexOf(x.vacNameEn) > -1;
@@ -221,10 +221,10 @@ describe("Benefits Selectors", () => {
     it("displays appropriate benefits if patronType is organization", () => {
       state.patronType = "organization";
       const nameEnList = [
-        "Community War Memorial",
-        "Community Engagement",
-        "Veteran and Family Well-Being Fund",
-        "Operational Stress Injury clinics"
+        "Community Engagement Fund",
+        "Community War Memorial Fund",
+        "Grave Marker Maintenance",
+        "Veteran and Family Well-Being Fund"
       ];
       const relevant_benefits = state.benefits.filter(x => {
         return nameEnList.indexOf(x.vacNameEn) > -1;

--- a/__tests__/selectors/urls_test.js
+++ b/__tests__/selectors/urls_test.js
@@ -165,6 +165,57 @@ describe("getPrintUrl", () => {
           benefits: ["1", "3", "4"]
         }
       ],
+      benefitEligibility: [
+        {
+          id: "0",
+          benefit: ["0"],
+          patronType: ["p1"],
+          serviceType: ["na"],
+          statusAndVitals: ["na"]
+        },
+        {
+          id: "1",
+          benefit: ["2"],
+          patronType: ["p1"],
+          serviceType: ["na"],
+          statusAndVitals: ["na"]
+        },
+        {
+          id: "2",
+          benefit: ["4"],
+          patronType: ["p1"],
+          serviceType: ["na"],
+          statusAndVitals: ["na"]
+        },
+        {
+          id: "3",
+          benefit: ["2"],
+          patronType: ["p2"],
+          serviceType: ["na"],
+          statusAndVitals: ["na"]
+        },
+        {
+          id: "4",
+          benefit: ["1"],
+          patronType: ["p3"],
+          serviceType: ["na"],
+          statusAndVitals: ["na"]
+        },
+        {
+          id: "5",
+          benefit: ["3"],
+          patronType: ["p3"],
+          serviceType: ["na"],
+          statusAndVitals: ["na"]
+        },
+        {
+          id: "6",
+          benefit: ["4"],
+          patronType: ["p3"],
+          serviceType: ["na"],
+          statusAndVitals: ["na"]
+        }
+      ],
       multipleChoiceOptions: [
         {
           variable_name: "p1",

--- a/__tests__/selectors/urls_test.js
+++ b/__tests__/selectors/urls_test.js
@@ -169,51 +169,37 @@ describe("getPrintUrl", () => {
         {
           id: "0",
           benefit: ["0"],
-          patronType: ["p1"],
-          serviceType: ["na"],
-          statusAndVitals: ["na"]
+          patronType: ["p1"]
         },
         {
           id: "1",
           benefit: ["2"],
-          patronType: ["p1"],
-          serviceType: ["na"],
-          statusAndVitals: ["na"]
+          patronType: ["p1"]
         },
         {
           id: "2",
           benefit: ["4"],
-          patronType: ["p1"],
-          serviceType: ["na"],
-          statusAndVitals: ["na"]
+          patronType: ["p1"]
         },
         {
           id: "3",
           benefit: ["2"],
-          patronType: ["p2"],
-          serviceType: ["na"],
-          statusAndVitals: ["na"]
+          patronType: ["p2"]
         },
         {
           id: "4",
           benefit: ["1"],
-          patronType: ["p3"],
-          serviceType: ["na"],
-          statusAndVitals: ["na"]
+          patronType: ["p3"]
         },
         {
           id: "5",
           benefit: ["3"],
-          patronType: ["p3"],
-          serviceType: ["na"],
-          statusAndVitals: ["na"]
+          patronType: ["p3"]
         },
         {
           id: "6",
           benefit: ["4"],
-          patronType: ["p3"],
-          serviceType: ["na"],
-          statusAndVitals: ["na"]
+          patronType: ["p3"]
         }
       ],
       multipleChoiceOptions: [

--- a/components/benefit_expansion.js
+++ b/components/benefit_expansion.js
@@ -43,7 +43,7 @@ export class BenefitExpansion extends Component {
       selectedNeeds,
       benefits,
       reduxState.needs,
-      reduxState.eligibilityPaths,
+      reduxState.benefitEligibility,
       reduxState.multipleChoiceOptions
     );
   };

--- a/pages/benefits-directory.js
+++ b/pages/benefits-directory.js
@@ -93,7 +93,8 @@ const mapStateToProps = (reduxState, props) => {
     filteredBenefits: getFilteredBenefits(reduxState, props),
     searchString: reduxState.searchString,
     selectedNeeds: reduxState.selectedNeeds,
-    benefits: reduxState.benefits
+    benefits: reduxState.benefits,
+    benefitEligibility: reduxState.benefitEligibility
   };
 };
 
@@ -107,7 +108,8 @@ BenefitsDirectory.propTypes = {
   searchString: PropTypes.string.isRequired,
   selectedNeeds: PropTypes.object.isRequired,
   setPageWidth: PropTypes.func.isRequired,
-  benefits: PropTypes.array.isRequired
+  benefits: PropTypes.array.isRequired,
+  benefitEligibility: PropTypes.array
 };
 
 export default withI18N(

--- a/selectors/benefits.js
+++ b/selectors/benefits.js
@@ -29,7 +29,6 @@ export const getFilteredBenefitsFunction = (
   let eligibleBenefitIds = [];
 
   // iterate through benefitEligibility table and any benefit that matches, add to the list (but don't add more than once!)
-  console.log(JSON.stringify(benefits));
   benefitEligibility.forEach(be => {
     if (benefitEligibilityMatch(be, profileFilters, multipleChoiceOptions)) {
       eligibleBenefitIds.push(be.benefit[0]);

--- a/selectors/benefits.js
+++ b/selectors/benefits.js
@@ -127,7 +127,6 @@ export const getFilteredBenefitsWithoutSearch = createSelector(
     getNeedsFilter,
     getBenefits,
     getNeeds,
-    getEligibilityPaths,
     getBenefitEligibility,
     getMultipleChoiceOptions,
     getQuestions
@@ -137,7 +136,6 @@ export const getFilteredBenefitsWithoutSearch = createSelector(
     selectedNeeds,
     benefits,
     needs,
-    eligibilityPaths,
     benefitEligibility,
     multipleChoiceOptions
   ) => {
@@ -146,7 +144,6 @@ export const getFilteredBenefitsWithoutSearch = createSelector(
       selectedNeeds,
       benefits,
       needs,
-      eligibilityPaths,
       benefitEligibility,
       multipleChoiceOptions
     );

--- a/selectors/benefits.js
+++ b/selectors/benefits.js
@@ -29,6 +29,7 @@ export const getFilteredBenefitsFunction = (
   let eligibleBenefitIds = [];
 
   // iterate through benefitEligibility table and any benefit that matches, add to the list (but don't add more than once!)
+  console.log(JSON.stringify(benefits));
   benefitEligibility.forEach(be => {
     if (benefitEligibilityMatch(be, profileFilters, multipleChoiceOptions)) {
       eligibleBenefitIds.push(be.benefit[0]);
@@ -101,7 +102,6 @@ export const benefitEligibilityMatch = (
       }
     }
   });
-
   return matches;
 };
 

--- a/utils/hardcoded_strings.js
+++ b/utils/hardcoded_strings.js
@@ -2,6 +2,7 @@ exports.tableNames = [
   "areaOffices",
   "benefits",
   "eligibilityPaths",
+  "benefitEligibility",
   "needs",
   "translations",
   "questions",


### PR DESCRIPTION
Closes #1680 

This changes over the eligibility matching in the benefits selector for the benefit cards to the new benefitEligibility format / table from airtable, instead of the old eligibilityPaths.

Old eligibility match code has not yet been removed as other content such as next steps is still using the old format.