### PR TITLE
Improve accessibility for benefit list navigation

### DIFF
--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -76,83 +76,75 @@ export class BenefitCard extends Component {
 
     const searchWords = this.props.searchString.split(/\s+/);
     return (
-      <li
-        aria-label={
-          this.props.t("current-language-code") === "en"
-            ? benefit.vacNameEn
-            : benefit.vacNameFr
-        }
-      >
-        <Grid item xs={12}>
-          <div className={root}>
-            <Paper className={cardBody}>
-              <BenefitCardHeader
+      <Grid item xs={12}>
+        <div className={root}>
+          <Paper className={cardBody}>
+            <BenefitCardHeader
+              benefit={benefit}
+              t={t}
+              store={this.props.store}
+            />
+            <Header className={benefitName} size="sm" headingLevel="h2">
+              <Highlighter
+                searchWords={searchWords}
+                autoEscape={true}
+                textToHighlight={
+                  this.props.currentLanguage === "en"
+                    ? benefit.vacNameEn
+                    : benefit.vacNameFr
+                }
+              />
+            </Header>
+
+            <OneLiner className={"cardDescription " + cardDescriptionText}>
+              <Highlighter
+                searchWords={searchWords}
+                autoEscape={true}
+                textToHighlight={
+                  this.props.currentLanguage === "en"
+                    ? benefit.oneLineDescriptionEn
+                    : benefit.oneLineDescriptionFr
+                }
+              />
+            </OneLiner>
+            <div className={padding}>
+              {needsMet.map(need => (
+                <NeedTag key={benefit.id + need.id} t={t} need={need} />
+              ))}
+            </div>
+            {this.state.expanded ? (
+              <BenefitExpansion
+                className={padding}
                 benefit={benefit}
                 t={t}
                 store={this.props.store}
               />
-              <Header className={benefitName} size="sm" headingLevel="h2">
-                <Highlighter
-                  searchWords={searchWords}
-                  autoEscape={true}
-                  textToHighlight={
-                    this.props.currentLanguage === "en"
-                      ? benefit.vacNameEn
-                      : benefit.vacNameFr
-                  }
-                />
-              </Header>
+            ) : null}
 
-              <OneLiner className={"cardDescription " + cardDescriptionText}>
-                <Highlighter
-                  searchWords={searchWords}
-                  autoEscape={true}
-                  textToHighlight={
-                    this.props.currentLanguage === "en"
-                      ? benefit.oneLineDescriptionEn
-                      : benefit.oneLineDescriptionFr
-                  }
-                />
-              </OneLiner>
-              <div className={padding}>
-                {needsMet.map(need => (
-                  <NeedTag key={benefit.id + need.id} t={t} need={need} />
-                ))}
-              </div>
-              {this.state.expanded ? (
-                <BenefitExpansion
-                  className={padding}
-                  benefit={benefit}
-                  t={t}
-                  store={this.props.store}
-                />
-              ) : null}
-
-              <Grid container className={buttonRow}>
-                <Grid item xs={4}>
-                  <HeaderButton
-                    id={"see-more-less" + benefit.id}
-                    onClick={this.toggleExpanded}
-                    size="small"
-                  >
-                    {this.state.expanded ? t("B3.see_less") : t("B3.see_more")}
-                  </HeaderButton>
-                </Grid>
-                {this.props.showFavourite ? (
-                  <Grid item xs={8} className={alignRight}>
-                    <FavouriteButton
-                      benefit={benefit}
-                      toggleOpenState={() => {}}
-                      store={this.props.store}
-                      t={t}
-                    />
-                  </Grid>
-                ) : null}
+            <Grid container className={buttonRow}>
+              <Grid item xs={4}>
+                <HeaderButton
+                  id={"see-more-less" + benefit.id}
+                  onClick={this.toggleExpanded}
+                  size="small"
+                >
+                  {this.state.expanded ? t("B3.see_less") : t("B3.see_more")}
+                </HeaderButton>
               </Grid>
-            </Paper>
-          </div>
-        </Grid>
-      </li>
+              {this.props.showFavourite ? (
+                <Grid item xs={8} className={alignRight}>
+                  <FavouriteButton
+                    benefit={benefit}
+                    toggleOpenState={() => {}}
+                    store={this.props.store}
+                    t={t}
+                  />
+                </Grid>
+              ) : null}
+            </Grid>
+          </Paper>
+        </div>
+      </Grid>
     );
   }
 }

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -34,6 +34,7 @@ const buttonRow = css`
 `;
 const root = css`
   width: 100%;
+  display: block;
 `;
 const benefitName = css`
   padding-top: 35px;
@@ -75,75 +76,83 @@ export class BenefitCard extends Component {
 
     const searchWords = this.props.searchString.split(/\s+/);
     return (
-      <Grid item xs={12}>
-        <div className={root}>
-          <Paper className={cardBody}>
-            <BenefitCardHeader
-              benefit={benefit}
-              t={t}
-              store={this.props.store}
-            />
-            <Header className={benefitName} size="sm" headingLevel="h2">
-              <Highlighter
-                searchWords={searchWords}
-                autoEscape={true}
-                textToHighlight={
-                  this.props.currentLanguage === "en"
-                    ? benefit.vacNameEn
-                    : benefit.vacNameFr
-                }
-              />
-            </Header>
-
-            <OneLiner className={"cardDescription " + cardDescriptionText}>
-              <Highlighter
-                searchWords={searchWords}
-                autoEscape={true}
-                textToHighlight={
-                  this.props.currentLanguage === "en"
-                    ? benefit.oneLineDescriptionEn
-                    : benefit.oneLineDescriptionFr
-                }
-              />
-            </OneLiner>
-            <div className={padding}>
-              {needsMet.map(need => (
-                <NeedTag key={benefit.id + need.id} t={t} need={need} />
-              ))}
-            </div>
-            {this.state.expanded ? (
-              <BenefitExpansion
-                className={padding}
+      <li
+        aria-label={
+          this.props.t("current-language-code") === "en"
+            ? benefit.vacNameEn
+            : benefit.vacNameFr
+        }
+      >
+        <Grid item xs={12}>
+          <div className={root}>
+            <Paper className={cardBody}>
+              <BenefitCardHeader
                 benefit={benefit}
                 t={t}
                 store={this.props.store}
               />
-            ) : null}
+              <Header className={benefitName} size="sm" headingLevel="h2">
+                <Highlighter
+                  searchWords={searchWords}
+                  autoEscape={true}
+                  textToHighlight={
+                    this.props.currentLanguage === "en"
+                      ? benefit.vacNameEn
+                      : benefit.vacNameFr
+                  }
+                />
+              </Header>
 
-            <Grid container className={buttonRow}>
-              <Grid item xs={4}>
-                <HeaderButton
-                  id={"see-more-less" + benefit.id}
-                  onClick={this.toggleExpanded}
-                  size="small"
-                >
-                  {this.state.expanded ? t("B3.see_less") : t("B3.see_more")}
-                </HeaderButton>
-              </Grid>
-              {this.props.showFavourite ? (
-                <Grid item xs={8} className={alignRight}>
-                  <FavouriteButton
-                    benefit={benefit}
-                    toggleOpenState={() => {}}
-                    store={this.props.store}
-                    t={t}
-                  />
-                </Grid>
+              <OneLiner className={"cardDescription " + cardDescriptionText}>
+                <Highlighter
+                  searchWords={searchWords}
+                  autoEscape={true}
+                  textToHighlight={
+                    this.props.currentLanguage === "en"
+                      ? benefit.oneLineDescriptionEn
+                      : benefit.oneLineDescriptionFr
+                  }
+                />
+              </OneLiner>
+              <div className={padding}>
+                {needsMet.map(need => (
+                  <NeedTag key={benefit.id + need.id} t={t} need={need} />
+                ))}
+              </div>
+              {this.state.expanded ? (
+                <BenefitExpansion
+                  className={padding}
+                  benefit={benefit}
+                  t={t}
+                  store={this.props.store}
+                />
               ) : null}
-            </Grid>
-          </Paper>
-        </div>
-      </Grid>
+
+              <Grid container className={buttonRow}>
+                <Grid item xs={4}>
+                  <HeaderButton
+                    id={"see-more-less" + benefit.id}
+                    onClick={this.toggleExpanded}
+                    size="small"
+                  >
+                    {this.state.expanded ? t("B3.see_less") : t("B3.see_more")}
+                  </HeaderButton>
+                </Grid>
+                {this.props.showFavourite ? (
+                  <Grid item xs={8} className={alignRight}>
+                    <FavouriteButton
+                      benefit={benefit}
+                      toggleOpenState={() => {}}
+                      store={this.props.store}
+                      t={t}
+                    />
+                  </Grid>
+                ) : null}
+              </Grid>
+            </Paper>
+          </div>
+        </Grid>
+      </li>
     );
   }
 }

--- a/components/benefit_list.js
+++ b/components/benefit_list.js
@@ -93,15 +93,24 @@ export class BenefitList extends React.Component {
     ) : (
       <ul className={list}>
         {sortedBenefits.map((benefit, i) => (
-          <BenefitCard
-            id={"bc" + i}
-            benefit={benefit}
-            t={t}
-            currentLanguage={currentLanguage}
+          <li
             key={benefit.id}
-            showFavourite={showFavourites}
-            store={store}
-          />
+            aria-label={
+              this.props.t("current-language-code") === "en"
+                ? benefit.vacNameEn
+                : benefit.vacNameFr
+            }
+          >
+            <BenefitCard
+              id={"bc" + i}
+              benefit={benefit}
+              t={t}
+              currentLanguage={currentLanguage}
+              key={benefit.id}
+              showFavourite={showFavourites}
+              store={store}
+            />
+          </li>
         ))}
       </ul>
     );

--- a/components/benefit_list.js
+++ b/components/benefit_list.js
@@ -17,7 +17,7 @@ const list = css`
   list-style: none;
   padding-left: 0;
   margin-top: 0;
