### PR TITLE
Update home link in breadcrumbs

### DIFF
--- a/__tests__/components/favourites_test.js
+++ b/__tests__/components/favourites_test.js
@@ -49,7 +49,7 @@ describe("Favourites", () => {
       },
       url: { query: {} },
       printUrl: "/print",
-      geUrl: "/",
+      guidedExperienceUrl: "/",
       saveFavourites: jest.fn()
     };
     _shallowFavourites = undefined;

--- a/__tests__/components/favourites_test.js
+++ b/__tests__/components/favourites_test.js
@@ -49,7 +49,7 @@ describe("Favourites", () => {
       },
       url: { query: {} },
       printUrl: "/print",
-      homeUrl: "/",
+      geUrl: "/",
       saveFavourites: jest.fn()
     };
     _shallowFavourites = undefined;

--- a/components/BB.js
+++ b/components/BB.js
@@ -2,7 +2,7 @@ import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import { connect } from "react-redux";
-import { getPrintUrl, getHomeUrl } from "../selectors/urls";
+import { getPrintUrl, getGeUrl } from "../selectors/urls";
 import { withTheme } from "@material-ui/core/styles";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
@@ -91,11 +91,11 @@ export class BB extends Component {
   }
 
   render() {
-    const { t, url, store, homeUrl, printUrl } = this.props; // eslint-disable-line no-unused-vars
+    const { t, url, store, geUrl, printUrl } = this.props; // eslint-disable-line no-unused-vars
 
     const breadcrumbs = [
       {
-        url: homeUrl,
+        url: geUrl,
         name: t("ge.Find benefits and services")
       }
     ];
@@ -198,7 +198,7 @@ const mapStateToProps = (reduxState, props) => {
     cookiesDisabled: reduxState.cookiesDisabled,
     benefits: reduxState.benefits,
     favouriteBenefits: reduxState.favouriteBenefits,
-    homeUrl: getHomeUrl(reduxState, props),
+    geUrl: getGeUrl(reduxState, props),
     printUrl: getPrintUrl(reduxState, props, {})
   };
 };
