### PR TITLE
Fixed server error when a table is empty

### DIFF
--- a/utils/airtable_es2015.js
+++ b/utils/airtable_es2015.js
@@ -95,7 +95,9 @@ var hydrateFromAirtable = (exports.hydrateFromAirtable = async function hydrateF
   await Promise.all(promises);
   dataStore["errors"] = [];
   airtableConstants.tableNames.forEach(function(tableName) {
-    fillEmptyValues(dataStore[tableName]);
+    if (dataStore[tableName].length > 0) {
+      fillEmptyValues(dataStore[tableName]);
+    }
   });
 
   // replace ids in linked records


### PR DESCRIPTION
To see this bug, delete all the rows from a table like "questionClearLogic" and notice that `yarn download` fails. This PR fixes that.