### PR TITLE
Test json data

### DIFF
--- a/__tests__/data/area_offices_data_test.js
+++ b/__tests__/data/area_offices_data_test.js
@@ -14,17 +14,11 @@ describe("Area offices data", () => {
     data.forEach(a => {
       expect(
         !!a.address_en &&
-          a.address_en !== "" &&
           !!a.address_fr &&
-          a.address_fr !== "" &&
           !!a.lat &&
-          a.lat !== "" &&
           !!a.lng &&
-          a.lng !== "" &&
           !!a.name_en &&
-          a.name_en !== "" &&
-          !!a.name_fr &&
-          a.name_fr !== ""
+          !!a.name_fr
       ).toBeTruthy();
     });
   });

--- a/__tests__/data/area_offices_data_test.js
+++ b/__tests__/data/area_offices_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Area offices data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).areaOffices;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/area_offices_data_test.js
+++ b/__tests__/data/area_offices_data_test.js
@@ -9,4 +9,23 @@ describe("Area offices data", () => {
   it("is not empty", () => {
     expect(data).not.toHaveLength(0);
   });
+
+  it("has required fields in all rows", () => {
+    data.forEach(a => {
+      expect(
+        !!a.address_en &&
+          a.address_en !== "" &&
+          !!a.address_fr &&
+          a.address_fr !== "" &&
+          !!a.lat &&
+          a.lat !== "" &&
+          !!a.lng &&
+          a.lng !== "" &&
+          !!a.name_en &&
+          a.name_en !== "" &&
+          !!a.name_fr &&
+          a.name_fr !== ""
+      ).toBeTruthy();
+    });
+  });
 });

--- a/__tests__/data/area_offices_data_test.js
+++ b/__tests__/data/area_offices_data_test.js
@@ -12,14 +12,12 @@ describe("Area offices data", () => {
 
   it("has required fields in all rows", () => {
     data.forEach(a => {
-      expect(
-        !!a.address_en &&
-          !!a.address_fr &&
-          !!a.lat &&
-          !!a.lng &&
-          !!a.name_en &&
-          !!a.name_fr
-      ).toBeTruthy();
+      expect(a.address_en).toBeTruthy();
+      expect(a.address_fr).toBeTruthy();
+      expect(a.lat).toBeTruthy();
+      expect(a.lng).toBeTruthy();
+      expect(a.name_en).toBeTruthy();
+      expect(a.name_fr).toBeTruthy();
     });
   });
 });

--- a/__tests__/data/benefit_eligibility_data_test.js
+++ b/__tests__/data/benefit_eligibility_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Benefit eligibility data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).benefitEligibility;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/benefit_examples_data_test.js
+++ b/__tests__/data/benefit_examples_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Benefit examples data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).benefitExamples;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/benefits_data_test.js
+++ b/__tests__/data/benefits_data_test.js
@@ -9,4 +9,31 @@ describe("Benefits data", () => {
   it("is not empty", () => {
     expect(data).not.toHaveLength(0);
   });
+
+  it("has required fields in all rows", () => {
+    data.forEach(b => {
+      expect(
+        !!b.vacNameEn &&
+          b.vacNameEn !== "" &&
+          !!b.vacNameFr &&
+          b.vacNameFr !== "" &&
+          !!b.oneLineDescriptionEn &&
+          b.oneLineDescriptionEn !== "" &&
+          !!b.oneLineDescriptionFr &&
+          b.oneLineDescriptionFr !== ""
+        // !!b.benefitPageEn && b.benefitPageEn !== "" && currently failing :(
+        // !!b.benefitPageFr && b.benefitPageFr !== ""
+      ).toBeTruthy();
+    });
+  });
+
+  it("is in the eligibility table", () => {
+    data.forEach(b => {
+      expect(b.benefitEligibility).toBeTruthy();
+    });
+  });
+
+  it("has valid URLs in all rows", () => {
+    // complete this
+  });
 });

