### PR TITLE
Fixing nextStepsFixture and next steps tests in benefits_test 

### DIFF
--- a/__tests__/fixtures/nextSteps.js
+++ b/__tests__/fixtures/nextSteps.js
@@ -2,26 +2,22 @@ const nextStepsFixture = [
   {
     variable_name: "ns_0",
     english: "bullet 0 [test link](/some_url)",
-    french: "french bullet 0",
-    eligibilityPath: ["ep_1"]
+    french: "french bullet 0"
   },
   {
     variable_name: "ns_1",
     english: "bullet 1",
-    french: "french bullet 1",
-    eligibilityPath: ["ep_2"]
+    french: "french bullet 1"
   },
   {
     variable_name: "ns_2",
     english: "bullet 2",
-    french: "french bullet 2",
-    eligibilityPath: ["ep_0"]
+    french: "french bullet 2"
   },
   {
     variable_name: "ns_3",
     english: "bullet 3",
-    french: "french bullet 3",
-    eligibilityPath: ["ep_0"]
+    french: "french bullet 3"
   }
 ];
 

--- a/__tests__/fixtures/nextSteps_complex.js
+++ b/__tests__/fixtures/nextSteps_complex.js
@@ -6,7 +6,7 @@ const nextSteps = [
     french:
       "Avez-vous planifi\u00e9 votre [entrevue de transition](http://www.veterans.gc.ca/fra/services/transition/interview)? Tout membre actif a droit \u00e0 un entretien avec un agent d\u2019ACC afin de s\u2019assurer que la transition de la vie militaire \u00e0 la vie civile se passe le mieux possible.",
     id: "recKyNwxKXQQGcokF",
-    patronType: "servingMember"
+    patronType: ["recC9OodJNCqbnGy2"]
   },
   {
     bullet_name: "doctorsNote",
@@ -15,7 +15,7 @@ const nextSteps = [
     french:
       "Assurez-vous d\u2019avoir en main un billet du m\u00e9decin attestant de votre probl\u00e8me de sant\u00e9 reli\u00e9 au service. Votre processus de demande d\u2019avantages en sera grandement facilit\u00e9.",
     id: "recp2EOCHfUhGU2jq",
-    patronType: "family",
+    patronType: ["recuWkVDSEWc1K0eU"],
     serviceType: "CAF"
   },
   {
@@ -25,7 +25,7 @@ const nextSteps = [
     french:
       "Assistez \u00e0 une s\u00e9ance du SPSC pour en apprendre davantage sur ce que l\u2019ACC peut faire pour vous.",
     id: "recdLLujXxdXQEzXC",
-    patronType: "servingMember"
+    patronType: ["recC9OodJNCqbnGy2"]
   },
   {
     bullet_name: "firstStep",

--- a/__tests__/fixtures/nextSteps_complex.js
+++ b/__tests__/fixtures/nextSteps_complex.js
@@ -14,7 +14,6 @@ const nextSteps = [
       "Make sure you have a doctor\u2019s note for your service-related health issue. This will make applying for these benefits go a lot smoother.",
     french:
       "Assurez-vous d\u2019avoir en main un billet du m\u00e9decin attestant de votre probl\u00e8me de sant\u00e9 reli\u00e9 au service. Votre processus de demande d\u2019avantages en sera grandement facilit\u00e9.",
-    eligibilityPath: ["recBlSOo6diB5tkwc"],
     id: "recp2EOCHfUhGU2jq",
     patronType: "family",
     serviceType: "CAF"
@@ -25,7 +24,6 @@ const nextSteps = [
       "Attend a SCAN session to learn more about what VAC can do for you.",
     french:
       "Assistez \u00e0 une s\u00e9ance du SPSC pour en apprendre davantage sur ce que l\u2019ACC peut faire pour vous.",
-    eligibilityPath: ["recR03cJel83BGYSD"],
     id: "recdLLujXxdXQEzXC",
     patronType: "servingMember"
   },
@@ -34,7 +32,6 @@ const nextSteps = [
     english:
       "If you are looking for more information please look at _See more_.",
     french: "(fra)If you are looking for more information look at See more.",
-    eligibilityPath: ["recDABExyenzg5QNw"],
     id: "recDGuWEo84Pie18s"
   },
   {
@@ -43,14 +40,12 @@ const nextSteps = [
       "If you wish to complete an application please see _Register for My VAC Account_.",
     french:
       "(fra)If you wish to complete an application please see _Register for My VAC Account_",
-    eligibilityPath: ["recDABExyenzg5QNw"],
     id: "recg5X7mEmlm4Qb2C"
   },
   {
     bullet_name: "thirdStep",
     english: "If you saved a card to your list please look at _Saved list_.",
     french: "(fra)If you saved a card to your list please look at Saved list.",
-    eligibilityPath: ["recDABExyenzg5QNw"],
     id: "recyxzgPs14QzD8uS"
   }
 ];

--- a/__tests__/selectors/benefits_test.js
+++ b/__tests__/selectors/benefits_test.js
@@ -218,14 +218,18 @@ describe("Benefits Selectors", () => {
 
   describe("getFilteredNextSteps", () => {
     it("displays all next steps if no eligibility paths are selected", () => {
-      expect(getFilteredNextSteps(state, props).length).toEqual(
-        nextStepsFixture.length
-      );
+      console.log(getFilteredNextSteps(state, props).length);
+      expect(getFilteredNextSteps(state, props).length).toEqual(3);
     });
 
     it("displays expected next steps if the patronType is organization", () => {
       state.patronType = "organization";
       expect(getFilteredNextSteps(state, props).length).toEqual(3);
+    });
+
+    it("displays expected next steps if the patronType is servingMember", () => {
+      state.patronType = "servingMember";
+      expect(getFilteredNextSteps(state, props).length).toEqual(5);
     });
   });
 });

--- a/__tests__/selectors/benefits_test.js
+++ b/__tests__/selectors/benefits_test.js
@@ -33,6 +33,8 @@ describe("Benefits Selectors", () => {
       needs: needsFixture,
       selectedNeeds: {},
       patronType: "",
+      statusAndVitals: "",
+      serviceHealthIssue: "",
       searchString: "",
       serviceType: "",
       benefitExamples: benefitExamplesFixture,
@@ -55,8 +57,8 @@ describe("Benefits Selectors", () => {
       );
       expect(returnValue.patronType).toEqual("p2");
       expect(returnValue.serviceType).toEqual("s1");
-      expect(returnValue.statusAndVitals).toEqual(undefined);
-      expect(returnValue.serviceHealthIssue).toEqual(undefined);
+      expect(returnValue.statusAndVitals).toEqual("");
+      expect(returnValue.serviceHealthIssue).toEqual("");
     });
   });
 
@@ -217,8 +219,7 @@ describe("Benefits Selectors", () => {
   });
 
   describe("getFilteredNextSteps", () => {
-    it("displays all next steps if no eligibility paths are selected", () => {
-      console.log(getFilteredNextSteps(state, props).length);
+    it("displays next steps with no eligibility requirements if no eligibility paths are selected", () => {
       expect(getFilteredNextSteps(state, props).length).toEqual(3);
     });
 

--- a/components/guided_experience_page.js
+++ b/components/guided_experience_page.js
@@ -17,8 +17,6 @@ export class GuidedExperiencePage extends Component {
       t("current-language-code") === "en"
         ? question.guided_experience_page_title_english
         : question.guided_experience_page_title_french;
-
-    console.log(reduxState);
     return (
       <Layout
         i18n={i18n}

--- a/components/guided_experience_page.js
+++ b/components/guided_experience_page.js
@@ -17,6 +17,8 @@ export class GuidedExperiencePage extends Component {
       t("current-language-code") === "en"
         ? question.guided_experience_page_title_english
         : question.guided_experience_page_title_french;
+
+    console.log(reduxState);
     return (
       <Layout
         i18n={i18n}


### PR DESCRIPTION
Closes #1700

Trying to figure out why the tests are failing.... `getFilteredNextSteps(state, props).length` should equal 3 when no selections, and should equal 5 when `patronType = servingMember`. Results are 6 and 3, respectively; 6 is the total number of next steps in the fixture, and 3 is the number of next steps with no eligibility attached.