### PR TITLE
Made skip to main content button its own component, fixed language button bug

### DIFF
--- a/__tests__/components/skip_to_main_content_test.js
+++ b/__tests__/components/skip_to_main_content_test.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { mount } from "enzyme";
+import SkipToMainContent from "../../components/skip_to_main_content";
+const { axe, toHaveNoViolations } = require("jest-axe");
+expect.extend(toHaveNoViolations);
+
+describe("SkipToMainContent", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      skipLink: "/index",
+      t: x => x
+    };
+  });
+
+  it("passes axe tests", async () => {
+    let html = mount(<SkipToMainContent {...props} />).html();
+    expect(await axe(html)).toHaveNoViolations();
+  });
+});

--- a/components/federal_banner.js
+++ b/components/federal_banner.js
@@ -5,6 +5,7 @@ import { Button } from "@material-ui/core";
 import LanguageButton from "./language_button";
 import FIP from "./fip";
 import { globalTheme } from "../theme";
+import SkipToMainContent from "./skip_to_main_content";
 
 export const breakpoints = {
   xs: 481,
@@ -67,45 +68,12 @@ const container = css`
   `)};
 `;
 
-const skipLinkContainer = css`
-  position: absolute;
-  text-align: center;
-  width: 90%;
-  z-index: 3;
-  top: 10px;
-  left: 0px;
-  list-style: none;
-`;
-
-const skipLinkStyle = css`
-  width: 1px !important;
-  height: 1px !important;
-  overflow: hidden !important;
-  display: inline-block;
-  color: white;
-  text-decoration: none;
-  font-family: ${globalTheme.fontFamily};
-
-  :focus {
-    width: auto !important;
-    height: auto !important;
-    outline: 3px solid #ffbf47;
-    outline-offset: 0;
-  }
-`;
-
 class FederalBanner extends Component {
   render() {
     const { t, skipLink } = this.props;
     return (
       <div>
-        <ul className={skipLinkContainer}>
-          <li>
-            <a className={skipLinkStyle} href={skipLink} id="skipLink">
-              {t("skipLink")}
-            </a>
-          </li>
-        </ul>
+        <SkipToMainContent skipLink={skipLink} t={t} />
         <div className={container}>
           <div className="svg-container">
             <FIP fillColor="white" t={this.props.t} />

--- a/components/layout.js
+++ b/components/layout.js
@@ -74,7 +74,7 @@ class Layout extends Component {
           <Head title={title} t={t} />
           <ErrorBoundary>
             <Content>
-              <div className={header}>
+              <header className={header}>
                 <Container>
                   <FederalBanner
                     i18n={this.props.i18n}
@@ -96,7 +96,7 @@ class Layout extends Component {
                     </AlphaBanner>
                   </Container>
                 </div>
-              </div>
+              </header>
               <div role="main" id="main">
                 {this.props.children}
               </div>

--- a/components/skip_to_main_content.js
+++ b/components/skip_to_main_content.js
@@ -20,7 +20,7 @@ const skipLinkStyle = css`
   :focus {
     width: auto !important;
     height: auto !important;
-    outline: 3px solid #ffbf47;
+    outline: 3px solid ${globalTheme.colour.focusColour};
     outline-offset: 0;
   }
 `;

--- a/components/skip_to_main_content.js
+++ b/components/skip_to_main_content.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { css } from "emotion";
+import PropTypes from "prop-types";
+import { globalTheme } from "../theme";
+
+const skipLinkStyle = css`
+  z-index: 3;
+  text-align: center;
+  position: absolute;
+  top: 15px;
+  left: 50%;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  display: inline-block;
+  color: white;
+  text-decoration: none;
+  font-family: ${globalTheme.fontFamily};
+
+  :focus {
+    width: auto !important;
+    height: auto !important;
+    outline: 3px solid #ffbf47;
+    outline-offset: 0;
+  }
+`;
+
+const SkipToMainContent = props => {
+  return (
+    <a className={skipLinkStyle} href={props.skipLink} id="skipLink">
+      {props.t("skipLink")}
+    </a>
+  );
+};
+
+SkipToMainContent.propTypes = {
+  skipLink: PropTypes.string.isRequired,
+  t: PropTypes.func.isRequired
+};
+
+export default SkipToMainContent;


### PR DESCRIPTION
Closes #1702 

The language button is no longer obscured. So that the skip link will be read out by voiceover I made the div containing the federal+beta banners a header element (I got the idea from this page: https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html#). Voiceover focuses on the header initially, and then tabbing gets you to the skip button.