### PR TITLE
Avoid use of http:// links unless necessary.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -233,7 +233,7 @@ See [SECURITY.md](/SECURITY.md) for more details
 ### Testing
 
 We are using a combination of unit tests and end-to-end tests to validate the code base. Unit tests are written
-using [`jest`](https://jestjs.io/) and [`enzyme`](http://airbnb.io/enzyme/). We have made the decision not to test for
+using [`jest`](https://jestjs.io/) and [`enzyme`](https://airbnb.io/enzyme/). We have made the decision not to test for
 correct styling, but rather focus on the logic in the components. We currently have over 200 tests that are run by CircleCI
 on every commit. PRs are not approved if code is added to the app without sufficient testing. PRs should not be merged
 if the tests do not pass.


### PR DESCRIPTION
This is a minor update to provide the https instead of http link in the docs.

I'll be creating a broader issue for the use of http:// links throughout the rest of the project. Feel free to merge this at will, it's a trivial change.