--- a/__tests__/data/benefits_data_test.js
+++ b/__tests__/data/benefits_data_test.js
@@ -32,8 +32,4 @@ describe("Benefits data", () => {
       expect(b.benefitEligibility).toBeTruthy();
     });
   });
-
-  it("has valid URLs in all rows", () => {
-    // complete this
-  });
 });

--- a/__tests__/data/benefits_data_test.js
+++ b/__tests__/data/benefits_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Benefits data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).benefits;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/benefits_data_test.js
+++ b/__tests__/data/benefits_data_test.js
@@ -12,14 +12,12 @@ describe("Benefits data", () => {
 
   it("has required fields in all rows", () => {
     data.forEach(b => {
-      expect(
-        !!b.vacNameEn &&
-          !!b.vacNameFr &&
-          !!b.oneLineDescriptionEn &&
-          !!b.oneLineDescriptionFr // &&
-        // !!b.benefitPageEn &&    currently failing
-        // !!b.benefitPageFr
-      ).toBeTruthy();
+      expect(b.vacNameEn).toBeTruthy();
+      expect(b.vacNameFr).toBeTruthy();
+      expect(b.oneLineDescriptionEn).toBeTruthy();
+      expect(b.oneLineDescriptionFr).toBeTruthy();
+      //expect(b.benefitPageEn).toBeTruthy()  currently failing
+      //expect(b.benefitPageFr).toBeTruthy()  currently failing
     });
   });
 

--- a/__tests__/data/benefits_data_test.js
+++ b/__tests__/data/benefits_data_test.js
@@ -14,15 +14,11 @@ describe("Benefits data", () => {
     data.forEach(b => {
       expect(
         !!b.vacNameEn &&
-          b.vacNameEn !== "" &&
           !!b.vacNameFr &&
-          b.vacNameFr !== "" &&
           !!b.oneLineDescriptionEn &&
-          b.oneLineDescriptionEn !== "" &&
-          !!b.oneLineDescriptionFr &&
-          b.oneLineDescriptionFr !== ""
-        // !!b.benefitPageEn && b.benefitPageEn !== "" && currently failing :(
-        // !!b.benefitPageFr && b.benefitPageFr !== ""
+          !!b.oneLineDescriptionFr // &&
+        // !!b.benefitPageEn &&    currently failing
+        // !!b.benefitPageFr
       ).toBeTruthy();
     });
   });

--- a/__tests__/data/multiple_choice_options_data_test.js
+++ b/__tests__/data/multiple_choice_options_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Multiple choice options data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).multipleChoiceOptions;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/needs_data_test.js
+++ b/__tests__/data/needs_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Needs data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).needs;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/next_steps_data_test.js
+++ b/__tests__/data/next_steps_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Next steps data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).nextSteps;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/question_clear_logic_data_test.js
+++ b/__tests__/data/question_clear_logic_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Question clear logic data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).questionClearLogic;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/question_display_logic_data_test.js
+++ b/__tests__/data/question_display_logic_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Question display logic data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).questionDisplayLogic;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/questions_data_test.js
+++ b/__tests__/data/questions_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Questions data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).questions;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/translations_data_test.js
+++ b/__tests__/data/translations_data_test.js
@@ -12,14 +12,7 @@ describe("Translations data", () => {
 
   it("has required fields in all rows", () => {
     data.forEach(t => {
-      expect(
-        !!t.key &&
-          t.key !== "" &&
-          !!t.English &&
-          t.English !== "" &&
-          !!t.French &&
-          t.French !== ""
-      ).toBeTruthy();
+      expect(!!t.key && !!t.English && !!t.French).toBeTruthy();
     });
   });
 });

--- a/__tests__/data/translations_data_test.js
+++ b/__tests__/data/translations_data_test.js
@@ -12,7 +12,9 @@ describe("Translations data", () => {
 
   it("has required fields in all rows", () => {
     data.forEach(t => {
-      expect(!!t.key && !!t.English && !!t.French).toBeTruthy();
+      expect(t.key).toBeTruthy();
+      expect(t.English).toBeTruthy();
+      expect(t.French).toBeTruthy();
     });
   });
 });

