### PR TITLE
Fixed fontSize proptype

### DIFF
--- a/components/typography/anchor_link.js
+++ b/components/typography/anchor_link.js
@@ -37,7 +37,7 @@ AnchorLink.defaultProps = {
 };
 AnchorLink.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  fontSize: PropTypes.number,
+  fontSize: PropTypes.string,
   fontWeight: PropTypes.string,
   className: PropTypes.string
 };


### PR DESCRIPTION
Closes #1742 

The warning in the console is now gone.