-  li {
+  > li {
     padding: 12px;
   }
 `;

--- a/components/benefit_list.js
+++ b/components/benefit_list.js
@@ -13,6 +13,15 @@ const Div = css`
   top: 40%;
 `;
 
+const list = css`
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
+  li {
+    padding: 12px;
+  }
+`;
+
 export class BenefitList extends React.Component {
   state = {
     loading: false
@@ -82,17 +91,19 @@ export class BenefitList extends React.Component {
         <CircularProgress size={100} />
       </div>
     ) : (
-      sortedBenefits.map((benefit, i) => (
-        <BenefitCard
-          id={"bc" + i}
-          benefit={benefit}
-          t={t}
-          currentLanguage={currentLanguage}
-          key={benefit.id}
-          showFavourite={showFavourites}
-          store={store}
-        />
-      ))
+      <ul className={list}>
+        {sortedBenefits.map((benefit, i) => (
+          <BenefitCard
+            id={"bc" + i}
+            benefit={benefit}
+            t={t}
+            currentLanguage={currentLanguage}
+            key={benefit.id}
+            showFavourite={showFavourites}
+            store={store}
+          />
+        ))}
+      </ul>
     );
   }
 }

--- a/components/child_benefit_list.js
+++ b/components/child_benefit_list.js
@@ -26,6 +26,8 @@ const heading = css`
 `;
 const listStyle = css`
   padding-left: 20px;
+  list-style: disc;
+  margin: 16px 0;
 `;
 
 const logExit = url => {

--- a/components/example_bullets.js
+++ b/components/example_bullets.js
@@ -15,8 +15,9 @@ const margin = css`
   li {
     margin-bottom: 10px;
     margin-left: 6px; // this is so bullets appear in 2nd column in IE
+    list-style: disc;
   }
-  margin-left: -6px;
+  margin: 16px 0px 16px -6px;
 `;
 
 const root = css`


### PR DESCRIPTION
Closes #1682 

Wrapped the benefits list in an <ul> and made each benefit card a <li>. Screenreaders now announce the number of items in the list, and group / announce each benefit card. It also indicates when you have reached the end of the list.