### PR TITLE
remove react-moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "react-jss": "^8.6.1",
     "react-jsx-parser": "^1.13.0",
     "react-modal": "^3.7.1",
-    "react-moment": "^0.8.4",
     "react-redux": "^5.1.1",
     "redux": "^4.0.1",
     "redux-mock-store": "^1.5.3",

--- a/pages/data-validation.js
+++ b/pages/data-validation.js
@@ -6,7 +6,6 @@ import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import Paper from "../components/paper";
-import ReactMoment from "react-moment";
 import withI18N from "../lib/i18nHOC";
 import Layout from "../components/layout";
 import { connect } from "react-redux";
@@ -238,7 +237,7 @@ export class DataValidation extends Component {
             <p>
               {t("dv.last_cache_update")}
               :&nbsp;
-              <ReactMoment format="llll">{this.props.timestamp}</ReactMoment>
+              {Date(this.props.timestamp)}
             </p>
             <a href="/refresh">
               <Button id="refreshCache">{t("refresh-cache")}</Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8829,10 +8829,6 @@ react-modal@^3.7.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-moment@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/react-moment/-/react-moment-0.8.4.tgz#18eb59e1541c8b216353e23c21e9db50e42e2edb"
-
 react-redux@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.1.tgz#88e368682c7fa80e34e055cd7ac56f5936b0f52f"


### PR DESCRIPTION
fixes #1790 . refactor the data-validation page to not use react-moment. Basically, time of last Airtable cache used to look like

![image](https://user-images.githubusercontent.com/8228248/52146398-96658780-2631-11e9-951c-e98ee3c7c566.png)

now looks like

![image](https://user-images.githubusercontent.com/8228248/52146418-a41b0d00-2631-11e9-82d2-484b9abb4949.png)