--- a/__tests__/data/translations_data_test.js
+++ b/__tests__/data/translations_data_test.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+describe("Translations data", () => {
+  let data;
+  beforeEach(() => {
+    data = JSON.parse(fs.readFileSync("data/data.json")).translations;
+  });
+
+  it("is not empty", () => {
+    expect(data).not.toHaveLength(0);
+  });
+});

--- a/__tests__/data/translations_data_test.js
+++ b/__tests__/data/translations_data_test.js
@@ -9,4 +9,17 @@ describe("Translations data", () => {
   it("is not empty", () => {
     expect(data).not.toHaveLength(0);
   });
+
+  it("has required fields in all rows", () => {
+    data.forEach(t => {
+      expect(
+        !!t.key &&
+          t.key !== "" &&
+          !!t.English &&
+          t.English !== "" &&
+          !!t.French &&
+          t.French !== ""
+      ).toBeTruthy();
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "docs": "styleguidist server",
     "docs:build": "styleguidist build",
     "bundle_analyzer": "BUNDLE_CHECK=true yarn build",
-    "download": "node scripts/download.js data/data.json"
+    "download": "node scripts/download.js data/data.json",
+    "test_urls": "node scripts/test_benefit_urls.js"
   },
   "dependencies": {
     "@emotion/core": "^10.0.4",

--- a/scripts/test_benefit_urls.js
+++ b/scripts/test_benefit_urls.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const urlCheck = require("../utils/url_check");
+
+const benefits = JSON.parse(fs.readFileSync("data/data.json")).benefits;
+
+benefits.map(b => {
+  Promise.resolve(urlCheck.fetchUrl(b.benefitPageEn)).then(result => {
+    if (!result) {
+      console.log(
+        `${b.vacNameEn}: Error connecting to benefitPageEn (${b.benefitPageEn})`
+      );
+    }
+  });
+  Promise.resolve(urlCheck.fetchUrl(b.benefitPageFr)).then(result => {
+    if (!result) {
+      console.log(
+        `${b.vacNameEn}: Error connecting to benefitPageFr (${b.benefitPageFr})`
+      );
+    }
+  });
+});

--- a/scripts/test_benefit_urls.js
+++ b/scripts/test_benefit_urls.js
@@ -3,7 +3,7 @@ const urlCheck = require("../utils/url_check");
 
 const benefits = JSON.parse(fs.readFileSync("data/data.json")).benefits;
 
-benefits.map(b => {
+const checkBenefitUrls = b => {
   Promise.resolve(urlCheck.fetchUrl(b.benefitPageEn)).then(result => {
     if (!result) {
       console.log(
@@ -18,4 +18,8 @@ benefits.map(b => {
       );
     }
   });
+};
+
+benefits.map((b, index) => {
+  setTimeout(() => checkBenefitUrls(b), index * 20);
 });

--- a/utils/url_check.js
+++ b/utils/url_check.js
@@ -1,6 +1,7 @@
 require("isomorphic-fetch");
 
 exports.checkURL = undefined;
+exports.fetchUrl = undefined;
 
 var checkURL = (exports.checkURL = async function checkURL(
   benefitId,
@@ -28,13 +29,13 @@ var checkURL = (exports.checkURL = async function checkURL(
   }
 });
 
-var fetchUrl = async function fetchURL(url) {
+var fetchUrl = (exports.fetchUrl = async function fetchURL(url) {
   return await fetch(url).then(
     resp => {
-      return resp.url !== url ? false : true;
+      return resp.url === url;
     },
     () => {
       return false;
     }
   );
-};
+});


### PR DESCRIPTION
resolves #1805 

Perform the tests that are on the data validation page on the static Airtable data (via `yarn test` and as part of CI).

The exception is the testing of the urls. I don't think they should be part of CI, as then CI could fail because of network flakiness. Instead I added a `yarn test_urls` function to test the urls manually.

Note that there's one benefit, (Peer Support) that currently fails the data-validation tests since it doesn't have a url. The corresponding lines in the jest tests are commented out in this PR.