### PR TITLE
Content update

### DIFF
--- a/__tests__/fixtures/questions.js
+++ b/__tests__/fixtures/questions.js
@@ -4,7 +4,7 @@ const questionsFixture = [
     multiple_choice_options: ["service-person", "family", "organization"],
     display_text_english: "My selection:",
     display_text_french: "Ma sélection:",
-    guided_experience_english: "Select who will be receiving the benefits.",
+    guided_experience_english: "Select who would be receiving the benefits.",
     guided_experience_french: "Montre moi des avantages pour:",
     id: "recwwXPBszQacaMsb",
     tooltip_english: "tooltip_patronType_en",

--- a/__tests__/fixtures/questions_complex.js
+++ b/__tests__/fixtures/questions_complex.js
@@ -10,10 +10,10 @@ const questions = [
     display_text_english: "My selection:",
     display_text_french: "Ma sélection:",
     "question display logic": ["recn0zobKUhFIowAh", "recdXDG6qy8fOltJr"],
-    guided_experience_english: "Select who will be receiving the benefits.",
+    guided_experience_english: "Select who would be receiving the benefits.",
     guided_experience_french: "Sélectionnez qui recevra les services.",
     guided_experience_page_title_english:
-      "Select who will be receiving the benefits.",
+      "Select who would be receiving the benefits.",
     guided_experience_page_title_french:
       "Sélectionnez qui recevra les services.",
     breadcrumb_english: "Benefit recipient",

--- a/cypress/integration/guided_experience_spec.js
+++ b/cypress/integration/guided_experience_spec.js
@@ -7,7 +7,7 @@ describe("Guided Experience", function() {
   });
 
   it("successfully loads start page", () => {
-    cy.contains("Select who will be receiving the benefits.");
+    cy.contains("Select who would be receiving the benefits.");
   });
 
   it("can skip through to benefits-directory", () => {
@@ -35,6 +35,6 @@ describe("Guided Experience", function() {
   it("can go back from summary and edit answer", () => {
     cy.visit("summary");
     cy.get("#edit-patronType").click();
-    cy.contains("Select who will be receiving the benefits.");
+    cy.contains("Select who would be receiving the benefits.");
   });
 });

--- a/data/data.json
+++ b/data/data.json
@@ -862,7 +862,6 @@
         "recPl2BKSR89x0mGN",
         "recHXVbwGofjJnMhY"
       ],
-      "benefitEligibility": ["recFXLOY29h9a5OSp"],
       "seeMoreSentenceEn": "Some examples of what this program may provide:",
       "seeMoreSentenceFr": "Quelques exemples de ce que ce programme peut fournir :",
       "id": "recsRSTzSMCIkxnnJ",
@@ -870,7 +869,8 @@
       "childBenefits": [],
       "benefitPolicyEn": "",
       "benefitPolicyFR": "",
-      "examples": ""
+      "examples": "",
+      "benefitEligibility": []
     },
     {
       "vacNameEn": "Treatment benefits",
@@ -1583,15 +1583,6 @@
       "serviceHealthIssue": ["recAmXQ89MNnaecZu"],
       "Name": "recJjXjUz5Ax5cher",
       "path": "family + CAF, WSV (WWII or Korea), RCMP + deceased + hasServiceHealthIssue"
-    },
-    {
-      "benefit": ["recsRSTzSMCIkxnnJ"],
-      "patronType": ["recFABO2SLhcwRkjT"],
-      "serviceType": ["rec9TxYv9brvsbp2P", "recLd3F8AA3l2DSGN"],
-      "Name": "recFXLOY29h9a5OSp",
-      "path": "servingMember + CAF, RCMP",
-      "statusAndVitals": [],
-      "serviceHealthIssue": []
     },
     {
       "benefit": ["rechXeFmQ9yIZpt37"],
@@ -3300,11 +3291,11 @@
       "id": "titles.1_saved_benefit"
     },
     {
-      "id": "links.myvac",
       "section": "links",
       "key": "myvac",
       "English": "https://www.veterans.gc.ca/eng/e_services/?utm_source=fbas",
-      "French": "https://www.veterans.gc.ca/fra/e_services/?utm_source=fbas"
+      "French": "https://www.veterans.gc.ca/fra/e_services/?utm_source=fbas",
+      "id": "links.myvac"
     }
   ],
   "questions": [
@@ -3319,7 +3310,7 @@
       "display_text_english": "My selection:",
       "display_text_french": "Ma sélection:",
       "question display logic": ["recqrmO0TSWr3Sal8", "recgoq6VzwN19P7ui"],
-      "guided_experience_english": "Select who will be receiving the benefits.",
+      "guided_experience_english": "Select who would be receiving the benefits.",
       "guided_experience_french": "Sélectionnez qui recevra les services.",
       "guided_experience_page_title_english": "Select who would be receiving the benefits.",
       "guided_experience_page_title_french": "Sélectionnez qui recevra les services.",
@@ -3513,7 +3504,6 @@
         "recD0T5A745koaYs4",
         "recjyIt9cm0Q0fex8",
         "recxvf53GWGPOONpe",
-        "recFXLOY29h9a5OSp",
         "recj42X5sBINDRIBl"
       ],
       "nextSteps": [
@@ -3640,7 +3630,6 @@
         "rec5rbCaZaiqSivuZ",
         "recWIN9A7KLaH3ESa",
         "recWH4cNVr9CDfW7i",
-        "recFXLOY29h9a5OSp",
         "recEvCUXPtqLG8ht1",
         "recj42X5sBINDRIBl",
         "recwHANeVjaGAzFQO",
@@ -3664,8 +3653,7 @@
       "benefitEligibility 3": [
         "recJjXjUz5Ax5cher",
         "recxvf53GWGPOONpe",
-        "recWH4cNVr9CDfW7i",
-        "recFXLOY29h9a5OSp"
+        "recWH4cNVr9CDfW7i"
       ],
       "key (DO NOT EDIT)": "RCMP",
       "id": "recLd3F8AA3l2DSGN",
@@ -4585,5 +4573,5 @@
     }
   ],
   "errors": [],
-  "timestamp": 1551372536122
+  "timestamp": 1551790127073
 }


### PR DESCRIPTION
Scott requested this a content update to ensure Transition interview is invisible in the app.

FYI, maybe it's worth reevaluating some tests. The cypress tests failed in the first push because "Select who will be receiving the benefits" was hardcoded in several places. Updating to "Select who would be receiving the benefits" fixed them. Should these lines be hardcoded?