### PR TITLE
Move beta banner and adjust styling

### DIFF
--- a/__tests__/components/alpha_banner_test.js
+++ b/__tests__/components/alpha_banner_test.js
@@ -21,7 +21,8 @@ describe("AlphaBanner", () => {
       i18n: {
         changeLanguage: () => {}
       },
-      t: x => x
+      t: x => x,
+      url: { query: "test" }
     };
     _mountedAlphaBanner = undefined;
   });

--- a/__tests__/components/alpha_banner_test.js
+++ b/__tests__/components/alpha_banner_test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { AlphaBanner } from "../../components/alpha_banner";
+import translate from "../fixtures/translate";
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
 
@@ -21,8 +22,8 @@ describe("AlphaBanner", () => {
       i18n: {
         changeLanguage: () => {}
       },
-      t: x => x,
-      url: { query: "test" }
+      t: translate,
+      url: { query: { lng: "en" } }
     };
     _mountedAlphaBanner = undefined;
   });
@@ -35,5 +36,9 @@ describe("AlphaBanner", () => {
 
   it("shows the alpha badge", () => {
     expect(mountedAlphaBanner().find("PhaseBadge").length).toEqual(1);
+  });
+
+  it("contains a link to the feedback page", () => {
+    expect(mountedAlphaBanner().find("Link").length).toEqual(1);
   });
 });

--- a/__tests__/components/layout_test.js
+++ b/__tests__/components/layout_test.js
@@ -48,12 +48,4 @@ describe("Layout", () => {
     props.hideNoscript = true;
     expect(mountedLayout().find("Noscript").length).toEqual(0);
   });
-
-  it("contains a link to the feedback page", () => {
-    expect(
-      mountedLayout()
-        .find("Link")
-        .text()
-    ).toContain("beta_banner.link_text");
-  });
 });

--- a/components/BB.js
+++ b/components/BB.js
@@ -16,6 +16,7 @@ import Header from "./typography/header";
 import NextSteps from "./next_steps";
 import QuickLinks from "./quick_links";
 import StickyHeader from "./sticky_header";
+import AlphaBanner from "./alpha_banner";
 
 const divider = css`
   border-top: 2px solid ${globalTheme.colour.duckEggBlue};
@@ -80,6 +81,7 @@ export class BB extends Component {
           />
         </div>
         <Paper id={this.props.id} padding="md" className={innerDiv}>
+          <AlphaBanner t={t} url={url} />
           <Grid container spacing={32}>
             <Grid item xs={12}>
               <Header headingLevel="h1" size="xl">

--- a/components/BB.js
+++ b/components/BB.js
@@ -26,7 +26,7 @@ const outerDiv = css`
   padding-bottom: 100px;
 `;
 const innerDiv = css`
-  padding-top: 45px;
+  padding-top: 35px;
 `;
 const topMatter = css`
   background-color: ${globalTheme.colour.white};

--- a/components/BB.js
+++ b/components/BB.js
@@ -26,7 +26,7 @@ const outerDiv = css`
   padding-bottom: 100px;
 `;
 const innerDiv = css`
-  padding-top: 35px;
+  padding-top: 24px;
 `;
 const topMatter = css`
   background-color: ${globalTheme.colour.white};

--- a/components/alpha_banner.js
+++ b/components/alpha_banner.js
@@ -18,7 +18,7 @@ const noPadding = css`
 `;
 
 const bottomMargin = css`
-  margin-bottom: 1.5em;
+  margin-bottom: 24px;
 `;
 
 const Banner = css`
@@ -26,7 +26,7 @@ const Banner = css`
   display: -ms-flexbox;
   align-items: center;
   -ms-flex-align: center;
-  padding: 0 0 1rem 0;
+  padding: 0 0 24px 0;
   border-bottom: 4px solid ${globalTheme.colour.darkPaleGrey};
   margin: 0px;
   min-width: 20em;

--- a/components/alpha_banner.js
+++ b/components/alpha_banner.js
@@ -17,12 +17,17 @@ const noPadding = css`
   padding: 0;
 `;
 
+const bottomMargin = css`
+  margin-bottom: 1.5em;
+`;
+
 const Banner = css`
   display: flex;
   display: -ms-flexbox;
   align-items: center;
   -ms-flex-align: center;