@@ -209,7 +209,7 @@ BB.propTypes = {
   setCookiesDisabled: PropTypes.func.isRequired,
   saveFavourites: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
-  homeUrl: PropTypes.string,
+  geUrl: PropTypes.string,
   printUrl: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
   favouriteBenefits: PropTypes.array.isRequired,

--- a/components/BB.js
+++ b/components/BB.js
@@ -2,7 +2,7 @@ import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import { connect } from "react-redux";
-import { getPrintUrl, getGeUrl } from "../selectors/urls";
+import { getPrintUrl, getGuidedExperienceUrl } from "../selectors/urls";
 import { withTheme } from "@material-ui/core/styles";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
@@ -91,11 +91,11 @@ export class BB extends Component {
   }
 
   render() {
-    const { t, url, store, geUrl, printUrl } = this.props; // eslint-disable-line no-unused-vars
+    const { t, url, store, guidedExperienceUrl, printUrl } = this.props; // eslint-disable-line no-unused-vars
 
     const breadcrumbs = [
       {
-        url: geUrl,
+        url: guidedExperienceUrl,
         name: t("ge.Find benefits and services")
       }
     ];
@@ -198,7 +198,7 @@ const mapStateToProps = (reduxState, props) => {
     cookiesDisabled: reduxState.cookiesDisabled,
     benefits: reduxState.benefits,
     favouriteBenefits: reduxState.favouriteBenefits,
-    geUrl: getGeUrl(reduxState, props),
+    guidedExperienceUrl: getGuidedExperienceUrl(reduxState, props),
     printUrl: getPrintUrl(reduxState, props, {})
   };
 };
@@ -209,7 +209,7 @@ BB.propTypes = {
   setCookiesDisabled: PropTypes.func.isRequired,
   saveFavourites: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
-  geUrl: PropTypes.string,
+  guidedExperienceUrl: PropTypes.string,
   printUrl: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
   favouriteBenefits: PropTypes.array.isRequired,

--- a/components/BB.js
+++ b/components/BB.js
@@ -92,14 +92,21 @@ export class BB extends Component {
 
   render() {
     const { t, url, store, homeUrl, printUrl } = this.props; // eslint-disable-line no-unused-vars
+
+    const breadcrumbs = [
+      {
+        url: homeUrl,
+        name: t("ge.Find benefits and services")
+      }
+    ];
+
     return (
       <Container>
         <div className={topMatter}>
           <BreadCrumbs
             t={t}
-            breadcrumbs={[]}
-            homeUrl={homeUrl}
-            pageTitle={t("ge.Find benefits and services")}
+            breadcrumbs={breadcrumbs}
+            pageTitle={t("breadcrumbs.ben_dir_page_title")}
           />
         </div>
         <Paper id={this.props.id} padding="md" styles={innerDiv}>

--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -40,11 +40,11 @@ const currentPageStyle = css`
 
 export class BreadCrumbs extends Component {
   render() {
-    const { breadcrumbs, homeUrl } = this.props;
+    const { breadcrumbs, t } = this.props;
     return (
       <div css={greyBanner}>
         <div>
-          <HeaderLink id="homeButton" href={homeUrl} css={urlStyle}>
+          <HeaderLink id="homeButton" href={t("ge.home_link")} css={urlStyle}>
             {this.props.t("titles.home")}
           </HeaderLink>
           {breadcrumbs.map((breadcrumb, i) => (
@@ -70,8 +70,7 @@ export class BreadCrumbs extends Component {
 BreadCrumbs.propTypes = {
   t: PropTypes.func.isRequired,
   breadcrumbs: PropTypes.array.isRequired,
-  pageTitle: PropTypes.string.isRequired,
-  homeUrl: PropTypes.string
+  pageTitle: PropTypes.string.isRequired
 };
 
 export default BreadCrumbs;

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import BenefitList from "./benefit_list";
 import { connect } from "react-redux";
-import { getPrintUrl, getHomeUrl } from "../selectors/urls";
+import { getPrintUrl, getGeUrl } from "../selectors/urls";
 import Link from "next/link";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
@@ -72,7 +72,7 @@ export class Favourites extends Component {
   };
 
   render() {
-    const { t, url, printUrl, homeUrl, store } = this.props; // eslint-disable-line no-unused-vars
+    const { t, url, printUrl, geUrl, store } = this.props; // eslint-disable-line no-unused-vars
 
     const filteredBenefits = this.filterBenefits(
       this.props.benefits,
@@ -81,7 +81,7 @@ export class Favourites extends Component {
 
     const breadcrumbs = [
       {
-        url: homeUrl,
+        url: geUrl,
         name: t("ge.Find benefits and services")
       },
       {
@@ -213,7 +213,7 @@ const mapStateToProps = (reduxState, props) => {
     cookiesDisabled: reduxState.cookiesDisabled,
     benefits: reduxState.benefits,
     printUrl: getPrintUrl(reduxState, props, { fromFavourites: true }),
-    homeUrl: getHomeUrl(reduxState, props)
+    geUrl: getGeUrl(reduxState, props)
   };
 };
 
@@ -226,7 +226,7 @@ Favourites.propTypes = {
   favouriteBenefits: PropTypes.array.isRequired,
   saveFavourites: PropTypes.func.isRequired,
   url: PropTypes.object.isRequired,
-  homeUrl: PropTypes.string.isRequired,
+  geUrl: PropTypes.string.isRequired,
   store: PropTypes.object
 };
 

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -81,8 +81,12 @@ export class Favourites extends Component {
 
     const breadcrumbs = [
       {
-        url: mutateUrl(url, "/benefits-directory"),
+        url: homeUrl,
         name: t("ge.Find benefits and services")
+      },
+      {
+        url: mutateUrl(url, "/benefits-directory"),
+        name: t("breadcrumbs.ben_dir_page_title")
       }
     ];
 
@@ -91,7 +95,6 @@ export class Favourites extends Component {
         <Container id="favourites">
           <BreadCrumbs
             t={t}
-            homeUrl={homeUrl}
             breadcrumbs={breadcrumbs}
             pageTitle={t("index.your_saved_benefits")}
           />

--- a/components/favourites.js
+++ b/components/favourites.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import BenefitList from "./benefit_list";
 import { connect } from "react-redux";
-import { getPrintUrl, getGeUrl } from "../selectors/urls";
+import { getPrintUrl, getGuidedExperienceUrl } from "../selectors/urls";
 import Link from "next/link";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
@@ -72,7 +72,7 @@ export class Favourites extends Component {
   };
 
   render() {
-    const { t, url, printUrl, geUrl, store } = this.props; // eslint-disable-line no-unused-vars
+    const { t, url, printUrl, guidedExperienceUrl, store } = this.props; // eslint-disable-line no-unused-vars
 
     const filteredBenefits = this.filterBenefits(
       this.props.benefits,
@@ -81,7 +81,7 @@ export class Favourites extends Component {
 
     const breadcrumbs = [
       {
-        url: geUrl,
+        url: guidedExperienceUrl,
         name: t("ge.Find benefits and services")
       },
       {
@@ -213,7 +213,7 @@ const mapStateToProps = (reduxState, props) => {
     cookiesDisabled: reduxState.cookiesDisabled,
     benefits: reduxState.benefits,
     printUrl: getPrintUrl(reduxState, props, { fromFavourites: true }),
-    geUrl: getGeUrl(reduxState, props)
+    guidedExperienceUrl: getGuidedExperienceUrl(reduxState, props)
   };
 };
 
@@ -226,7 +226,7 @@ Favourites.propTypes = {
   favouriteBenefits: PropTypes.array.isRequired,
   saveFavourites: PropTypes.func.isRequired,
   url: PropTypes.object.isRequired,
-  geUrl: PropTypes.string.isRequired,
+  guidedExperienceUrl: PropTypes.string.isRequired,
   store: PropTypes.object
 };
 

--- a/components/guided_experience.js
+++ b/components/guided_experience.js
@@ -16,7 +16,6 @@ import { showQuestion, getPageName } from "../utils/common";
 import HeaderButton from "./header_button";
 import Button from "./button";
 import Link from "next/link";
-import { getHomeUrl } from "../selectors/urls";
 import { AlphaBanner } from "./alpha_banner";
 
 const greyBox = css`
@@ -169,7 +168,7 @@ export class GuidedExperience extends Component {
   }
 
   render() {
-    const { t, url, id, reduxState, homeUrl } = this.props;
+    const { t, url, id, reduxState } = this.props;
     const question = reduxState.questions.filter(
       x => x.variable_name === id
     )[0];
@@ -189,7 +188,6 @@ export class GuidedExperience extends Component {
           <BreadCrumbs
             t={t}
             breadcrumbs={[]}
-            homeUrl={homeUrl}
             pageTitle={t("ge.Find benefits and services")}
           />
         </div>
@@ -271,11 +269,10 @@ export class GuidedExperience extends Component {
   }
 }
 
-const mapStateToProps = (reduxState, props) => {
+const mapStateToProps = reduxState => {
   return {
     reduxState: reduxState,
-    sectionOrder: reduxState.questions.map(x => x.variable_name),
-    homeUrl: getHomeUrl(reduxState, props)
+    sectionOrder: reduxState.questions.map(x => x.variable_name)
   };
 };
 
@@ -286,8 +283,7 @@ GuidedExperience.propTypes = {
   sectionOrder: PropTypes.array.isRequired,
   t: PropTypes.func.isRequired,
   children: PropTypes.object.isRequired,
-  store: PropTypes.object,
-  homeUrl: PropTypes.string
+  store: PropTypes.object
 };
 
 export default connect(mapStateToProps)(GuidedExperience);

--- a/data/data.json
+++ b/data/data.json
@@ -3303,6 +3303,13 @@
       "French": "(fra) The benefits and services you save to this list will remain available only on this device for you to view again.",
       "section": "favourites",
       "key": "quick_links_text"
+    },
+    {
+      "id": "breadcrumbs.ben_dir_page_title",
+      "English": "Results",
+      "French": "(fra) Résultats",
+      "section": "breadcrumbs",
+      "key": "ben_dir_page_title"
     }
   ],
   "questions": [

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -104,7 +104,6 @@ export class Feedback extends Component {
             <BreadCrumbs
               t={t}
               breadcrumbs={[]}
-              homeUrl={homeUrl}
               pageTitle={t("ge.Find benefits and services")}
             />
           </div>

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -17,7 +17,7 @@ import Raven from "raven-js";
 import AlphaBanner from "../components/alpha_banner";
 import Link from "next/link";
 import BreadCrumbs from "../components/breadcrumbs";
-import { getHomeUrl } from "../selectors/urls";
+import { getGeUrl } from "../selectors/urls";
 import Paper from "../components/paper";
 import HeaderLink from "../components/header_link";
 
@@ -87,12 +87,12 @@ export class Feedback extends Component {
   };
 
   render() {
-    const { t, i18n, questions, store, url, homeUrl } = this.props;
+    const { t, i18n, questions, store, url, geUrl } = this.props;
     const question = questions.filter(x => x.variable_name === "feedback")[0];
 
     const breadcrumbs = [
       {
-        url: homeUrl,
+        url: geUrl,
         name: t("ge.Find benefits and services")
       }
     ];
@@ -199,14 +199,14 @@ export class Feedback extends Component {
 const mapStateToProps = (reduxState, props) => {
   return {
     questions: reduxState.questions,
-    homeUrl: getHomeUrl(reduxState, props),
+    geUrl: getGeUrl(reduxState, props),
     betaFeedback: reduxState.betaFeedback
   };
 };
 
 Feedback.propTypes = {
   t: PropTypes.func.isRequired,
-  homeUrl: PropTypes.string,
+  geUrl: PropTypes.string,
   betaFeedback: PropTypes.string.isRequired,
   url: PropTypes.object.isRequired,
   i18n: PropTypes.object.isRequired,

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -89,6 +89,14 @@ export class Feedback extends Component {
   render() {
     const { t, i18n, questions, store, url, homeUrl } = this.props;
     const question = questions.filter(x => x.variable_name === "feedback")[0];
+
+    const breadcrumbs = [
+      {
+        url: homeUrl,
+        name: t("ge.Find benefits and services")
+      }
+    ];
+
     return (
       <Layout
         t={t}
@@ -103,8 +111,8 @@ export class Feedback extends Component {
           <div className={topMatter}>
             <BreadCrumbs
               t={t}
-              breadcrumbs={[]}
-              pageTitle={t("ge.Find benefits and services")}
+              breadcrumbs={breadcrumbs}
+              pageTitle={t("feedback.page_header")}
             />
           </div>
           <Paper id="feedbackPagePaper" padding="md" styles={innerDiv}>

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -17,7 +17,7 @@ import Raven from "raven-js";
 import AlphaBanner from "../components/alpha_banner";
 import Link from "next/link";
 import BreadCrumbs from "../components/breadcrumbs";
-import { getGeUrl } from "../selectors/urls";
+import { getGuidedExperienceUrl } from "../selectors/urls";
 import Paper from "../components/paper";
 import HeaderLink from "../components/header_link";
 
@@ -87,12 +87,12 @@ export class Feedback extends Component {
   };
 
   render() {
-    const { t, i18n, questions, store, url, geUrl } = this.props;
+    const { t, i18n, questions, store, url, guidedExperienceUrl } = this.props;
     const question = questions.filter(x => x.variable_name === "feedback")[0];
 
     const breadcrumbs = [
       {
-        url: geUrl,
+        url: guidedExperienceUrl,
         name: t("ge.Find benefits and services")
       }
     ];
@@ -199,14 +199,14 @@ export class Feedback extends Component {
 const mapStateToProps = (reduxState, props) => {
   return {
     questions: reduxState.questions,
-    geUrl: getGeUrl(reduxState, props),
+    guidedExperienceUrl: getGuidedExperienceUrl(reduxState, props),
     betaFeedback: reduxState.betaFeedback
   };
 };
 
 Feedback.propTypes = {
   t: PropTypes.func.isRequired,
-  geUrl: PropTypes.string,
+  guidedExperienceUrl: PropTypes.string,
   betaFeedback: PropTypes.string.isRequired,
   url: PropTypes.object.isRequired,
   i18n: PropTypes.object.isRequired,

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -18,7 +18,7 @@ import { connect } from "react-redux";
 import GuidedExperienceSummary from "../components/guided_experience_summary";
 import Body from "../components/typography/body";
 import { getFilteredBenefits } from "../selectors/benefits";
-import { getHomeUrl } from "../selectors/urls";
+import { getGeUrl } from "../selectors/urls";
 import AlphaBanner from "../components/alpha_banner";
 
 const box = css`
@@ -44,7 +44,7 @@ export class Summary extends Component {
       reduxState,
       store,
       filteredBenefits,
-      homeUrl
+      geUrl
     } = this.props;
     const prevSection =
       reduxState.patronType === "organization" ? "patronType" : "needs";
@@ -53,7 +53,7 @@ export class Summary extends Component {
 
     const breadcrumbs = [
       {
-        url: homeUrl,
+        url: geUrl,
         name: t("ge.Find benefits and services")
       }
     ];
@@ -133,7 +133,7 @@ const mapStateToProps = (reduxState, props) => {
   return {
     reduxState: reduxState,
     filteredBenefits: getFilteredBenefits(reduxState, props),
-    homeUrl: getHomeUrl(reduxState, props)
+    geUrl: getGeUrl(reduxState, props)
   };
 };
 
@@ -144,7 +144,7 @@ Summary.propTypes = {
   url: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   store: PropTypes.object,
-  homeUrl: PropTypes.string
+  geUrl: PropTypes.string
 };
 
 export default withI18N(connect(mapStateToProps)(Summary));

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -50,6 +50,14 @@ export class Summary extends Component {
       reduxState.patronType === "organization" ? "patronType" : "needs";
     const backUrl = mutateUrl(url, "/" + getPageName(prevSection));
     const benefitsToConsider = getBenefitCountString(filteredBenefits, t);
+
+    const breadcrumbs = [
+      {
+        url: homeUrl,
+        name: t("ge.Find benefits and services")
+      }
+    ];
+
     return (
       <Layout
         i18n={i18n}
@@ -64,8 +72,7 @@ export class Summary extends Component {
           <div>
             <BreadCrumbs
               t={t}
-              breadcrumbs={[]}
-              homeUrl={homeUrl}
+              breadcrumbs={breadcrumbs}
               pageTitle={t("ge.Find benefits and services")}
             />
           </div>

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -18,7 +18,7 @@ import { connect } from "react-redux";
 import GuidedExperienceSummary from "../components/guided_experience_summary";
 import Body from "../components/typography/body";
 import { getFilteredBenefits } from "../selectors/benefits";
-import { getGeUrl } from "../selectors/urls";
+import { getGuidedExperienceUrl } from "../selectors/urls";
 import AlphaBanner from "../components/alpha_banner";
 
 const box = css`
@@ -44,7 +44,7 @@ export class Summary extends Component {
       reduxState,
       store,
       filteredBenefits,
-      geUrl
+      guidedExperienceUrl
     } = this.props;
     const prevSection =
       reduxState.patronType === "organization" ? "patronType" : "needs";
@@ -53,7 +53,7 @@ export class Summary extends Component {
 
     const breadcrumbs = [
       {
-        url: geUrl,
+        url: guidedExperienceUrl,
         name: t("ge.Find benefits and services")
       }
     ];
@@ -133,7 +133,7 @@ const mapStateToProps = (reduxState, props) => {
   return {
     reduxState: reduxState,
     filteredBenefits: getFilteredBenefits(reduxState, props),
-    geUrl: getGeUrl(reduxState, props)
+    guidedExperienceUrl: getGuidedExperienceUrl(reduxState, props)
   };
 };
 
@@ -144,7 +144,7 @@ Summary.propTypes = {
   url: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   store: PropTypes.object,
-  geUrl: PropTypes.string
+  guidedExperienceUrl: PropTypes.string
 };
 
 export default withI18N(connect(mapStateToProps)(Summary));

--- a/selectors/urls.js
+++ b/selectors/urls.js
@@ -47,7 +47,7 @@ export const getFavouritesUrl = createSelector(
   }
 );
 
-export const getGeUrl = createSelector(
+export const getGuidedExperienceUrl = createSelector(
   [
     getProfileFilters,
     getNeedsFilter,

--- a/selectors/urls.js
+++ b/selectors/urls.js
@@ -47,7 +47,7 @@ export const getFavouritesUrl = createSelector(
   }
 );
 
-export const getHomeUrl = createSelector(
+export const getGeUrl = createSelector(
   [
     getProfileFilters,
     getNeedsFilter,


### PR DESCRIPTION
Closes #2010. This PR changes the `Home` breadcrumb href from the guided experience url to the VAC home page url, changes `Find benefits and services` breadcrumb href from the benefits directory page to the first guided experience page, adds a `Results` breadcrumb to replace the previous benefits directory breadcrumb (which used to be `Find benefits and services`), and adds a breadcrumb for the feedback page (`Help us improve`).

It might be worth refactoring the breadcrumbs implementation such that the feedback page breadcrumbs are more flexible. The feedback page is accessible by any page on the site, but the breadcrumbs on the feedback page are currently `Home` > `Find benefits and services` > `Help us improve`. Changing the breadcrumbs to be more dynamic may require keeping track of the current breadcrumb path, without allowing the breadcrumbs to circle back (e.g. `Home` > `Find benefits and services` > `Saved list` > `Help us improve` > `Find benefits and services`. We could store the user's breadcrumbs list in redux, but changes to the breadcrumbs from the user's navigation will require some serious logic to be in place.

An argument for keeping the current breadcrumbs implementation: the user already has the back button option on the feedback page to route to their previous page, and the completion of the the feedback page leads to the feedback submitted page, and then back to the benefits directory. The use cases may require more design input. What do we set the breadcrumbs to in cases such as the one listed above? `Home` > `Find benefits and services` > `Saved list` > `Help us improve` > `Find benefits and services`

 If we decide to change anything about the feedback page breadcrumbs, it can be its own issue.