### PR TITLE
Screenreader now reads number of saved benefits

### DIFF
--- a/components/BB.js
+++ b/components/BB.js
@@ -100,13 +100,14 @@ export class BB extends Component {
                     <HeaderLink
                       id="savedBenefits"
                       href={this.props.favouritesUrl}
+                      size="fullWidth"
                     >
                       <SaveChecked />
                       {t("B3.favouritesButtonText")}
+                      <span className={dot} id="favouritesDot">
+                        {this.props.favouriteBenefits.length}
+                      </span>
                     </HeaderLink>
-                    <span className={dot} id="favouritesDot">
-                      {this.props.favouriteBenefits.length}
-                    </span>
                   </Grid>
                   <Grid item xs={12}>
                     <HeaderButton

--- a/components/header_link.js
+++ b/components/header_link.js
@@ -33,6 +33,9 @@ const style = css`
 const small = css`
   font-size: 18px;
 `;
+const fullWidth = css`
+  width: 100%;
+`;
 
 const nowrap = css`
   white-space: nowrap;
@@ -58,20 +61,15 @@ class HeaderLink extends Component {
       ...otherProps
     } = this.props;
 
+    let cName;
+    if (size === "small") cName = cx(style, small, className);
+    else if (size === "fullWidth") cName = cx(style, fullWidth, className);
+    else if (altStyle === "grey") cName = cx(style, grey, className);
+    else cName = cx(style, className);
+
     return (
       <Link href={href}>
-        <a
-          className={
-            size === "small"
-              ? cx(style, small, className)
-              : altStyle === "grey"
-              ? cx(style, grey, className)
-              : cx(style, className)
-          }
-          href={href}
-          onClick={onClick}
-          {...otherProps}
-        >
+        <a className={cName} href={href} onClick={onClick} {...otherProps}>
           {arrow === "back" ? <ArrowBack /> : null}
           {children}
           {arrow === "forward" ? (


### PR DESCRIPTION
Closes #1759 

Currently just reads the number of benefits (so when the user tabs to the link they hear "Saved List 2" for example). If we want different / more information read, let me know and I will enhance this PR.