### PR TITLE
Don't render next steps if there are none

### DIFF
--- a/__tests__/components/BB_test.js
+++ b/__tests__/components/BB_test.js
@@ -50,7 +50,8 @@ describe("BB", () => {
       filteredBenefits: [],
       setSelectedNeeds: () => true,
       favouriteBenefits: [],
-      url: { query: {} }
+      url: { query: {} },
+      filteredNextSteps: nextStepsFixture
     };
     _shallowBB = undefined;
     _mountedBB = undefined;

--- a/__tests__/components/favourites_test.js
+++ b/__tests__/components/favourites_test.js
@@ -48,7 +48,8 @@ describe("Favourites", () => {
       },
       url: { query: {} },
       homeUrl: "/",
-      nextStepsRef: React.createRef()
+      nextStepsRef: React.createRef(),
+      filteredNextSteps: nextStepsFixture
     };
     _shallowFavourites = undefined;
     _mountedFavourites = undefined;

--- a/__tests__/components/next_steps_test.js
+++ b/__tests__/components/next_steps_test.js
@@ -33,6 +33,11 @@ describe("NextSteps", () => {
     );
   });
 
+  it("renders nothing if there are no next steps", () => {
+    props.filteredNextSteps = [];
+    expect(mount(<NextSteps {...props} />).html()).toEqual(null);
+  });
+
   it("renders an anchor tag if a markdown link is included", () => {
     expect(
       mount(<NextSteps {...props} />)

--- a/components/BB.js
+++ b/components/BB.js
@@ -10,6 +10,7 @@ import {
   getHomeUrl,
   getSummaryUrl
 } from "../selectors/urls";
+import { getFilteredNextSteps } from "../selectors/benefits";
 import { css } from "emotion";
 import Container from "../components/container";
 import HeaderButton from "./header_button";
@@ -106,7 +107,14 @@ export class BB extends Component {
   }
 
   render() {
-    const { t, url, store, homeUrl, favouriteBenefits } = this.props; // eslint-disable-line no-unused-vars
+    const {
+      t,
+      url,
+      store,
+      homeUrl,
+      favouriteBenefits,
+      filteredNextSteps
+    } = this.props; // eslint-disable-line no-unused-vars
     const longFavouritesText = t("favourites.saved_benefits", {
       x: favouriteBenefits.length
     });
@@ -142,15 +150,17 @@ export class BB extends Component {
                       <span className={shortText}>{shortFavouritesText}</span>
                     </HeaderLink>
                   </Grid>
-                  <Grid item xs={4} sm={12}>
-                    <HeaderButton
-                      id="nextSteps"
-                      onClick={() => this.scrollToNextSteps()}
-                    >
-                      <AssignmentTurnedIn />
-                      {t("nextSteps.whats_next")}
-                    </HeaderButton>
-                  </Grid>
+                  {filteredNextSteps.length > 0 ? (
+                    <Grid item xs={4} sm={12}>
+                      <HeaderButton
+                        id="nextSteps"
+                        onClick={() => this.scrollToNextSteps()}
+                      >
+                        <AssignmentTurnedIn />
+                        {t("nextSteps.whats_next")}
+                      </HeaderButton>
+                    </Grid>
+                  ) : null}
                   <Grid item xs={4} sm={12}>
                     <HeaderLink
                       id="editSelections"
@@ -224,7 +234,8 @@ const mapStateToProps = (reduxState, props) => {
     favouritesUrl: getFavouritesUrl(reduxState, props),
     homeUrl: getHomeUrl(reduxState, props),
     summaryUrl: getSummaryUrl(reduxState, props),
-    printUrl: getPrintUrl(reduxState, props, {})
+    printUrl: getPrintUrl(reduxState, props, {}),
+    filteredNextSteps: getFilteredNextSteps(reduxState, props)
   };
 };
 
@@ -239,7 +250,8 @@ BB.propTypes = {
   homeUrl: PropTypes.string,
   t: PropTypes.func.isRequired,
   favouriteBenefits: PropTypes.array.isRequired,
-  store: PropTypes.object
+  store: PropTypes.object,
+  filteredNextSteps: PropTypes.array
 };
 
 export default connect(

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -19,6 +19,7 @@ import BreadCrumbs from "./breadcrumbs";
 import ShareBox from "./share_box";
 import NextSteps from "./next_steps";
 import ContactUs from "./contact_us";
+import { getFilteredNextSteps } from "../selectors/benefits";
 
 const saveCSS = css`
   font-size: 70px !important;
@@ -93,7 +94,7 @@ export class Favourites extends Component {
   }
 
   render() {
-    const { t, url, homeUrl } = this.props; // eslint-disable-line no-unused-vars
+    const { t, url, homeUrl, filteredNextSteps } = this.props; // eslint-disable-line no-unused-vars
 
     const filteredBenefits = this.filterBenefits(
       this.props.benefits,
@@ -119,17 +120,19 @@ export class Favourites extends Component {
           <Grid container spacing={32}>
             <Grid item lg={3} md={3} sm={4} xs={12} className={sidebar}>
               <div className={sidebar}>
-                <Grid container spacing={16} className={sidebarLinks}>
-                  <Grid item xs={12}>
-                    <HeaderButton
-                      id="nextSteps"
-                      onClick={() => this.scrollToNextSteps()}
-                    >
-                      <AssignmentTurnedIn />
-                      {t("nextSteps.whats_next")}
-                    </HeaderButton>
+                {filteredNextSteps.length > 0 ? (
+                  <Grid container spacing={16} className={sidebarLinks}>
+                    <Grid item xs={12}>
+                      <HeaderButton
+                        id="nextSteps"
+                        onClick={() => this.scrollToNextSteps()}
+                      >
+                        <AssignmentTurnedIn />
+                        {t("nextSteps.whats_next")}
+                      </HeaderButton>
+                    </Grid>
                   </Grid>
-                </Grid>
+                ) : null}
                 <ShareBox
                   className={hideOnMobile}
                   t={t}
@@ -230,7 +233,8 @@ const mapStateToProps = (reduxState, props) => {
     cookiesDisabled: reduxState.cookiesDisabled,
     benefits: reduxState.benefits,
     printUrl: getPrintUrl(reduxState, props, { fromFavourites: true }),
-    homeUrl: getHomeUrl(reduxState, props)
+    homeUrl: getHomeUrl(reduxState, props),
+    filteredNextSteps: getFilteredNextSteps(reduxState, props)
   };
 };
 
@@ -243,7 +247,8 @@ Favourites.propTypes = {
   favouriteBenefits: PropTypes.array.isRequired,
   url: PropTypes.object.isRequired,
   homeUrl: PropTypes.string.isRequired,
-  store: PropTypes.object
+  store: PropTypes.object,
+  filteredNextSteps: PropTypes.array
 };
 
 export default connect(

--- a/components/next_steps.js
+++ b/components/next_steps.js
@@ -62,7 +62,7 @@ export class NextSteps extends Component {
     const { t } = this.props;
     const bullets = this.getBullets();
 
-    return (
+    return bullets.length > 0 ? (
       <div className={outerDiv}>
         <Grid container spacing={24}>
           <Grid item xs={12}>
@@ -84,7 +84,7 @@ export class NextSteps extends Component {
           </Grid>
         </Grid>
       </div>
-    );
+    ) : null;
   }
 }
 


### PR DESCRIPTION
Closes #1755 . Decided to implement it anyways since it was like a one line fix.

Currently there's no way to test this in the app, since there are 3 next steps in Airtable with no requirements.

I wrote a test for it in jest. If you want to test it in the app, you'll need to modify getBullets() to return an empty array.