### PR TITLE
fixed material ui typography warning

### DIFF
--- a/__tests__/components/favourite_button_test.js
+++ b/__tests__/components/favourite_button_test.js
@@ -36,13 +36,15 @@ describe("FavouriteButton", () => {
 
   it("is favourited if in list", () => {
     let mounted = mount(<FavouriteButton {...props} />);
-    expect(mounted.find("svg").hasClass("saved")).toEqual(true);
+    expect(mounted.find("span").html()).toContain(
+      "B3.favouritesButtonTextRemove"
+    );
   });
 
   it("is not favourited if not in list", () => {
     props.favouriteBenefits = [];
     let mounted = mount(<FavouriteButton {...props} />);
-    expect(mounted.find("svg").hasClass("notSaved")).toEqual(true);
+    expect(mounted.find("span").html()).toContain("B3.favouritesButtonBText");
   });
 
   it("has a working toggleFavourite function", async () => {

--- a/__tests__/components/needs_selector_test.js
+++ b/__tests__/components/needs_selector_test.js
@@ -30,7 +30,8 @@ describe("NeedsSelector", () => {
     props = {
       theme: {},
       t: key => key,
-      saveQuestionResponse: jest.fn()
+      saveQuestionResponse: jest.fn(),
+      url: {}
     };
     reduxData = {
       needs: needsFixture,

--- a/__tests__/components/no_results_buttons_test.js
+++ b/__tests__/components/no_results_buttons_test.js
@@ -1,6 +1,6 @@
 import NoResultsButtons from "../../components/no_results_buttons";
 import React from "react";
-import { mount, shallow } from "enzyme";
+import { mount } from "enzyme";
 
 const { axe, toHaveNoViolations } = require("jest-axe");
 expect.extend(toHaveNoViolations);
@@ -22,7 +22,7 @@ describe("NoResultsButtons", () => {
 
   it("contains 2 buttons", () => {
     expect(
-      shallow(<NoResultsButtons {...props} />).find("Button").length
+      mount(<NoResultsButtons {...props} />).find("Button").length
     ).toEqual(2);
   });
 });

--- a/components/BB.js
+++ b/components/BB.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import { connect } from "react-redux";
 import { getPrintUrl, getHomeUrl } from "../selectors/urls";
 import { withTheme } from "@material-ui/core/styles";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Container from "../components/container";
 import { globalTheme } from "../theme";
 import { DisabledCookiesBanner } from "./disabled_cookies_banner";
@@ -101,7 +102,7 @@ export class BB extends Component {
             pageTitle={t("ge.Find benefits and services")}
           />
         </div>
-        <Paper id={this.props.id} padding="md" className={innerDiv}>
+        <Paper id={this.props.id} padding="md" styles={innerDiv}>
           <AlphaBanner t={t} url={url} />
           <Grid container spacing={32}>
             <Grid item xs={12}>
@@ -124,15 +125,15 @@ export class BB extends Component {
                 <Header
                   headingLevel="h2"
                   size="md_lg"
-                  className={stylingWithSidebar}
+                  styles={stylingWithSidebar}
                 >
                   {t("titles.benefits_and_services")}
                 </Header>
               </div>
-              <div className={selectionsEditorMobileStyle}>
+              <div css={selectionsEditorMobileStyle}>
                 <SelectionsEditorMobile t={t} store={store} url={url} />
               </div>
-              <div className={selectionsEditorStyle}>
+              <div css={selectionsEditorStyle}>
                 <SelectionsEditor t={t} store={store} url={url} />
               </div>
             </Grid>
@@ -152,7 +153,7 @@ export class BB extends Component {
               <BenefitsPane id="BenefitsPane" t={t} store={store} url={url} />
             </Grid>
             <Grid item xs={12}>
-              <div className={divider} />
+              <div css={divider} />
             </Grid>
             <Grid item md={4} xs={12}>
               <div id="next-steps">

--- a/components/benefit_card_header.js
+++ b/components/benefit_card_header.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 import CardHeaderParentInfo from "./card_header_parent_info";
 import CardHeaderImportantInfo from "./card_header_important_info";
@@ -49,9 +50,9 @@ export class BenefitCardHeader extends Component {
 
     if (includeParentInfo || includeImportantInfo) {
       return (
-        <div className={cardTop}>
+        <div css={cardTop}>
           <AlertIcon t={t} />
-          <div className={headerDesc}>
+          <div css={headerDesc}>
             {includeParentInfo ? (
               <CardHeaderParentInfo
                 t={t}

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import Highlighter from "react-highlight-words";
@@ -6,7 +6,8 @@ import FavouriteButton from "./favourite_button";
 import Paper from "./paper";
 import { connect } from "react-redux";
 import NeedTag from "./need_tag";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import BenefitExpansion from "./benefit_expansion";
 import BenefitCardHeader from "./benefit_card_header";
 import OneLiner from "./typography/one_liner";
@@ -89,15 +90,15 @@ export class BenefitCard extends Component {
     const searchWords = this.props.searchString.split(/\s+/);
     return (
       <Grid item xs={12}>
-        <div className={root}>
-          <Paper className={cardBody}>
+        <div css={root}>
+          <Paper styles={cardBody}>
             <BenefitCardHeader
               benefit={benefit}
               t={t}
               store={this.props.store}
               language={language}
             />
-            <Header className={benefitName} size="md" headingLevel="h2">
+            <Header styles={benefitName} size="md" headingLevel="h2">
               <Highlighter
                 searchWords={searchWords}
                 autoEscape={true}
@@ -117,8 +118,8 @@ export class BenefitCard extends Component {
                 />
               ) : null}
             </Header>
-            <div className={padding}>
-              {needsMet.length > 0 ? <Tag className={tagStyle} /> : null}
+            <div css={padding}>
+              {needsMet.length > 0 ? <Tag styles={tagStyle} /> : null}
               {needsMet.map(need => (
                 <NeedTag
                   key={benefit.id + need.id}
@@ -128,7 +129,10 @@ export class BenefitCard extends Component {
                 />
               ))}
             </div>
-            <OneLiner className={"cardDescription " + cardDescriptionText}>
+            <OneLiner
+              className={"cardDescription"}
+              styles={cardDescriptionText}
+            >
               <Highlighter
                 searchWords={searchWords}
                 autoEscape={true}
@@ -140,19 +144,19 @@ export class BenefitCard extends Component {
               />
             </OneLiner>
 
-            <Grid container className={buttonRow}>
+            <Grid container css={buttonRow}>
               <Grid item xs={12}>
                 <BenefitExpansion
-                  className={padding}
+                  css={padding}
                   benefit={benefit}
                   t={t}
                   store={store}
                 />
               </Grid>
               <Grid item xs={12}>
-                <div className={flex}>
+                <div css={flex}>
                   <LearnMoreButton benefit={benefit} t={t} />
-                  <div className={floatRight}>
+                  <div css={floatRight}>
                     {this.props.savedList ? (
                       <FavouriteButton
                         benefit={benefit}

--- a/components/benefit_expansion.js
+++ b/components/benefit_expansion.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { connect } from "react-redux";
 import ChildBenefitList from "./child_benefit_list";
 import {
@@ -82,7 +83,7 @@ export class BenefitExpansion extends Component {
     });
 
     return (
-      <div className={topBorder}>
+      <div css={topBorder}>
         <ExampleBullets
           benefit={benefit}
           t={t}
@@ -116,7 +117,7 @@ BenefitExpansion.propTypes = {
   benefit: PropTypes.object.isRequired,
   reduxState: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
-  className: PropTypes.string,
+  css: PropTypes.string,
   store: PropTypes.object
 };
 

--- a/components/benefit_list.js
+++ b/components/benefit_list.js
@@ -4,7 +4,8 @@ import BenefitCard from "./benefit_cards";
 
 import CircularProgress from "@material-ui/core/CircularProgress";
 
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const Div = css`
   width: 100%;
@@ -87,11 +88,11 @@ export class BenefitList extends React.Component {
       : this.sortBenefits(filteredBenefits);
 
     return loading ? (
-      <div className={Div}>
+      <div css={Div}>
         <CircularProgress size={100} />
       </div>
     ) : (
-      <ul className={list}>
+      <ul css={list}>
         {sortedBenefits.map((benefit, i) => (
           <li
             key={benefit.id}

--- a/components/benefits_pane.js
+++ b/components/benefits_pane.js
@@ -10,7 +10,8 @@ import {
   getFilteredBenefits,
   getNonFilteredBenefits
 } from "../selectors/benefits";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Header from "./typography/header";
 import SearchBox from "./search_box";
 import { getBenefitCountString } from "../utils/common";
@@ -87,7 +88,8 @@ export class BenefitsPane extends Component {
       <Grid container spacing={16}>
         <Grid item xs={12}>
           <Header
-            className={"BenefitsCounter " + title}
+            className={"BenefitsCounter"}
+            styles={title}
             size="md"
             headingLevel="h3"
             autoFocus={true}
@@ -112,7 +114,7 @@ export class BenefitsPane extends Component {
         {filteredBenefitsWithoutSearch.length === 0 ? null : (
           <React.Fragment>
             <Grid item xs={12}>
-              <div className={bottomPadding}>
+              <div css={bottomPadding}>
                 <SearchBox
                   inputId="bbSearchField"
                   buttonId="searchButtonLink"
@@ -146,9 +148,7 @@ export class BenefitsPane extends Component {
                   store={store}
                 />
 
-                {nonFilteredBenefits.length > 0 ? (
-                  <div className={spacer} />
-                ) : null}
+                {nonFilteredBenefits.length > 0 ? <div css={spacer} /> : null}
                 <ResultsHeader
                   benefitCount={nonFilteredBenefits.length}
                   headerText={t("B3.results_all_benefits")}

--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../theme";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import HeaderLink from "./header_link";
 
 const greyBanner = css`
@@ -41,25 +42,25 @@ export class BreadCrumbs extends Component {
   render() {
     const { breadcrumbs, homeUrl } = this.props;
     return (
-      <div className={greyBanner}>
+      <div css={greyBanner}>
         <div>
-          <HeaderLink id="homeButton" href={homeUrl} className={urlStyle}>
+          <HeaderLink id="homeButton" href={homeUrl} css={urlStyle}>
             {this.props.t("titles.home")}
           </HeaderLink>
           {breadcrumbs.map((breadcrumb, i) => (
             <span key={"breadcrumb" + i}>
-              <span className={separator}>{" > "}</span>
+              <span css={separator}>{" > "}</span>
               <HeaderLink
                 id={"breadcrumb" + i}
                 href={breadcrumb.url}
-                className={urlStyle}
+                css={urlStyle}
               >
                 {breadcrumb.name}
               </HeaderLink>
             </span>
           ))}
-          <span className={separator}>{" > "}</span>
-          <span className={currentPageStyle}>{this.props.pageTitle}</span>
+          <span css={separator}>{" > "}</span>
+          <span css={currentPageStyle}>{this.props.pageTitle}</span>
         </div>
       </div>
     );

--- a/components/button.js
+++ b/components/button.js
@@ -1,7 +1,7 @@
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import styled from "@emotion/styled";
 import PropTypes from "prop-types";
-import React from "react";
 import { globalTheme } from "../theme";
 
 const StyledButton = styled("button")(
@@ -90,7 +90,7 @@ const Button = ({ size, secondary, children, icon, ...props }) => (
     isBig={size === "big"}
     isSmall={size === "small"}
     isSecondary={secondary}
-    className={props.mobileFullWidth ? mobileFullWidth : ""}
+    css={props.mobileFullWidth ? mobileFullWidth : ""}
     {...props}
   >
     {children}

--- a/components/card_details.js
+++ b/components/card_details.js
@@ -1,7 +1,7 @@
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 import ExpandMore from "./icons/ExpandMore";
 
@@ -62,8 +62,8 @@ const CardDetails = ({ summary, children, ...props }) => (
   <StyledDetails {...props}>
     <StyledSummary>
       <div>{summary}</div>
-      <div className={flex2}>
-        <ExpandMore className="icon" />
+      <div css={flex2}>
+        <ExpandMore css="icon" />
       </div>
     </StyledSummary>
     <DetailsText>{children}</DetailsText>

--- a/components/card_header_parent_info.js
+++ b/components/card_header_parent_info.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { logEvent } from "../utils/analytics";
 import { globalTheme } from "../theme";
 
@@ -25,7 +26,7 @@ export class CardHeaderParentInfo extends Component {
     let a_elements = parentBenefits.map((b, i) => (
       <a
         key={"a" + i}
-        className={headerUrl}
+        css={headerUrl}
         href={this.benefitUrl(b)}
         rel="noopener noreferrer"
         onClick={() => {

--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -1,14 +1,16 @@
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 import { globalTheme } from "../theme";
 import { uuidv4 } from "../utils/common";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const StyledCheckbox = styled("label")({
   display: "block",
   position: "relative",
-  padding: "0 0 0 38px"
+  padding: "0 0 0 38px",
+  marginBottom: "10px",
+  marginRight: "10px"
 });
 
 const StyledInput = styled("input")(
@@ -85,14 +87,12 @@ const sidebarLabelStyle = css({
   padding: "6px 10px 15px 12px !important"
 });
 
-const Checkbox = ({ children, className, sidebar, ...props }) => {
+const Checkbox = ({ children, sidebar, ...props }) => {
   const guid = uuidv4();
   return (
-    <StyledCheckbox className={className} htmlFor={guid}>
+    <StyledCheckbox htmlFor={guid}>
       <StyledInput type="checkbox" {...props} id={guid} />
-      <StyledLabel
-        className={cx(mobileLabelStyle, sidebar ? sidebarLabelStyle : null)}
-      >
+      <StyledLabel css={[mobileLabelStyle, sidebar ? sidebarLabelStyle : null]}>
         {children}
       </StyledLabel>
     </StyledCheckbox>
@@ -100,18 +100,11 @@ const Checkbox = ({ children, className, sidebar, ...props }) => {
 };
 
 Checkbox.defaultProps = {
-  className: undefined
+  styles: undefined
 };
 
 Checkbox.propTypes = {
-  /**
-   * Text content for checkbox
-   */
   children: PropTypes.node.isRequired,
-  /**
-   * CSS Classname for outermost container
-   */
-  className: PropTypes.string,
   sidebar: PropTypes.bool
 };
 

--- a/components/child_benefit_list.js
+++ b/components/child_benefit_list.js
@@ -1,6 +1,6 @@
-import React from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import HeaderLink from "./header_link";
 import { logEvent } from "../utils/analytics";
 import CardDetails from "./card_details";
@@ -35,14 +35,14 @@ const ChildBenefitList = props => {
   const language = t("current-language-code");
   return (
     <CardDetails summary={colonText}>
-      <div className={children}>
+      <div css={children}>
         <div>
-          <ul className={listStyle}>
+          <ul css={listStyle}>
             {benefits.map(cb => (
-              <li key={cb.id} className={liStyle}>
+              <li key={cb.id} css={liStyle}>
                 <HeaderLink
                   rel="noopener noreferrer"
-                  className={heading}
+                  css={heading}
                   size="small"
                   href={language === "en" ? cb.benefitPageEn : cb.benefitPageFr}
                   onClick={() => {

--- a/components/container.js
+++ b/components/container.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const vacStyle = css`
   padding-right: 15px;
@@ -29,11 +30,11 @@ const morePaddingIfBig = css`
 
 class Container extends Component {
   render() {
-    let className = vacStyle;
-    if (this.props.className) className = cx(vacStyle, this.props.className);
+    let css = vacStyle;
+    if (this.props.className) css = [vacStyle, this.props.className];
     return (
-      <div className={className} id={this.props.id ? this.props.id : ""}>
-        <div className={morePaddingIfBig}>{this.props.children}</div>
+      <div css={css} id={this.props.id ? this.props.id : ""}>
+        <div css={morePaddingIfBig}>{this.props.children}</div>
       </div>
     );
   }
@@ -43,7 +44,7 @@ Container.propTypes = {
   children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   id: PropTypes.string,
   mobileFullWidth: PropTypes.bool,
-  className: PropTypes.string
+  className: PropTypes.object
 };
 
 export default Container;

--- a/components/disabled_cookies_banner.js
+++ b/components/disabled_cookies_banner.js
@@ -1,6 +1,6 @@
-import React from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Close from "./icons/Close";
 
 import { globalTheme } from "../theme";
@@ -34,12 +34,8 @@ const CloseIcon = css`
 `;
 
 export const DisabledCookiesBanner = ({ t, onClose }) => (
-  <Body className={Banner}>
-    <button
-      className={CloseIcon}
-      aria-label="Hide cookie warning"
-      onClick={onClose}
-    >
+  <Body css={Banner}>
+    <button css={CloseIcon} aria-label="Hide cookie warning" onClick={onClose}>
       <Close />
     </button>
     <span>

--- a/components/dropdown.js
+++ b/components/dropdown.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 
 const cerulean = globalTheme.colour.cerulean.replace("#", "%23"); //The character # is reserved in URLs as the start of a fragment identifier. You must encode this as %23 for the URL to be valid.
@@ -51,18 +52,13 @@ export class Dropdown extends Component {
   render() {
     const { value, onChange, children, label, id } = this.props;
     return (
-      <div className={wrapper}>
-        <label htmlFor={id} className={left}>
+      <div css={wrapper}>
+        <label htmlFor={id} css={left}>
           {label}
           &nbsp;&nbsp;
         </label>
-        <div className={right}>
-          <select
-            className={selectStyle}
-            value={value}
-            id={id}
-            onChange={onChange}
-          >
+        <div css={right}>
+          <select css={selectStyle} value={value} id={id} onChange={onChange}>
             {children}
           </select>
         </div>

--- a/components/example_bullets.js
+++ b/components/example_bullets.js
@@ -1,7 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 import Highlighter from "react-highlight-words";
 import CardDetails from "./card_details";
@@ -62,14 +63,14 @@ export class ExampleBullets extends React.Component {
     }
     return (
       <CardDetails
-        className={root}
+        css={root}
         summary={
           t("current-language-code") === "en"
             ? benefit.seeMoreSentenceEn
             : benefit.seeMoreSentenceFr
         }
       >
-        <ul className={margin}>{bullets}</ul>
+        <ul css={margin}>{bullets}</ul>
       </CardDetails>
     );
   }

--- a/components/favourite_button.js
+++ b/components/favourite_button.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import SaveChecked from "./icons/SaveChecked";
 import SaveUnchecked from "./icons/SaveUnchecked";
 import { connect } from "react-redux";
 import Cookies from "universal-cookie";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import HeaderButton from "./header_button";
 import { areCookiesDisabled } from "../utils/common";
 import Tooltip from "./tooltip";
@@ -82,11 +83,11 @@ export class FavouriteButton extends Component {
       <Tooltip
         disabled={!this.props.cookiesDisabled}
         tooltipText={t("favourites.disabled_cookies_tooltip")}
-        className={icon ? rightAlign : null}
+        styles={icon ? rightAlign : null}
       >
         {icon ? (
           <button
-            className={xButton}
+            css={xButton}
             disabled={this.props.cookiesDisabled}
             aria-label={longButtonText + " " + benefitName}
             id={"favourite-" + benefit.id}
@@ -102,7 +103,7 @@ export class FavouriteButton extends Component {
             disabled={this.props.cookiesDisabled}
             ariaLabel={longButtonText + " " + benefitName}
             id={"favourite-" + benefit.id}
-            className={saveButton}
+            css={saveButton}
             aria-label={t("B3.favouritesButtonText")}
             onClick={() => this.toggleFavourite(benefit.id)}
             onMouseOver={() => {
@@ -111,9 +112,9 @@ export class FavouriteButton extends Component {
             size="small"
           >
             {isSaved ? (
-              <SaveChecked className={cx("saved", saveIcon)} />
+              <SaveChecked css={["saved", saveIcon]} />
             ) : (
-              <SaveUnchecked className={cx("notSaved", saveIcon)} />
+              <SaveUnchecked css={["notSaved", saveIcon]} />
             )}
             <span>{longButtonText}</span>
           </HeaderButton>

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -1,11 +1,12 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import BenefitList from "./benefit_list";
 import { connect } from "react-redux";
 import { getPrintUrl, getHomeUrl } from "../selectors/urls";
 import Link from "next/link";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Container from "./container";
 import Header from "./typography/header";
 import Body from "./typography/body";
@@ -94,15 +95,11 @@ export class Favourites extends Component {
             breadcrumbs={breadcrumbs}
             pageTitle={t("index.your_saved_benefits")}
           />
-          <Paper padding="md" className={innerDiv}>
+          <Paper padding="md" styles={innerDiv}>
             <AlphaBanner t={t} url={url} />
             <Grid container spacing={32}>
               <Grid item xs={12}>
-                <Header
-                  className={"BenefitsCounter"}
-                  size="xl"
-                  headingLevel="h1"
-                >
+                <Header css={"BenefitsCounter"} size="xl" headingLevel="h1">
                   {t("titles.saved_list")}
                 </Header>
               </Grid>
@@ -136,11 +133,7 @@ export class Favourites extends Component {
                     </Grid>
                   ) : null}
                   <Grid item xs={12}>
-                    <Header
-                      className={headerPadding}
-                      size="md"
-                      headingLevel="h3"
-                    >
+                    <Header styles={headerPadding} size="md" headingLevel="h3">
                       {filteredBenefits.length === 1
                         ? t("titles.1_saved_benefit")
                         : t("titles.x_saved_benefits", {
@@ -174,7 +167,7 @@ export class Favourites extends Component {
                 ) : null}
               </Grid>
               <Grid item xs={12}>
-                <div className={divider} />
+                <div css={divider} />
               </Grid>
               <Grid item md={4} xs={12}>
                 <div id="next-steps">

--- a/components/feedbackBar.js
+++ b/components/feedbackBar.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import SubmitButton from "./button";
 import { logEvent } from "../utils/analytics";
 import Raven from "raven-js";
 import TextArea from "./text_area";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import FooterButton from "./footer_button";
 import { globalTheme } from "../theme";
 import Header from "./typography/header";
@@ -151,23 +152,23 @@ export class FeedbackBar extends Component {
 
     return (
       <div
-        className={FeedbackWrapper}
+        css={FeedbackWrapper}
         aria-label={t("feedback.page_title")}
         role="complementary"
       >
         {this.state.commentFormToggled ? (
-          <div className={CommentBox} role="form">
-            <Header size="lg" headingLevel="h2" className={topHeading}>
+          <div css={CommentBox} role="form">
+            <Header size="lg" headingLevel="h2" styles={topHeading}>
               {t("comment-help-us-improve")}
             </Header>
-            <p className={pStyle}>{t("comment-privacy-disclaimer")}</p>
-            <div className={TextHold}>
+            <p css={pStyle}>{t("comment-privacy-disclaimer")}</p>
+            <div css={TextHold}>
               <TextArea
                 id="commentTextArea"
                 name="bugFiling"
                 maxLength={500}
                 t={t}
-                className={textArea}
+                css={textArea}
                 onChange={
                   this.state.commentIsBug
                     ? this.handleChange("bug")
@@ -191,36 +192,32 @@ export class FeedbackBar extends Component {
             &nbsp; &nbsp;
             <FooterButton
               id="cancelComment"
-              className={cancelButton}
+              css={cancelButton}
               onClick={() => this.cancelComment()}
             >
               {t("cancel")}
             </FooterButton>
           </div>
         ) : null}
-        <div className={Div}>
+        <div css={Div}>
           {this.state.feedbackSubmitted && !this.state.commentFormToggled ? (
-            <div className={Inner}>
-              <Header size="sm" headingLevel="h2" className={whiteNormalFont}>
+            <div css={Inner}>
+              <Header size="sm" headingLevel="h2" styles={whiteNormalFont}>
                 {t("feedback.response_p1")}
               </Header>
               <FooterButton
                 id="feedbackReset"
-                className={resetButton}
+                css={resetButton}
                 onClick={() => this.resetFeedback()}
               >
                 {t("feedback.response_p2")}
               </FooterButton>
             </div>
           ) : !this.state.feedbackSubmitted ? (
-            <div className={Inner}>
+            <div css={Inner}>
               <Grid container spacing={8}>
                 <Grid item md={5} xs={12}>
-                  <Header
-                    size="sm"
-                    headingLevel="h2"
-                    className={whiteNormalFont}
-                  >
+                  <Header size="sm" headingLevel="h2" styles={whiteNormalFont}>
                     {t("feedback-prompt")}
                   </Header>
                 </Grid>
@@ -240,7 +237,7 @@ export class FeedbackBar extends Component {
                   </FooterButton>
                 </Grid>
                 <Grid item md={4} xs={12}>
-                  <Header size="sm" headingLevel="h2" className={fileBugHeader}>
+                  <Header size="sm" headingLevel="h2" styles={fileBugHeader}>
                     <FooterButton
                       id="feedbackBug"
                       onClick={() => this.sendFeedback("Bug")}

--- a/components/footer_button.js
+++ b/components/footer_button.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 const style = css`
   font-family: ${globalTheme.fontFamilySansSerif};
   font-size: 18px;
@@ -25,13 +26,9 @@ const style = css`
 
 class FooterButton extends Component {
   render() {
-    const { className, onClick, children, ...other } = this.props;
+    const { css, onClick, children, ...other } = this.props;
     return (
-      <button
-        className={className ? cx(style, className) : style}
-        onClick={onClick}
-        {...other}
-      >
+      <button css={css ? [style, css] : style} onClick={onClick} {...other}>
         {children}
       </button>
     );
@@ -39,7 +36,7 @@ class FooterButton extends Component {
 }
 FooterButton.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  className: PropTypes.string,
+  css: PropTypes.string,
   onClick: PropTypes.func
 };
 export default FooterButton;

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -1,7 +1,8 @@
+/** @jsx jsx */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
-import { css } from "emotion";
+import { css, jsx } from "@emotion/core";
 import Container from "./container";
 import Header from "./typography/header";
 import Body from "./typography/body";
@@ -192,7 +193,7 @@ export class GuidedExperience extends Component {
             pageTitle={t("ge.Find benefits and services")}
           />
         </div>
-        <Paper padding="md" className={box}>
+        <Paper padding="md" styles={box}>
           <AlphaBanner t={t} url={url} />
           <Grid container spacing={24} role="form">
             {id === "patronType" ? (
@@ -203,7 +204,7 @@ export class GuidedExperience extends Component {
                   </Header>
                   {id === "patronType" ? (
                     <React.Fragment>
-                      <Body className={greyBox}>
+                      <Body styles={greyBox}>
                         <p>{t("ge.intro_text_p1")}</p>
                         <p>{t("ge.intro_text_p2")}</p>
                       </Body>
@@ -212,12 +213,12 @@ export class GuidedExperience extends Component {
                 </Grid>
               </React.Fragment>
             ) : null}
-            <Grid item xs={12} className={questions}>
+            <Grid item xs={12} css={questions}>
               <Header size="md_lg" headingLevel="h2">
                 {this.getSubtitle(question)}
               </Header>
               {question.tooltip_english && question.tooltip_english !== "" ? (
-                <Body className={body}>
+                <Body styles={body}>
                   {t("current-language-code") === "en"
                     ? question.tooltip_english
                     : question.tooltip_french}
@@ -228,11 +229,11 @@ export class GuidedExperience extends Component {
             <Grid item xs={12}>
               <Grid container spacing={16}>
                 <Grid item xs={12} md={8}>
-                  <Grid container spacing={8} className={mobileReverse}>
+                  <Grid container spacing={8} css={mobileReverse}>
                     <HeaderLink
                       id="prevButton"
                       href={backUrl}
-                      className={mobileFullWidth}
+                      css={mobileFullWidth}
                       hasBorder
                     >
                       {t("back")}
@@ -241,7 +242,7 @@ export class GuidedExperience extends Component {
                       <Button
                         id="nextButton"
                         mobileFullWidth={true}
-                        className={leftMargin}
+                        css={leftMargin}
                       >
                         {this.getNextUrl().indexOf("benefits-directory") > -1
                           ? t("ge.show_results")
@@ -250,12 +251,12 @@ export class GuidedExperience extends Component {
                     </Link>
                   </Grid>
                 </Grid>
-                <Grid item xs={12} md={4} className={alignRight}>
+                <Grid item xs={12} md={4} css={alignRight}>
                   <Link id="skipLink" href={this.getSkipUrl()}>
                     <HeaderButton
                       id="skipButton"
                       altStyle="grey"
-                      className={mobileFullWidth}
+                      styles={mobileFullWidth}
                     >
                       {t("ge.skip")}
                     </HeaderButton>

--- a/components/guided_experience_needs.js
+++ b/components/guided_experience_needs.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core/";
 import NeedButton from "./need_button";
 import { connect } from "react-redux";
 import { logEvent } from "../utils/analytics";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const root = css`
   padding: 0 15px !important;
@@ -43,11 +44,11 @@ export class GuidedExperienceNeeds extends Component {
   render() {
     const { t, store } = this.props; // eslint-disable-line no-unused-vars
     return (
-      <div className={root}>
+      <div css={root}>
         <Grid container spacing={24}>
-          <ul className={needsList}>
+          <ul css={needsList}>
             {this.props.needs.map(need => (
-              <li key={need.id} className={needCss}>
+              <li key={need.id} css={needCss}>
                 <NeedButton
                   key={need.nameEn.replace(/ /g, "-") + "-checkbox"}
                   need={need}

--- a/components/guided_experience_profile.js
+++ b/components/guided_experience_profile.js
@@ -1,8 +1,9 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import RadioSelector from "./radio_selector";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const outerDiv = css`
   padding: 12px;
@@ -12,7 +13,7 @@ export class GuidedExperienceProfile extends Component {
   render() {
     const { t } = this.props;
     return (
-      <div className={outerDiv}>
+      <div css={outerDiv}>
         <Grid container spacing={24}>
           <RadioSelector
             id={"RadioSelector" + this.props.selectorType}

--- a/components/guided_experience_summary.js
+++ b/components/guided_experience_summary.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 import { showQuestion } from "../utils/common";
 import { connect } from "react-redux";
@@ -17,7 +18,7 @@ export class GuidedExperienceSummary extends Component {
     const { url, t, reduxState, store } = this.props;
     return (
       <div>
-        <ul className={breadcrumbList}>
+        <ul css={breadcrumbList}>
           {reduxState.questions
             .map(x => x.variable_name)
             .filter((x, i) => showQuestion(x, i, reduxState))

--- a/components/header_button.js
+++ b/components/header_button.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const style = css`
   display: inline-block;
@@ -50,7 +51,6 @@ class HeaderButton extends Component {
   render() {
     const {
       id,
-      className,
       children,
       size,
       altStyle,
@@ -61,7 +61,7 @@ class HeaderButton extends Component {
       ...otherProps
     } = this.props;
 
-    let cName = [className];
+    let cName = [this.props.styles];
     if (size === "small") cName.unshift(small);
     if (altStyle === "grey") cName.unshift(grey);
     if (hasBorder === true) cName.unshift(borderStyle);
@@ -71,7 +71,7 @@ class HeaderButton extends Component {
       <button
         aria-label={ariaLabel}
         disabled={disabled}
-        className={cx(cName)}
+        css={cName}
         id={"a-" + id}
         onClick={onClick}
         {...otherProps}
@@ -91,7 +91,7 @@ HeaderButton.propTypes = {
     PropTypes.array,
     PropTypes.object
   ]),
-  className: PropTypes.string,
+  styles: PropTypes.object,
   label: PropTypes.object,
   disabled: PropTypes.bool,
   hasBorder: PropTypes.bool,

--- a/components/header_link.js
+++ b/components/header_link.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Link from "next/link";
 
 const style = css`
@@ -49,7 +50,7 @@ const grey = css`
 class HeaderLink extends Component {
   render() {
     const {
-      className,
+      css,
       children,
       href,
       size,
@@ -59,7 +60,7 @@ class HeaderLink extends Component {
       ...otherProps
     } = this.props;
 
-    let cName = [className];
+    let cName = [css];
     if (size === "small") cName.unshift(small);
     if (altStyle === "grey") cName.unshift(grey);
     if (hasBorder === true) cName.unshift(borderStyle);
@@ -67,7 +68,7 @@ class HeaderLink extends Component {
 
     return (
       <Link href={href}>
-        <a className={cx(cName)} href={href} onClick={onClick} {...otherProps}>
+        <a css={cName} href={href} onClick={onClick} {...otherProps}>
           {children}
         </a>
       </Link>
@@ -83,7 +84,7 @@ HeaderLink.propTypes = {
     PropTypes.array,
     PropTypes.object
   ]),
-  className: PropTypes.string,
+  css: PropTypes.string,
   label: PropTypes.object,
   onClick: PropTypes.func,
   disabled: PropTypes.bool,

--- a/components/icons/alert_icon.js
+++ b/components/icons/alert_icon.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../../theme";
 
 export class AlertIcon extends Component {
@@ -15,7 +16,7 @@ export class AlertIcon extends Component {
 
   render() {
     return (
-      <div className={this.outer}>
+      <div css={this.outer}>
         <svg
           role="img"
           aria-label={this.props.t("alt_text.important")}
@@ -23,7 +24,7 @@ export class AlertIcon extends Component {
           height={this.props.height}
           viewBox="0 0 25 22"
           xmlns="http://www.w3.org/2000/svg"
-          className={this.inner}
+          css={this.inner}
         >
           <path
             d="M11,0 C4.928,0 0,4.928 0,11 C0,17.072 4.928,22 11,22 C17.072,22 22,17.072 22,11 C22,4.928 17.072,0 11,0 L11,0 Z M12.1,16.5 L9.9,16.5 L9.9,14.3 L12.1,14.3 L12.1,16.5 L12.1,16.5 Z M12.1,12.1 L9.9,12.1 L9.9,5.5 L12.1,5.5 L12.1,12.1 L12.1,12.1 Z"

--- a/components/layout.js
+++ b/components/layout.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import styled from "@emotion/styled";
 import {
   MuiThemeProvider,
@@ -20,7 +21,7 @@ import VacHeaderFr from "./vac_header_fr";
 import SkipToMainContent from "./skip_to_main_content";
 
 const Content = styled("div")`
-  min-height: calc(100vh - 65px);
+  min-height: calc(100vh - 165px);
 `;
 const black_bg = css`
   background-color: ${globalTheme.colour.blackish2};
@@ -81,7 +82,7 @@ class Layout extends Component {
           <ErrorBoundary>
             <Content>
               <SkipToMainContent skipLink={skipLink} t={t} />
-              <div id="header_css" className={black_bg}>
+              <div id="header_css" css={black_bg}>
                 {t("current-language-code") === "en" ? (
                   <VacHeaderEn t={t} url={url} />
                 ) : (
@@ -90,12 +91,12 @@ class Layout extends Component {
               </div>
               <main id="main">{this.props.children}</main>
             </Content>
-            <div className={backgoundColour1}>
+            <div css={backgoundColour1}>
               <Container>
                 <FeedbackBar t={t} />
               </Container>
             </div>
-            <div id="footer_styles" className={fontStyle}>
+            <div id="footer_styles" css={fontStyle}>
               {t("current-language-code") === "en" ? (
                 <VacFooterEn />
               ) : (

--- a/components/learn_more_button.js
+++ b/components/learn_more_button.js
@@ -1,6 +1,6 @@
-import React from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Button from "./button";
 import { logEvent } from "../utils/analytics";
 import { globalTheme } from "../theme";
@@ -20,7 +20,7 @@ const LearnMoreButton = props => {
 
   return (
     <a
-      className={anchorFocus}
+      css={anchorFocus}
       href={url}
       rel="noopener noreferrer"
       onClick={() => {

--- a/components/myvac_button.js
+++ b/components/myvac_button.js
@@ -1,8 +1,9 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import FooterLink from "./typography/footer_link";
 import FolderMouse from "./icons/FolderMouse";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 
 const desktopButton = css`
@@ -23,7 +24,7 @@ class MyVacButton extends Component {
   render() {
     const { t } = this.props;
     return (
-      <FooterLink href={t("links.myvac")} className={desktopButton}>
+      <FooterLink href={t("links.myvac")} css={desktopButton}>
         {t("myvac_button_text")}
         <FolderMouse />
       </FooterLink>

--- a/components/need_button.js
+++ b/components/need_button.js
@@ -3,14 +3,8 @@ import PropTypes from "prop-types";
 import Checkbox from "./checkbox";
 import { connect } from "react-redux";
 import { logEvent } from "../utils/analytics";
-import { css } from "emotion";
 import Router from "next/router";
 import { mutateUrl } from "../utils/common";
-
-const style = css`
-  margin-bottom: 10px;
-  margin-right: 10px;
-`;
 
 export class NeedButton extends Component {
   handleClick = id => {
@@ -39,7 +33,6 @@ export class NeedButton extends Component {
         onChange={() => this.handleClick(need.id)}
         value={need.id}
         disabled={disabled ? "disabled" : null}
-        className={style}
         sidebar={this.props.updateUrl}
       >
         {t("current-language-code") === "en" ? need.nameEn : need.nameFr}

--- a/components/need_tag.js
+++ b/components/need_tag.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../theme";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const needsTag = css`
   font-size: 14px;
@@ -19,7 +20,7 @@ export class NeedTag extends Component {
   render() {
     const { t, need, last } = this.props;
     return (
-      <div className={needsTag}>
+      <div css={needsTag}>
         {(t("current-language-code") === "en"
           ? need.nameEn.toUpperCase()
           : need.nameFr.toUpperCase()) + (last ? "" : ",")}

--- a/components/needs_selector.js
+++ b/components/needs_selector.js
@@ -1,9 +1,10 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import NeedButton from "./need_button";
 import { Grid } from "@material-ui/core";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Header from "./typography/header";
 import { showQuestion } from "../utils/common";
 
@@ -43,15 +44,15 @@ export class NeedsSelector extends Component {
 
     if (showQuestion("needs", undefined, this.props.reduxState)) {
       return (
-        <div className={topBorder}>
-          <Header size="sm" className={formLabel}>
+        <div css={topBorder}>
+          <Header size="sm" styles={formLabel}>
             {t("filter by category")}
           </Header>
           <Grid container spacing={16}>
             <Grid item xs={9}>
-              <div className={subFormLabel}>{t("Select all that apply")}</div>
+              <div css={subFormLabel}>{t("Select all that apply")}</div>
             </Grid>
-            <Grid item xs={12} className={needsButtons}>
+            <Grid item xs={12} css={needsButtons}>
               {needs.map(need => (
                 <NeedButton
                   key={need.id}

--- a/components/next_steps.js
+++ b/components/next_steps.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 import { Grid } from "@material-ui/core";
 import { connect } from "react-redux";
@@ -35,7 +36,7 @@ export class NextSteps extends Component {
         .replace("<p>", "<span>")
         .replace("</p>", "</span>");
       return (
-        <li key={n} className={liItem}>
+        <li key={n} css={liItem}>
           <JsxParser jsx={jsxString} />
         </li>
       );
@@ -48,7 +49,7 @@ export class NextSteps extends Component {
       <div>
         <Grid container spacing={24}>
           <Grid item xs={12}>
-            <ul id="nextStepsList" className={whatsNextList}>
+            <ul id="nextStepsList" css={whatsNextList}>
               {bullets}
             </ul>
           </Grid>

--- a/components/no_results_buttons.js
+++ b/components/no_results_buttons.js
@@ -1,6 +1,6 @@
-import React from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Button from "./button";
 import { globalTheme } from "../theme";
 import Body from "./typography/body";
@@ -25,18 +25,18 @@ const orText = css`
 
 const NoResultsButtons = props => {
   return (
-    <div className={buttonBar}>
+    <div css={buttonBar}>
       <Button
-        className={button}
+        css={button}
         id="reset_filters_button"
         onClick={() => props.clearFilters()}
       >
         {props.t("BenefitsPane.reset_filters")}
       </Button>
 
-      <Body className={orText}>{props.t("BenefitsPane.or")}</Body>
+      <Body styles={orText}>{props.t("BenefitsPane.or")}</Body>
 
-      <Button className={button} id="contact_us_button" secondary>
+      <Button css={button} id="contact_us_button" secondary>
         {props.t("BenefitsPane.contact_us")}
       </Button>
     </div>

--- a/components/noscript.js
+++ b/components/noscript.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 
 const Modal = css`
@@ -33,9 +34,9 @@ class Noscript extends Component {
 
     return (
       <noscript>
-        <div className={Modal}>
-          <div className={ModalContent}>
-            <div className="copy">
+        <div css={Modal}>
+          <div css={ModalContent}>
+            <div css="copy">
               <p dangerouslySetInnerHTML={{ __html: t("noscript") }} />
             </div>
           </div>

--- a/components/paper.js
+++ b/components/paper.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 
 class Paper extends Component {
@@ -20,11 +21,7 @@ class Paper extends Component {
   render() {
     return (
       <div
-        className={
-          this.props.className
-            ? cx(this.style, this.props.className)
-            : this.style
-        }
+        css={this.props.styles ? [this.style, this.props.styles] : [this.style]}
       >
         {this.props.children}
       </div>
@@ -35,7 +32,11 @@ class Paper extends Component {
 Paper.propTypes = {
   children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   padding: PropTypes.string,
-  className: PropTypes.string
+  styles: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ])
 };
 
 export default Paper;

--- a/components/profile_selector.js
+++ b/components/profile_selector.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import RadioSelector from "./radio_selector";
 import { connect } from "react-redux";
 import { Grid } from "@material-ui/core";
 import { showQuestion } from "../utils/common";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const radioStyle = css`
   margin-left: 0px;
@@ -31,7 +32,7 @@ export class ProfileSelector extends Component {
         jsx_array.push(
           <Grid item xs={12} key={question.variable_name + "RadioSelector"}>
             <RadioSelector
-              className={radioStyle}
+              styles={radioStyle}
               id={question.variable_name + "RadioSelector"}
               t={t}
               legend={

--- a/components/quick_links.js
+++ b/components/quick_links.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import HeaderButton from "./header_button";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { Grid } from "@material-ui/core";
 import { globalTheme } from "../theme";
 
@@ -66,16 +67,16 @@ class QuickLinks extends Component {
   render() {
     const { t, onFavourites } = this.props;
     return (
-      <div className={greyBox}>
+      <div css={greyBox}>
         <Grid container>
           <Grid item xs={12} md={4}>
-            <div className={leftDiv}>
-              <span className={quickLinksText}>{t("quick_links")}</span>
-              <div className={link}>
+            <div css={leftDiv}>
+              <span css={quickLinksText}>{t("quick_links")}</span>
+              <div css={link}>
                 {onFavourites ? (
                   <HeaderButton
                     id="saved-list-button"
-                    className={linkStyle}
+                    styles={linkStyle}
                     onClick={() => this.scrollToId("#saved-list")}
                   >
                     {t("titles.saved_list")}
@@ -83,17 +84,17 @@ class QuickLinks extends Component {
                 ) : (
                   <HeaderButton
                     id="benefits-and-services-button"
-                    className={linkStyle}
+                    styles={linkStyle}
                     onClick={() => this.scrollToId("#benefits-and-services")}
                   >
                     {t("titles.benefits_and_services")}
                   </HeaderButton>
                 )}
               </div>
-              <div className={link}>
+              <div css={link}>
                 <HeaderButton
                   id="next-steps-button"
-                  className={linkStyle}
+                  styles={linkStyle}
                   onClick={() => this.scrollToId("#next-steps")}
                 >
                   {t("nextSteps.whats_next")}
@@ -102,7 +103,7 @@ class QuickLinks extends Component {
             </div>
           </Grid>
           <Grid item xs={12} md={8}>
-            <div className={rightDiv}>{t("B3.check eligibility")}</div>
+            <div css={rightDiv}>{t("B3.check eligibility")}</div>
           </Grid>
         </Grid>
       </div>
@@ -116,8 +117,7 @@ QuickLinks.defaultProps = {
 
 QuickLinks.propTypes = {
   t: PropTypes.func.isRequired,
-  onFavourites: PropTypes.bool,
-  className: PropTypes.string
+  onFavourites: PropTypes.bool
 };
 
 export default QuickLinks;

--- a/components/radio.js
+++ b/components/radio.js
@@ -1,6 +1,6 @@
-import React from "react";
 import PropTypes from "prop-types";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 
 const rootStyle = css({
@@ -75,21 +75,17 @@ const sidebarLabelStyle = css({
   padding: "6px 10px 15px 12px !important"
 });
 
-const Radio = ({ children, className, value, sidebar, ...input }) => (
-  <div className={cx(rootStyle, className)}>
+const Radio = ({ children, styles, value, sidebar, ...input }) => (
+  <div css={[rootStyle, styles]}>
     <input
       type="radio"
-      className={inputStyle}
+      css={inputStyle}
       value={value}
       id={value + "-0"}
       {...input}
     />
     <label
-      className={cx(
-        mobileLabelStyle,
-        labelStyle,
-        sidebar ? sidebarLabelStyle : null
-      )}
+      css={[mobileLabelStyle, labelStyle, sidebar ? sidebarLabelStyle : null]}
       htmlFor={value + "-0"}
     >
       {children}
@@ -98,11 +94,11 @@ const Radio = ({ children, className, value, sidebar, ...input }) => (
 );
 
 Radio.defaultProps = {
-  className: undefined
+  styles: undefined
 };
 
 Radio.propTypes = {
-  className: PropTypes.string,
+  styles: PropTypes.object,
   value: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   sidebar: PropTypes.bool

--- a/components/radio_selector.js
+++ b/components/radio_selector.js
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { logEvent } from "../utils/analytics";
 import { globalTheme } from "../theme";
-import { css, cx } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Header from "./typography/header";
 import Tooltip from "./tooltip";
 import Radio from "./radio";
@@ -112,24 +113,24 @@ export class RadioSelector extends React.Component {
       responses,
       legend,
       tooltipText,
-      className
+      styles
     } = this.props;
     if (options.length !== 0) {
       return (
-        <div className={formControl}>
+        <div css={formControl}>
           <Tooltip
             disabled={!tooltipText}
             tooltipText={tooltipText}
             width={250}
           >
-            <Header className={formLabel} size="sm">
-              <span className={tooltipText ? underline : ""}>{legend}</span>
+            <Header styles={formLabel} size="sm">
+              <span css={tooltipText ? underline : ""}>{legend}</span>
             </Header>
           </Tooltip>
 
           <div
             aria-label={legend}
-            className={className ? cx(leftIndent, className) : leftIndent}
+            css={styles ? [leftIndent, styles] : leftIndent}
           >
             {options.map(option => {
               return (
@@ -138,7 +139,7 @@ export class RadioSelector extends React.Component {
                   checked={responses[selectorType] === option.variable_name}
                   onChange={this.handleSelect}
                   value={option.variable_name}
-                  className={radioOption}
+                  styles={radioOption}
                   sidebar={this.props.updateUrl}
                 >
                   {t("current-language-code") === "en"
@@ -190,7 +191,7 @@ RadioSelector.propTypes = {
   options: PropTypes.array.isRequired,
   tooltipText: PropTypes.string,
   store: PropTypes.object,
-  className: PropTypes.string,
+  styles: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   name: PropTypes.string,
   updateUrl: PropTypes.bool,
   url: PropTypes.object

--- a/components/results_header.js
+++ b/components/results_header.js
@@ -1,6 +1,6 @@
-import React from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Header from "./typography/header";
 
 const headerPadding = css`
@@ -12,7 +12,7 @@ const headerPadding = css`
 const ResultsHeader = props => {
   if (props.searchString.trim() !== "" && props.benefitCount > 0) {
     return (
-      <Header className={headerPadding} size="sm_md" headingLevel="h3">
+      <Header css={headerPadding} size="sm_md" headingLevel="h3">
         {props.headerText}
       </Header>
     );

--- a/components/selections_editor.js
+++ b/components/selections_editor.js
@@ -1,11 +1,12 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import NeedsSelector from "./needs_selector";
 import ProfileSelector from "./profile_selector";
 import { connect } from "react-redux";
 import { Grid } from "@material-ui/core";
 import { globalTheme } from "../theme";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import HeaderButton from "./header_button";
 import Header from "./typography/header";
 import Router from "next/router";
@@ -81,9 +82,9 @@ export class SelectionsEditor extends Component {
     const { t, store, url } = this.props;
 
     return (
-      <Grid container className={root}>
+      <Grid container css={root}>
         <Grid item xs={12}>
-          <Header size="sm_md" className={filterTitle}>
+          <Header size="sm_md" styles={filterTitle}>
             {t("directory.edit_selections")}
           </Header>
         </Grid>
@@ -91,7 +92,7 @@ export class SelectionsEditor extends Component {
           {this.countSelected() > 0 ? (
             <HeaderButton
               id="ClearFilters"
-              className={clearButton}
+              styles={clearButton}
               onClick={() => {
                 this.clearFilters();
               }}
@@ -101,11 +102,11 @@ export class SelectionsEditor extends Component {
           ) : null}
         </Grid>
 
-        <Grid item xs={12} className={profileStyle}>
+        <Grid item xs={12} css={profileStyle}>
           <ProfileSelector t={t} store={store} url={url} />
         </Grid>
-        <div className={divider} />
-        <Grid item xs={12} className={profileStyle}>
+        <div css={divider} />
+        <Grid item xs={12} css={profileStyle}>
           <NeedsSelector t={t} store={store} url={url} />
         </Grid>
       </Grid>

--- a/components/selections_editor_mobile.js
+++ b/components/selections_editor_mobile.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import ExpansionPanel from "@material-ui/core/ExpansionPanel";
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
@@ -9,7 +9,8 @@ import ProfileSelector from "./profile_selector";
 import { connect } from "react-redux";
 import { Grid } from "@material-ui/core";
 import { globalTheme } from "../theme";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import HeaderButton from "./header_button";
 import Header from "./typography/header";
 import Router from "next/router";
@@ -99,17 +100,13 @@ export class SelectionsEditorMobile extends Component {
   render() {
     const { t, store, url } = this.props;
     return (
-      <ExpansionPanel
-        className={root}
-        defaultExpanded
-        expanded={this.state.open}
-      >
+      <ExpansionPanel css={root} defaultExpanded expanded={this.state.open}>
         <ExpansionPanelSummary
-          className={summary}
-          expandIcon={<ExpandMoreIcon className={greyishBrown} />}
+          css={summary}
+          expandIcon={<ExpandMoreIcon css={greyishBrown} />}
           onClick={() => this.toggleOpenState()}
         >
-          <Header headingLevel="h2" size="sm_md" className={filterTitle}>
+          <Header headingLevel="h2" size="sm_md" styles={filterTitle}>
             {t("directory.edit_selections")}
           </Header>{" "}
         </ExpansionPanelSummary>
@@ -120,7 +117,7 @@ export class SelectionsEditorMobile extends Component {
               {this.countSelected() > 0 ? (
                 <HeaderButton
                   id="ClearFiltersMobile"
-                  className={clearButton}
+                  styles={clearButton}
                   onClick={() => {
                     this.clearFilters();
                   }}
@@ -129,11 +126,11 @@ export class SelectionsEditorMobile extends Component {
                 </HeaderButton>
               ) : null}
             </Grid>
-            <Grid item sm={12} className={profileStyle}>
+            <Grid item sm={12} css={profileStyle}>
               <ProfileSelector t={t} store={store} url={url} />
             </Grid>
-            <div className={divider} />
-            <Grid item sm={12} className={needsStyle}>
+            <div css={divider} />
+            <Grid item sm={12} css={needsStyle}>
               <NeedsSelector t={t} store={store} url={url} />
             </Grid>
           </Grid>

--- a/components/share_box.js
+++ b/components/share_box.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 import HeaderButton from "./header_button";
 import HeaderLink from "./header_link";
@@ -34,12 +35,12 @@ class ShareBox extends Component {
   uid = uuidv4();
 
   render() {
-    const { t, printUrl, url, showShareLink, className } = this.props;
+    const { t, printUrl, url, showShareLink, css } = this.props;
     return (
-      <div className={className}>
-        <span className={shareText}>{t("share_colon")}</span>
+      <div css={css}>
+        <span css={shareText}>{t("share_colon")}</span>
         <HeaderLink
-          className={shareBoxItem}
+          css={shareBoxItem}
           size="small"
           href={printUrl}
           target="_blank"
@@ -54,7 +55,7 @@ class ShareBox extends Component {
           <React.Fragment>
             <HeaderButton
               id={this.uid}
-              className={shareBoxItem}
+              styles={shareBoxItem}
               size="small"
               aria-label={t("titles.share")}
               onClick={() => this.setState({ showModal: true })}
@@ -81,7 +82,7 @@ ShareBox.propTypes = {
   printUrl: PropTypes.string,
   url: PropTypes.object.isRequired,
   showShareLink: PropTypes.bool.isRequired,
-  className: PropTypes.string
+  css: PropTypes.string
 };
 
 export default ShareBox;

--- a/components/share_modal.js
+++ b/components/share_modal.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import styled from "@emotion/styled";
 import ReactModal from "react-modal";
 import { Grid } from "@material-ui/core/";
@@ -215,15 +216,15 @@ class ShareModal extends Component {
       return (
         <ReactModal
           style={modalStyles}
-          className={modalCSS}
+          css={modalCSS}
           isOpen={isOpen}
           onRequestClose={() => this.close(onRequestClose)}
         >
-          <div className={header}>
+          <div css={header}>
             <span>{t("titles.share")}</span>
             <CloseButton onClick={() => this.close(closeModal)}>X</CloseButton>
           </div>
-          <div className={bodyStyle}>
+          <div css={bodyStyle}>
             <p>
               <label htmlFor={shareTargetId}>{t("share.copy_prompt")}</label>
             </p>
@@ -233,7 +234,7 @@ class ShareModal extends Component {
               </Grid>
               <Grid item xs={12} md={3}>
                 <CopyButton
-                  className="copyButton"
+                  css="copyButton"
                   data-copytarget={"#" + shareTargetId}
                   onClick={this.copyText}
                 >
@@ -242,7 +243,7 @@ class ShareModal extends Component {
               </Grid>
             </Grid>
 
-            <div className={topMargin}>{this.state.statusMessage}</div>
+            <div css={topMargin}>{this.state.statusMessage}</div>
           </div>
         </ReactModal>
       );
@@ -254,7 +255,7 @@ class ShareModal extends Component {
 
 ShareModal.propTypes = {
   uid: PropTypes.string.isRequired,
-  className: PropTypes.string,
+  css: PropTypes.string,
   isOpen: PropTypes.bool,
   onRequestClose: PropTypes.func,
   closeModal: PropTypes.func,

--- a/components/skip_to_main_content.js
+++ b/components/skip_to_main_content.js
@@ -1,5 +1,5 @@
-import React from "react";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import PropTypes from "prop-types";
 import { globalTheme } from "../theme";
 
@@ -27,7 +27,7 @@ const skipLinkStyle = css`
 
 const SkipToMainContent = props => {
   return (
-    <a className={skipLinkStyle} href={props.skipLink} id="skipLink">
+    <a css={skipLinkStyle} href={props.skipLink} id="skipLink">
       {props.t("skipLink")}
     </a>
   );

--- a/components/sticky_header.js
+++ b/components/sticky_header.js
@@ -1,11 +1,12 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import ShareBox from "../components/share_box";
 //import EditIcon from "./icons/Edit";
 import HeaderLink from "./header_link";
 import SaveChecked from "./icons/SaveChecked";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 import { connect } from "react-redux";
 import { getFavouritesUrl, getSummaryUrl } from "../selectors/urls";
@@ -65,7 +66,7 @@ export class StickyHeader extends Component {
     });
 
     return (
-      <Grid item xs={12} className={sticky}>
+      <Grid item xs={12} css={sticky}>
         <Grid container spacing={8}>
           <Grid item xs={6}>
             <ShareBox
@@ -75,26 +76,26 @@ export class StickyHeader extends Component {
               showShareLink={showShareLink}
             />
           </Grid>
-          <Grid item xs={6} className={alignRight}>
+          <Grid item xs={6} css={alignRight}>
             {/* <HeaderLink
               id="editSelections"
               href={this.props.summaryUrl}
               className={editStyle}
             >
               <EditIcon />
-              <span className={longText}>{t("directory.edit_selections")}</span>
-              <span className={shortText}>
+              <span css={longText}>{t("directory.edit_selections")}</span>
+              <span css={shortText}>
                 {t("directory.edit_selections_mobile")}
               </span>
             </HeaderLink> */}
             <HeaderLink
-              className={savedListStyle}
+              css={savedListStyle}
               id="savedBenefits"
               href={this.props.favouritesUrl}
             >
               <SaveChecked />
-              <span className={longText}>{longFavouritesText}</span>
-              <span className={shortText}>{shortFavouritesText}</span>
+              <span css={longText}>{longFavouritesText}</span>
+              <span css={shortText}>{shortFavouritesText}</span>
             </HeaderLink>
           </Grid>
         </Grid>

--- a/components/summary_row.js
+++ b/components/summary_row.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { Grid } from "@material-ui/core";
 import EditIcon from "./icons/Edit";
 import { globalTheme } from "../theme";
@@ -70,20 +71,20 @@ export class SummaryRow extends Component {
     )[0];
 
     return (
-      <li className={breadcrumbCss}>
+      <li css={breadcrumbCss}>
         <Grid container>
           <Grid item xs={9}>
-            <div className={bold}>
+            <div css={bold}>
               {t("current-language-code") === "en"
                 ? question.summary_english
                 : question.summary_french}
             </div>
             <div>{this.getAnswer()}</div>
           </Grid>
-          <Grid item xs={3} className={rightAlign}>
+          <Grid item xs={3} css={rightAlign}>
             <HeaderLink
               href={mutateUrl(url, "/" + getPageName(questionName))}
-              className={font}
+              css={font}
             >
               <EditIcon
                 focusable="true"
@@ -92,7 +93,7 @@ export class SummaryRow extends Component {
                 aria-label={t("alt_text.edit")}
                 height="5px"
               />
-              <span id={"edit-" + questionName} className={hideOnMobile}>
+              <span id={"edit-" + questionName} css={hideOnMobile}>
                 {t("ge.edit")}
               </span>
             </HeaderLink>

--- a/components/tooltip.js
+++ b/components/tooltip.js
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 
 const padding = 16;
@@ -27,34 +28,17 @@ class Tooltip extends Component {
     position: relative;
     display: inline-block;
     :hover {
-      .${this.tooltipTextStyle} {
-        visibility: visible;
-      }
-     .${this.tooltipTextStyle}::after {
-        content: " ";
-        position: absolute;
-        top: 100%; /* At the bottom of the tooltip */
-        left: 50%;
-        margin-left: -7px;
-        border-width: 7px;
-        border-style: solid;
-        border-color: ${
-          globalTheme.colour.paleGrey
-        } transparent transparent transparent;
+      visibility: visible;
     }
   `;
 
   render() {
-    const { children, disabled, tooltipText, className } = this.props;
+    const { children, disabled, tooltipText, styles } = this.props;
     return (
-      <div
-        className={
-          className ? cx(className, this.tooltipStyle) : this.tooltipStyle
-        }
-      >
+      <div css={styles ? [styles, this.tooltipStyle] : this.tooltipStyle}>
         {children}
         {!disabled ? (
-          <span className={this.tooltipTextStyle}>{tooltipText}</span>
+          <span css={this.tooltipTextStyle}>{tooltipText}</span>
         ) : null}
       </div>
     );
@@ -66,7 +50,7 @@ Tooltip.propTypes = {
   tooltipText: PropTypes.string,
   disabled: PropTypes.bool,
   width: PropTypes.number,
-  className: PropTypes.string
+  styles: PropTypes.object
 };
 
 Tooltip.defaultProps = {

--- a/components/typography/anchor_link.js
+++ b/components/typography/anchor_link.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 class AnchorLink extends Component {
   style = css`
@@ -21,10 +22,10 @@ class AnchorLink extends Component {
   `;
 
   render() {
-    const { className, children, fontSize, fontWeight, ...other } = this.props; // eslint-disable-line no-unused-vars
+    const { css, children, fontSize, fontWeight, ...other } = this.props; // eslint-disable-line no-unused-vars
 
     return (
-      <a className={cx(this.style, className)} {...other}>
+      <a css={[this.style, css]} {...other}>
         {children}
       </a>
     );
@@ -39,7 +40,7 @@ AnchorLink.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   fontSize: PropTypes.string,
   fontWeight: PropTypes.string,
-  className: PropTypes.string
+  css: PropTypes.string
 };
 
 export default AnchorLink;

--- a/components/typography/body.js
+++ b/components/typography/body.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const root = css`
   font-family: ${globalTheme.fontFamilySerif};
@@ -14,11 +15,7 @@ const root = css`
 
 export class Body extends Component {
   render() {
-    return (
-      <div className={cx(root, this.props.className)}>
-        {this.props.children}
-      </div>
-    );
+    return <div css={[root, this.props.styles]}>{this.props.children}</div>;
   }
 }
 
@@ -28,7 +25,7 @@ Body.propTypes = {
     PropTypes.object,
     PropTypes.array
   ]),
-  className: PropTypes.string
+  styles: PropTypes.object
 };
 
 export default Body;

--- a/components/typography/filter_text.js
+++ b/components/typography/filter_text.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const style = css`
   font-family: ${globalTheme.fontFamilySansSerif};
@@ -13,9 +14,9 @@ const style = css`
 
 class FilterText extends Component {
   render() {
-    const { className, children, ...other } = this.props;
+    const { css, children, ...other } = this.props;
     return (
-      <div className={className ? cx(style, className) : style} {...other}>
+      <div css={css ? [style, css] : style} {...other}>
         {children}
       </div>
     );
@@ -24,7 +25,7 @@ class FilterText extends Component {
 
 FilterText.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  className: PropTypes.string
+  css: PropTypes.string
 };
 
 export default FilterText;

--- a/components/typography/footer_link.js
+++ b/components/typography/footer_link.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const style = css`
   font-family: ${globalTheme.fontFamilySansSerif};
@@ -20,9 +21,9 @@ const style = css`
 
 class FooterLink extends Component {
   render() {
-    const { className, children, ...other } = this.props;
+    const { css, children, ...other } = this.props;
     return (
-      <a className={className ? cx(style, className) : style} {...other}>
+      <a css={css ? [style, css] : style} {...other}>
         {children}
       </a>
     );
@@ -35,7 +36,7 @@ FooterLink.propTypes = {
     PropTypes.string,
     PropTypes.array
   ]),
-  className: PropTypes.string
+  css: PropTypes.string
 };
 
 export default FooterLink;

--- a/components/typography/header.js
+++ b/components/typography/header.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const sizeDict = {
   xl: {
@@ -63,10 +64,9 @@ class Header extends Component {
   }
 
   render() {
-    const { children, className, headingLevel, id, autoFocus } = this.props;
-
+    const { children, styles, headingLevel, id, autoFocus } = this.props;
     const props = {
-      className: className ? cx(this.style, className) : this.style,
+      css: styles ? [this.style, styles] : this.style,
       id: id
     };
 
@@ -96,7 +96,7 @@ Header.propTypes = {
     PropTypes.string,
     PropTypes.array
   ]),
-  className: PropTypes.string,
+  styles: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   headingLevel: PropTypes.string,
   size: PropTypes.string,
   id: PropTypes.string,

--- a/components/typography/one_liner.js
+++ b/components/typography/one_liner.js
@@ -1,7 +1,8 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { globalTheme } from "../../theme";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const style = css`
   font-family: ${globalTheme.fontFamilySansSerif};
@@ -16,14 +17,16 @@ const style = css`
 
 class OneLiner extends Component {
   render() {
-    const { className, children } = this.props;
+    const { children } = this.props;
     return (
-      <div className={className ? cx(style, className) : style}>{children}</div>
+      <div css={this.props.styles ? [style, this.props.styles] : style}>
+        {children}
+      </div>
     );
   }
 }
 OneLiner.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  className: PropTypes.string
+  styles: PropTypes.object
 };
 export default OneLiner;

--- a/lib/i18nHOC.js
+++ b/lib/i18nHOC.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 
 const mapStateToProps = reduxState => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -14,6 +14,9 @@ const theme = createMuiTheme({
       md: 768,
       lg: 1000
     }
+  },
+  typography: {
+    useNextVariants: true
   }
 });
 

--- a/pages/all-benefits.js
+++ b/pages/all-benefits.js
@@ -30,7 +30,7 @@ export class AllBenefits extends Component {
         url={url}
       >
         <Container id="mainContent">
-          <Header size="xl" headingLevel="h1" paddingTop="30" css={header}>
+          <Header size="xl" headingLevel="h1" paddingTop="30" styles={header}>
             {t("all-benefits.List of all benefits")}
           </Header>
           <Grid item xs={12}>

--- a/pages/all-benefits.js
+++ b/pages/all-benefits.js
@@ -1,13 +1,21 @@
-import React, { Component } from "react";
+/** @jsx jsx */
+import { Component } from "react";
+import { css, jsx } from "@emotion/core";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
-
 import withI18N from "../lib/i18nHOC";
 import Layout from "../components/layout";
 import { connect } from "react-redux";
 import BenefitList from "../components/benefit_list";
 import Container from "../components/container";
 import Header from "../components/typography/header";
+
+const header = css`
+  padding-bottom: 10px;
+`;
+const list = css`
+  max-width: 800px;
+`;
 
 export class AllBenefits extends Component {
   render() {
@@ -22,19 +30,21 @@ export class AllBenefits extends Component {
         url={url}
       >
         <Container id="mainContent">
-          <Header size="xl" headingLevel="h1">
+          <Header size="xl" headingLevel="h1" paddingTop="30" css={header}>
             {t("all-benefits.List of all benefits")}
           </Header>
           <Grid item xs={12}>
             <Grid container spacing={24}>
-              <BenefitList
-                t={t}
-                currentLanguage={t("current-language-code")}
-                filteredBenefits={this.props.benefits}
-                searchString={this.props.searchString}
-                savedList={true}
-                store={this.props.store}
-              />
+              <div css={list}>
+                <BenefitList
+                  t={t}
+                  currentLanguage={t("current-language-code")}
+                  filteredBenefits={this.props.benefits}
+                  searchString={this.props.searchString}
+                  savedList={true}
+                  store={this.props.store}
+                />
+              </div>
             </Grid>
           </Grid>
         </Container>

--- a/pages/data-validation.js
+++ b/pages/data-validation.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -9,7 +9,8 @@ import Paper from "../components/paper";
 import withI18N from "../lib/i18nHOC";
 import Layout from "../components/layout";
 import { connect } from "react-redux";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import Container from "../components/container";
 import Button from "../components/button";
 import { globalTheme } from "../theme";
@@ -219,8 +220,8 @@ export class DataValidation extends Component {
         url={this.props.url}
       >
         <Container id="mainContent">
-          <p className={envDetailsStyling}>Build: {envDetails}</p>
-          <Paper className={cx(root, top)}>
+          <p css={envDetailsStyling}>Build: {envDetails}</p>
+          <Paper styles={[root, top]}>
             <p>
               {t("dv.last_cache_update")}
               :&nbsp;
@@ -230,8 +231,8 @@ export class DataValidation extends Component {
               <Button id="refreshCache">{t("refresh-cache")}</Button>
             </a>
           </Paper>
-          <Paper className={root}>
-            <Table className={table}>
+          <Paper styles={root}>
+            <Table css={table}>
               <TableHead>
                 <TableRow>
                   <TableCell>{t("dv.status")}</TableCell>
@@ -244,10 +245,10 @@ export class DataValidation extends Component {
                   return (
                     <TableRow key={i} id={n.name}>
                       <TableCell
-                        className={cx(
+                        css={[
                           tableCellCSS,
                           n.status ? tableCellGreen : tableCellRed
-                        )}
+                        ]}
                       >
                         {n.status !== undefined ? (
                           t("dv." + (n.status ? "Pass" : "Fail"))

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import Header from "../components/typography/header";
 import withI18N from "../lib/i18nHOC";
 import Layout from "../components/layout";
 import { globalTheme } from "../theme";
 import Container from "../components/container";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import RadioSelector from "../components/radio_selector";
 import { connect } from "react-redux";
 import HeaderButton from "../components/header_button";
@@ -92,17 +93,17 @@ export class Feedback extends Component {
             onClick={() => {
               window.history.back();
             }}
-            className={prevButton}
+            styles={prevButton}
             arrow="back"
           >
             {t("back")}
           </HeaderButton>
           <form>
-            <Header className={headerPadding} headingLevel="h1" size="lg">
+            <Header styles={headerPadding} headingLevel="h1" size="lg">
               {t("feedback.page_header")}
             </Header>
             <RadioSelector
-              className={radioStyle}
+              styles={radioStyle}
               legend={
                 t("current-language-code") === "en"
                   ? question.display_text_english
@@ -114,7 +115,7 @@ export class Feedback extends Component {
               store={store}
             />
             <TextArea
-              className={textAreaStyle}
+              css={textAreaStyle}
               name="group1"
               maxLength={500}
               t={t}
@@ -124,7 +125,7 @@ export class Feedback extends Component {
             </TextArea>
             <Details
               summary={t("feedback.details_question")}
-              className={detailsStyle}
+              css={detailsStyle}
             >
               {t("feedback.details_expansion_pt1")}
               <a href={t("feedback.vac_office_link")}>
@@ -136,7 +137,7 @@ export class Feedback extends Component {
               </a>
               {t("feedback.details_expansion_pt5")}
             </Details>
-            <div className={padding}>
+            <div css={padding}>
               <Button
                 id="send"
                 arrow={true}

--- a/pages/feedback_submitted.js
+++ b/pages/feedback_submitted.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import Header from "../components/typography/header";
 import withI18N from "../lib/i18nHOC";
 import Layout from "../components/layout";
 import { globalTheme } from "../theme";
 import Container from "../components/container";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { connect } from "react-redux";
 import HeaderLink from "../components/header_link";
 import PropTypes from "prop-types";
@@ -46,11 +47,11 @@ export class FeedbackSubmitted extends Component {
             {t("feedback.page_header")}
           </Header>
 
-          <p className={textStyle}>{t("feedback.submitted")}</p>
+          <p css={textStyle}>{t("feedback.submitted")}</p>
 
           <HeaderLink
             href={mutateUrl(url, "/benefits-directory")}
-            className={headerLinkStyle}
+            css={headerLinkStyle}
           >
             {t("feedback.ben_dir_link")}
           </HeaderLink>

--- a/pages/print.js
+++ b/pages/print.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import { connect } from "react-redux";
@@ -6,7 +6,8 @@ import withI18N from "../lib/i18nHOC";
 import NeedButton from "../components/need_button";
 import WordMark from "../components/word_mark";
 import FIP from "../components/fip";
-import { cx, css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 const root = css`
   font-family: Merriweather, serif;
@@ -165,10 +166,10 @@ export class Print extends Component {
       .join(", ");
 
     return (
-      <div className={root}>
+      <div css={root}>
         <Grid container spacing={24}>
           <Grid item xs={12}>
-            <div className={svgContainer}>
+            <div css={svgContainer}>
               <FIP fillColor="black" t={this.props.t} />
             </div>
           </Grid>
@@ -177,11 +178,11 @@ export class Print extends Component {
             ""
           ) : (
             <Grid item xs={12}>
-              <div className={box}>
-                <div className={bold}>{t("print.who_is_receiving")}</div>
+              <div css={box}>
+                <div css={bold}>{t("print.who_is_receiving")}</div>
                 <div className={"profile_section " + rules}>{profile_text}</div>
 
-                <div className="needs_section">
+                <div css="needs_section">
                   <Grid container spacing={0}>
                     {needs.map((need, i) => (
                       <Grid item xs={4} key={i}>
@@ -200,7 +201,7 @@ export class Print extends Component {
           )}
         </Grid>
 
-        <div className={cx(bigTitle, margins)}>
+        <div css={[bigTitle, margins]}>
           {this.countString(
             sortedFilteredBenefits,
             benefits,
@@ -208,12 +209,12 @@ export class Print extends Component {
             printingFromFavourites
           )}
         </div>
-        <table className={table}>
+        <table css={table}>
           <tbody>
             {sortedFilteredBenefits.map((b, i) => {
               return (
-                <tr key={i} className={benefitRow}>
-                  <td className={benefitCell}>
+                <tr key={i} css={benefitRow}>
+                  <td css={benefitCell}>
                     <div className="benefitsListItem">
                       <div>
                         <b>
@@ -234,27 +235,27 @@ export class Print extends Component {
             })}
           </tbody>
         </table>
-        <Grid container spacing={24} className={gridstyle}>
+        <Grid container spacing={24} css={gridstyle}>
           <Grid item xs={12}>
-            <hr className={hr} />
+            <hr css={hr} />
           </Grid>
           <Grid item xs={12}>
-            <div className={bigTitle}>{t("print.have_any_questions")}</div>
+            <div css={bigTitle}>{t("print.have_any_questions")}</div>
           </Grid>
           <Grid item xs={6}>
-            <div className={title}>{t("favourites.contact_us")}</div>
-            <div className={bold}>{t("contact.phone")}</div>
+            <div css={title}>{t("favourites.contact_us")}</div>
+            <div css={bold}>{t("contact.phone")}</div>
             <div>{t("favourites.call_time")}</div>
             <br />
-            <div className={bold}>{t("contact.email")}</div>
+            <div css={bold}>{t("contact.email")}</div>
             <div>{t("favourites.email_disclaimer")}</div>
             <br />
-            <div className={title}>{t("print.apply_online")}</div>
-            <div className={bold}>{t("contact.my_vac_link")}</div>
+            <div css={title}>{t("print.apply_online")}</div>
+            <div css={bold}>{t("contact.my_vac_link")}</div>
             <div>{t("print.sign_up_for_my_vac")}</div>
           </Grid>
         </Grid>
-        <div className={wordmark}>
+        <div css={wordmark}>
           <WordMark width="6em" flag="#000" />
         </div>
       </div>

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import withI18N from "../lib/i18nHOC";
 import Layout from "../components/layout";
 import PropTypes from "prop-types";
@@ -10,7 +10,8 @@ import Button from "../components/button";
 import Header from "../components/typography/header";
 import Router from "next/router";
 import BreadCrumbs from "../components/breadcrumbs";
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
 import { mutateUrl, getBenefitCountString, getPageName } from "../utils/common";
 import { connect } from "react-redux";
@@ -68,10 +69,10 @@ export class Summary extends Component {
               pageTitle={t("ge.Find benefits and services")}
             />
           </div>
-          <Paper padding="md" className={box}>
+          <Paper padding="md" styles={box}>
             <AlphaBanner t={t} url={url} />
             <Grid container spacing={24}>
-              <Grid item xs={12} className={questions}>
+              <Grid item xs={12} css={questions}>
                 <Header size="md_lg" headingLevel="h2">
                   {t("ge.summary_subtitle")}
                 </Header>
@@ -100,7 +101,7 @@ export class Summary extends Component {
                 </HeaderButton>
               </Grid>
               <Grid item xs={8} md={6}>
-                <div className={alignRight}>
+                <div css={alignRight}>
                   <Button
                     id="nextButton"
                     onClick={() =>

--- a/styles.js
+++ b/styles.js
@@ -1,4 +1,5 @@
-import { css } from "emotion";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
 
 /*This function is usually for hover events and such
   col: is the color in hex

--- a/utils/details_polyfill.js
+++ b/utils/details_polyfill.js
@@ -6,7 +6,7 @@ let detailsPolyfill = () => {
   if (supported) return;
 
   // Add a classname
-  document.documentElement.className += " no-details";
+  document.documentElement.css += " no-details";
 
   window.addEventListener("click", clickHandler);
 


### PR DESCRIPTION
Closes #1994 

Adding this configuration to our theme fixed the warning, which is to do with new behaviour in material ui (MUI) to map headings to h1, h2, etc elements. I checked and we're not using any of the MUI typography components that would be effected so this should make no difference to our app.