### PR TITLE
Fix for share copy link function only working sometimes

### DIFF
--- a/components/share_modal.js
+++ b/components/share_modal.js
@@ -128,7 +128,9 @@ class ShareModal extends Component {
 
   copyText(e) {
     let t = e.target.dataset.copytarget;
-    let shareInput = t ? document.querySelector(t) : null;
+    let shareInput = t
+      ? document.querySelector("[id='" + t.substr(1) + "']")
+      : null; // substr to strip out the '#'
     try {
       if (navigator.clipboard) {
         navigator.clipboard.writeText(shareInput.value).then(() => {


### PR DESCRIPTION
Closes #1902 

see: https://stackoverflow.com/questions/37270787/uncaught-syntaxerror-failed-to-execute-queryselector-on-document