-  padding: 0 0 1.5rem 0;
+  padding: 0 0 1rem 0;
+  border-bottom: 4px solid ${globalTheme.colour.darkPaleGrey};
   margin: 0px;
   min-width: 20em;
   color: ${globalTheme.colour.charcoalGrey};
@@ -42,7 +47,7 @@ export class AlphaBanner extends Component {
   render() {
     const { t, url, ...rest } = this.props;
     return (
-      <div>
+      <div className={bottomMargin}>
         <Container className={noPadding}>
           <aside {...rest} className={Banner}>
             <PhaseBadge phase={t("header.beta")} />

--- a/components/alpha_banner.js
+++ b/components/alpha_banner.js
@@ -40,7 +40,7 @@ const Banner = css`
  */
 export class AlphaBanner extends Component {
   render() {
-    const { children, t, url, ...rest } = this.props;
+    const { t, url, ...rest } = this.props;
     return (
       <div>
         <Container className={noPadding}>
@@ -64,8 +64,7 @@ AlphaBanner.propTypes = {
    * Heirarchy of child components to render within thr `Text` container
    */
   t: PropTypes.func.isRequired,
-  url: PropTypes.object.isRequired,
-  children: PropTypes.any
+  url: PropTypes.object.isRequired
 };
 
 export default AlphaBanner;

--- a/components/alpha_banner.js
+++ b/components/alpha_banner.js
@@ -1,46 +1,71 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { PhaseBadge } from "./phase_badge";
 import { css } from "emotion";
 import { globalTheme } from "../theme";
+import Container from "../components/container";
+import Link from "next/link";
+
+const white = css`
+  color: ${globalTheme.colour.charcoalGrey};
+  :focus {
+    outline: 3px solid ${globalTheme.colour.focusColour};
+  }
+`;
+
+const noPadding = css`
+  padding: 0;
+`;
 
 const Banner = css`
   display: flex;
   display: -ms-flexbox;
   align-items: center;
   -ms-flex-align: center;
-  padding: 1rem 0 1rem 0;
+  padding: 0 0 1.5rem 0;
   margin: 0px;
   min-width: 20em;
-  color: ${globalTheme.colour.white};
-  font: 0.694rem sans-serif;
+  color: ${globalTheme.colour.charcoalGrey};
+  font-family: ${globalTheme.fontFamilySerif};
   span:first-of-type {
     font-weight: 700 !important;
     padding: 0.2rem 0.7rem;
-    border-radius: 5px;
+    border-radius: 3px;
     background-color: ${globalTheme.colour.betaBlue};
+    margin-right: 1em;
   }
-`;
-
-const Text = css`
-  margin-left: 10px;
-  font-family: ${globalTheme.fontFamilySansSerif};
-  font-size: 12px;
 `;
 /**
  * Renders an alpha banner and renders passed children in the `Text` container
  */
-export const AlphaBanner = ({ children, t, ...rest }) => (
-  <aside {...rest} className={Banner}>
-    <PhaseBadge phase={t("header.beta")} />
-    <div className={Text}>{children}</div>
-  </aside>
-);
+export class AlphaBanner extends Component {
+  render() {
+    const { children, t, url, ...rest } = this.props;
+    return (
+      <div>
+        <Container className={noPadding}>
+          <aside {...rest} className={Banner}>
+            <PhaseBadge phase={t("header.beta")} />
+            <span>
+              {t("beta_banner.main")} &nbsp;
+              <Link href={{ pathname: "/feedback", query: url.query }}>
+                <a className={white}>{t("beta_banner.link_text")}</a>
+              </Link>
+            </span>
+          </aside>
+        </Container>
+      </div>
+    );
+  }
+}
 
 AlphaBanner.propTypes = {
   /**
    * Heirarchy of child components to render within thr `Text` container
    */
   t: PropTypes.func.isRequired,
+  url: PropTypes.object.isRequired,
   children: PropTypes.any
 };
+
+export default AlphaBanner;

--- a/components/alpha_banner.js
+++ b/components/alpha_banner.js
@@ -29,7 +29,6 @@ const Banner = css`
   padding: 0 0 24px 0;
   border-bottom: 4px solid ${globalTheme.colour.darkPaleGrey};
   margin: 0px;
-  min-width: 20em;
   color: ${globalTheme.colour.charcoalGrey};
   font-family: ${globalTheme.fontFamilySerif};
   span:first-of-type {
@@ -48,7 +47,7 @@ export class AlphaBanner extends Component {
     const { t, url, ...rest } = this.props;
     return (
       <div className={bottomMargin}>
-        <Container className={noPadding}>
+        <Container className={noPadding} mobileFullWidth>
           <aside {...rest} className={Banner}>
             <PhaseBadge phase={t("header.beta")} />
             <span>

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -28,7 +28,7 @@ const outerDiv = css`
   padding-bottom: 100px;
 `;
 const innerDiv = css`
-  padding-top: 35px;
+  padding-top: 24px;
 `;
 const headerPadding = css`
   margin-top: 7px;

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -18,6 +18,7 @@ import Cookies from "universal-cookie";
 import Paper from "./paper";
 import StickyHeader from "./sticky_header";
 import QuickLinks from "./quick_links";
+import AlphaBanner from "./alpha_banner";
 
 const divider = css`
   border-top: 2px solid ${globalTheme.colour.duckEggBlue};
@@ -97,6 +98,7 @@ export class Favourites extends Component {
             pageTitle={t("index.your_saved_benefits")}
           />
           <Paper padding="md" className={innerDiv}>
+            <AlphaBanner t={t} url={url} />
             <Grid container spacing={32}>
               <Grid item xs={12}>
                 <Header

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -28,7 +28,7 @@ const outerDiv = css`
   padding-bottom: 100px;
 `;
 const innerDiv = css`
-  padding-top: 45px;
+  padding-top: 35px;
 `;
 const headerPadding = css`
   margin-top: 7px;

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -36,6 +36,7 @@ const greyBox = css`
 
 const box = css`
   padding: 35px;
+  padding-top: 24px;
   @media only screen and (max-width: ${globalTheme.max.mobile}) {
     padding: 17px 26px 55px 26px;
   }

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -16,6 +16,7 @@ import HeaderButton from "./header_button";
 import Button from "./button";
 import Link from "next/link";
 import { getHomeUrl } from "../selectors/urls";
+import { AlphaBanner } from "./alpha_banner";
 
 const greyBox = css`
   background-color: ${globalTheme.colour.paleGreyTwo};
@@ -38,7 +39,6 @@ const box = css`
   @media only screen and (max-width: ${globalTheme.max.mobile}) {
     padding: 17px 26px 55px 26px;
   }
-  display: inline-flex;
 `;
 const alignRight = css`
   text-align: right;
@@ -191,6 +191,7 @@ export class GuidedExperience extends Component {
           />
         </div>
         <Paper padding="md" className={box}>
+          <AlphaBanner t={t} url={url} />
           <Grid container spacing={24}>
             {id === "patronType" ? (
               <React.Fragment>

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -35,7 +35,7 @@ const greyBox = css`
 `;
 
 const box = css`
-  padding: 50px;
+  padding: 35px;
   @media only screen and (max-width: ${globalTheme.max.mobile}) {
     padding: 17px 26px 55px 26px;
   }

--- a/components/guided_experience_needs.js
+++ b/components/guided_experience_needs.js
@@ -20,7 +20,7 @@ const needsList = css`
   -moz-columns: 2;
   max-width: 100%;
   padding-left: 0;
-  padding-top: 30px;
+  padding-top: 35px;
   @media (max-width: 599px) {
     columns: 1;
     -webkit-columns: 1;

--- a/components/guided_experience_needs.js
+++ b/components/guided_experience_needs.js
@@ -20,7 +20,7 @@ const needsList = css`
   -moz-columns: 2;
   max-width: 100%;
   padding-left: 0;
-  padding-top: 35px;
+  padding-top: 24px;
   @media (max-width: 599px) {
     columns: 1;
     -webkit-columns: 1;

--- a/components/layout.js
+++ b/components/layout.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { css } from "emotion";
 import styled from "@emotion/styled";
 import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
-import { AlphaBanner } from "../components/alpha_banner";
 import ErrorBoundary from "../components/error_boundary";
 import Head from "../components/head";
 import FeedbackBar from "../components/feedbackBar";
@@ -58,7 +57,7 @@ class Layout extends Component {
   }
 
   render() {
-    const { t, title, skipLink, url } = this.props;
+    const { t, title, skipLink } = this.props;
     const noScriptTag = this.props.hideNoscript ? null : <Noscript t={t} />;
     return (
       <MuiThemeProvider theme={theme}>
@@ -99,7 +98,6 @@ class Layout extends Component {
 
 Layout.propTypes = {
   children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-  url: PropTypes.object.isRequired,
   hideNoscript: PropTypes.bool.isRequired,
   i18n: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,

--- a/components/layout.js
+++ b/components/layout.js
@@ -12,11 +12,7 @@ import FederalBanner from "../components/federal_banner";
 import Noscript from "../components/noscript";
 import Container from "../components/container";
 import { globalTheme } from "../theme";
-import Link from "next/link";
 
-const alpha = css`
-  background-color: ${globalTheme.colour.alphaBlue};
-`;
 const Content = styled("div")`
   min-height: calc(100vh - 65px);
 `;
@@ -24,12 +20,7 @@ const header = css`
   background-color: ${globalTheme.colour.greyishBrownTwo};
   padding: 0px;
 `;
-const white = css`
-  color: white;
-  :focus {
-    outline: 3px solid ${globalTheme.colour.focusColour};
-  }
-`;
+
 const backgoundColour1 = css`
   background-color: ${globalTheme.colour.greyishBrownTwo};
 `;
@@ -83,16 +74,6 @@ class Layout extends Component {
                     skipLink={skipLink}
                   />
                 </Container>
-                <div className={alpha}>
-                  <Container>
-                    <AlphaBanner t={t}>
-                      {t("beta_banner.main")} &nbsp;
-                      <Link href={{ pathname: "/feedback", query: url.query }}>
-                        <a className={white}>{t("beta_banner.link_text")}</a>
-                      </Link>
-                    </AlphaBanner>
-                  </Container>
-                </div>
               </header>
               <div role="main" id="main">
                 {this.props.children}

--- a/components/phase_badge.js
+++ b/components/phase_badge.js
@@ -4,9 +4,9 @@ import styled from "@emotion/styled";
 import { globalTheme } from "../theme";
 
 const Badge = styled.span`
+  font-family: ${globalTheme.fontFamilySansSerif};
   line-height: 1.8;
   color: #fff;
-  border-radius: 0.125em;
   background-color: ${props =>
     props.phase === "alpha" ? "#e8026e" : "#ff5a02"};
   padding: 0.125rem 1rem;

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -15,6 +15,7 @@ import Details from "../components/details";
 require("isomorphic-fetch");
 import Raven from "raven-js";
 import Router from "next/router";
+import AlphaBanner from "../components/alpha_banner";
 
 const padding = css`
   padding-top: 15px;
@@ -86,6 +87,7 @@ export class Feedback extends Component {
         url={url}
       >
         <Container className={padding} id="mainContent">
+          <AlphaBanner t={t} url={url} />
           <HeaderButton
             onClick={() => {
               window.history.back();

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -18,13 +18,13 @@ import GuidedExperienceSummary from "../components/guided_experience_summary";
 import Body from "../components/typography/body";
 import { getFilteredBenefits } from "../selectors/benefits";
 import { getHomeUrl } from "../selectors/urls";
+import AlphaBanner from "../components/alpha_banner";
 
 const box = css`
   padding: 63px 63px 63px 63px;
   @media only screen and (max-width: ${globalTheme.max.mobile}) {
     padding: 26px 26px 55px 26px;
   }
-  display: inline-flex;
 `;
 const alignRight = css`
   text-align: right;
@@ -69,6 +69,7 @@ export class Summary extends Component {
             />
           </div>
           <Paper padding="md" className={box}>
+            <AlphaBanner t={t} url={url} />
             <Grid container spacing={24}>
               <Grid item xs={12} className={questions}>
                 <Header size="md_lg" headingLevel="h2">

--- a/theme.js
+++ b/theme.js
@@ -44,7 +44,7 @@ let theme = {
     alertYellow: "#fbb830",
     lightYellow: "#f9f4d3",
     alphaPink: "#d42dc9",
-    betaBlue: "#006de4",
+    betaBlue: "#634f70",
     alphaBlue: "#345075",
     salmon: "#ff6961",
     blueGrey: "#838d9b",


### PR DESCRIPTION
Closes #1851 

Implemented the styling from https://app.zeplin.io/project/5acbd659dc553ec84805afd4/screen/5b45ad8f38da59ab5e754fe3
not what's in the issue. The background colour of the beta banner will require somewhat significant refactoring of the markup layout, so will flag for design and decide how to proceed.