### PR TITLE
Removed front-end of saved list feature

### DIFF
--- a/__tests__/components/benefit_card_test.js
+++ b/__tests__/components/benefit_card_test.js
@@ -91,7 +91,7 @@ describe("BenefitCard", () => {
 
   it("Clicking the See More button expands the BenefitExpansion component", () => {
     mountedBenefitCard()
-      .find("HeaderButton")
+      .find("BenefitExpansion")
       .at(0)
       .simulate("click");
     expect(mountedBenefitCard().find("BenefitExpansion").length).toEqual(1);

--- a/__tests__/components/sticky_header_test.js
+++ b/__tests__/components/sticky_header_test.js
@@ -26,16 +26,16 @@ describe("StickyHeader", () => {
     expect(await axe(html)).toHaveNoViolations();
   });
 
-  it("contains saved list text that displays the number of saved list items", async () => {
-    expect(
-      mount(<StickyHeader {...props} />)
-        .find("#savedBenefits")
-        .first()
-        .find("span")
-        .first()
-        .text()
-    ).toContain("0");
-  });
+  // it("contains saved list text that displays the number of saved list items", async () => {
+  //   expect(
+  //     mount(<StickyHeader {...props} />)
+  //       .find("#savedBenefits")
+  //       .first()
+  //       .find("span")
+  //       .first()
+  //       .text()
+  //   ).toContain("0");
+  // });
 
   // it("contains edit selections link", () => {
   //   expect(

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -109,7 +109,7 @@ export class BenefitCard extends Component {
                     : benefit.vacNameFr
                 }
               />
-              {this.props.savedList === false ? (
+              {/* {this.props.savedList === false ? (
                 <FavouriteButton
                   benefit={benefit}
                   toggleOpenState={() => {}}
@@ -117,7 +117,7 @@ export class BenefitCard extends Component {
                   t={t}
                   icon={true}
                 />
-              ) : null}
+              ) : null} */}
             </Header>
             <div css={padding}>
               {needsMet.length > 0 ? <Tag css={tagStyle} /> : null}
@@ -157,7 +157,7 @@ export class BenefitCard extends Component {
               <Grid item xs={12}>
                 <div css={flex}>
                   <LearnMoreButton benefit={benefit} t={t} />
-                  <div css={floatRight}>
+                  {/* <div css={floatRight}>
                     {this.props.savedList ? (
                       <FavouriteButton
                         benefit={benefit}
@@ -166,7 +166,7 @@ export class BenefitCard extends Component {
                         t={t}
                       />
                     ) : null}
-                  </div>
+                  </div> */}
                 </div>
               </Grid>
             </Grid>

--- a/components/benefit_cards.js
+++ b/components/benefit_cards.js
@@ -2,7 +2,7 @@ import { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import Highlighter from "react-highlight-words";
-import FavouriteButton from "./favourite_button";
+//import FavouriteButton from "./favourite_button";
 import Paper from "./paper";
 import { connect } from "react-redux";
 import NeedTag from "./need_tag";
@@ -59,10 +59,10 @@ const flex = css`
     display: flex;
   }
 `;
-const floatRight = css`
-  margin-left: auto;
-  order: 2;
-`;
+// const floatRight = css`
+//   margin-left: auto;
+//   order: 2;
+// `;
 
 const tagStyle = css`
   font-size: 12px !important;

--- a/components/sticky_header.js
+++ b/components/sticky_header.js
@@ -88,7 +88,7 @@ export class StickyHeader extends Component {
                 {t("directory.edit_selections_mobile")}
               </span>
             </HeaderLink> */}
-            <HeaderLink
+            {/* <HeaderLink
               css={savedListStyle}
               id="savedBenefits"
               href={this.props.favouritesUrl}
@@ -96,7 +96,7 @@ export class StickyHeader extends Component {
               <SaveChecked />
               <span css={longText}>{longFavouritesText}</span>
               <span css={shortText}>{shortFavouritesText}</span>
-            </HeaderLink>
+            </HeaderLink> */}
           </Grid>
         </Grid>
       </Grid>

--- a/components/sticky_header.js
+++ b/components/sticky_header.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 import { Grid } from "@material-ui/core";
 import ShareBox from "../components/share_box";
 //import EditIcon from "./icons/Edit";
-import HeaderLink from "./header_link";
-import SaveChecked from "./icons/SaveChecked";
+// import HeaderLink from "./header_link";
+// import SaveChecked from "./icons/SaveChecked";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
 import { globalTheme } from "../theme";
@@ -20,30 +20,30 @@ const sticky = css`
 `;
 
 // if screen size is max.sm or smaller, hide long text
-const longText = css`
-  @media only screen and (max-width: ${globalTheme.max.sm}) {
-    display: none !important;
-  }
-`;
+// const longText = css`
+//   @media only screen and (max-width: ${globalTheme.max.sm}) {
+//     display: none !important;
+//   }
+// `;
 // if screen size is min.sm or larger, hide short text
-const shortText = css`
-  @media only screen and (min-width: ${globalTheme.min.sm}) {
-    display: none !important;
-  }
-`;
+// const shortText = css`
+//   @media only screen and (min-width: ${globalTheme.min.sm}) {
+//     display: none !important;
+//   }
+// `;
 const alignRight = css`
   text-align: right;
 `;
-const savedListStyle = css`
-  margin-left: 50px;
-  padding: 0px;
-  font-size: 20px;
-  color: ${globalTheme.colour.navy};
-  @media only screen and (max-width: ${globalTheme.max.sm}) {
-    font-size: 12px !important;
-    margin-left: 25px;
-  }
-`;
+// const savedListStyle = css`
+//   margin-left: 50px;
+//   padding: 0px;
+//   font-size: 20px;
+//   color: ${globalTheme.colour.navy};
+//   @media only screen and (max-width: ${globalTheme.max.sm}) {
+//     font-size: 12px !important;
+//     margin-left: 25px;
+//   }
+// `;
 /*
 const editStyle = css`
   padding: 0;
@@ -56,14 +56,14 @@ const editStyle = css`
 */
 export class StickyHeader extends Component {
   render() {
-    const { t, url, favouriteBenefits, showShareLink } = this.props;
+    const { t, url, /*favouriteBenefits,*/ showShareLink } = this.props;
 
-    const longFavouritesText = t("favourites.saved_benefits", {
-      x: favouriteBenefits.length
-    });
-    const shortFavouritesText = t("favourites.saved_benefits_mobile", {
-      x: favouriteBenefits.length
-    });
+    // const longFavouritesText = t("favourites.saved_benefits", {
+    //   x: favouriteBenefits.length
+    // });
+    // const shortFavouritesText = t("favourites.saved_benefits_mobile", {
+    //   x: favouriteBenefits.length
+    // });
 
     return (
       <Grid item xs={12} css={sticky}>
@@ -106,7 +106,7 @@ export class StickyHeader extends Component {
 
 const mapStateToProps = (reduxState, props) => {
   return {
-    favouriteBenefits: reduxState.favouriteBenefits,
+    // favouriteBenefits: reduxState.favouriteBenefits,
     favouritesUrl: getFavouritesUrl(reduxState, props),
     summaryUrl: getSummaryUrl(reduxState, props)
   };
@@ -119,8 +119,8 @@ StickyHeader.propTypes = {
   printUrl: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
   store: PropTypes.object,
-  showShareLink: PropTypes.bool,
-  favouriteBenefits: PropTypes.array.isRequired
+  showShareLink: PropTypes.bool
+  // favouriteBenefits: PropTypes.array.isRequired
 };
 
 export default connect(mapStateToProps)(StickyHeader);

--- a/server.js
+++ b/server.js
@@ -135,6 +135,10 @@ Promise.resolve(getAllData()).then(allData => {
         res
           .status(404)
           .send("The Data Validation page only exists on the staging app.");
+      } else if (req.url.includes("favourites") && !staging) {
+        res
+          .status(404)
+          .send("The Favourites page only exists on the staging app.");
       } else {
         const favouriteBenefits = new Cookies(req.headers.cookie).get(
           "favouriteBenefits"


### PR DESCRIPTION
This PR closes #2084. I only commented out the saved list UI parts and made the favourites page inaccessible on the prod environment. I think it's relevant to keep the backend fragments of the saved list feature for now, as some of it will be reusable in the feature which is to replace it.

There will have to be a thorough cleaning to refine the code: #2086