### PR TITLE
Add privacy statements to feedback text boxes

### DIFF
--- a/__tests__/components/feedback_bar_test.js
+++ b/__tests__/components/feedback_bar_test.js
@@ -121,7 +121,9 @@ describe("Feedback bar", () => {
         .find("#feedbackNo")
         .at(0)
         .simulate("click");
-      expect(mountedFeedbackBar().text()).toContain("comment-help-us-improve");
+      expect(mountedFeedbackBar().text()).toContain(
+        "feedback.privacy_statement"
+      );
     });
 
     it("shows the thank you for your feedback text after clicking submit button", () => {

--- a/components/feedbackBar.js
+++ b/components/feedbackBar.js
@@ -65,11 +65,6 @@ const fileBugHeader = css`
   font-weight: normal;
   float: right;
 `;
-const pStyle = css`
-  font-size: 20px;
-  font-weight: normal;
-  font-family: ${globalTheme.fontFamilySansSerif};
-`;
 const textArea = css`
   span {
     color: white;

--- a/components/feedbackBar.js
+++ b/components/feedbackBar.js
@@ -100,8 +100,14 @@ export class FeedbackBar extends Component {
   };
 
   cancelComment = () => {
-    this.setState({ feedbackSubmitted: false });
-    this.setState({ commentFormToggled: false });
+    // this.setState({ feedbackSubmitted: false });
+    // this.setState({ commentFormToggled: false });
+    // this.setState({ commentIsBug: true });
+    this.setState({
+      feedbackSubmitted: false,
+      commentFormToggled: false,
+      commentIsBug: false
+    });
   };
 
   sendComment = () => {
@@ -160,9 +166,10 @@ export class FeedbackBar extends Component {
         {this.state.commentFormToggled ? (
           <div css={CommentBox} role="form">
             <Header size="lg" headingLevel="h2" styles={topHeading}>
-              {t("comment-help-us-improve")}
+              {this.state.commentIsBug
+                ? t("comment-what-went-wrong")
+                : t("feedback.how_can_info_be_more_useful")}
             </Header>
-            <p css={pStyle}>{t("comment-privacy-disclaimer")}</p>
             <div css={TextHold}>
               <TextArea
                 id="commentTextArea"
@@ -176,9 +183,7 @@ export class FeedbackBar extends Component {
                     : this.handleChange("infoBeMoreUseful")
                 }
               >
-                {this.state.commentIsBug
-                  ? t("comment-what-went-wrong")
-                  : t("feedback.how_can_info_be_more_useful")}
+                {t("feedback.privacy_statement")}
               </TextArea>
             </div>
             <br />

--- a/components/feedbackBar.js
+++ b/components/feedbackBar.js
@@ -100,9 +100,6 @@ export class FeedbackBar extends Component {
   };
 
   cancelComment = () => {
-    // this.setState({ feedbackSubmitted: false });
-    // this.setState({ commentFormToggled: false });
-    // this.setState({ commentIsBug: true });
     this.setState({
       feedbackSubmitted: false,
       commentFormToggled: false,

--- a/components/text_area.js
+++ b/components/text_area.js
@@ -16,7 +16,7 @@ const LabelText = styled("span")({
   display: "block",
   clear: "none",
   fontWeight: 400,
-  fontSize: "20px",
+  fontSize: "18px",
   lineHeight: "1.5",
   color: globalTheme.colour.greyishBrown,
   paddingBottom: "5px"

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -139,7 +139,7 @@ export class Feedback extends Component {
                 url={url}
                 feedbackPage
               />
-              <Header headingLevel="h3" size="md" styles={textAreaHeader}>
+              <Header headingLevel="h2" size="md" styles={textAreaHeader}>
                 {t("feedback.tell_us_more")}
               </Header>
               <TextArea

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -60,6 +60,13 @@ const leftMargin = css`
 const textAreaHeader = css`
   margin-top: 50px;
 `;
+const textAreaPStyle = css`
+  margin-top: 0px;
+  margin-left: 5px;
+  font-size: 18px;
+  font-weight: normal;
+  font-family: ${globalTheme.fontFamilySansSerif};
+`;
 
 export class Feedback extends Component {
   state = {
@@ -142,15 +149,14 @@ export class Feedback extends Component {
               <Header headingLevel="h2" size="md" styles={textAreaHeader}>
                 {t("feedback.tell_us_more")}
               </Header>
+              <p css={textAreaPStyle}>{t("feedback.privacy_statement")}</p>
               <TextArea
                 css={textAreaStyle}
                 name="group1"
                 maxLength={500}
                 t={t}
                 onChange={this.handleChange("what_did_you_think")}
-              >
-                {t("feedback.privacy_statement")}
-              </TextArea>
+              />
               <Details
                 summary={t("feedback.details_question")}
                 css={detailsStyle}

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -37,6 +37,7 @@ const textAreaStyle = css`
   max-width: 700px;
 `;
 const detailsStyle = css`
+  font-size: 20px;
   margin-bottom: 30px;
   a {
     color: ${globalTheme.colour.greyishBrown};
@@ -55,6 +56,9 @@ const topMatter = css`
 `;
 const leftMargin = css`
   margin-left: 1.5em;
+`;
+const textAreaHeader = css`
+  margin-top: 50px;
 `;
 
 export class Feedback extends Component {
@@ -135,6 +139,9 @@ export class Feedback extends Component {
                 url={url}
                 feedbackPage
               />
+              <Header headingLevel="h3" size="md" styles={textAreaHeader}>
+                {t("feedback.tell_us_more")}
+              </Header>
               <TextArea
                 css={textAreaStyle}
                 name="group1"
@@ -142,7 +149,7 @@ export class Feedback extends Component {
                 t={t}
                 onChange={this.handleChange("what_did_you_think")}
               >
-                {t("feedback.tell_us_more")}
+                {t("feedback.privacy_statement")}
               </TextArea>
               <Details
                 summary={t("feedback.details_question")}

--- a/pages/feedback.js
+++ b/pages/feedback.js
@@ -61,8 +61,8 @@ const textAreaHeader = css`
   margin-top: 50px;
 `;
 const textAreaPStyle = css`
-  margin-top: 0px;
-  margin-left: 5px;
+  margin-top: 5px;
+  margin-left: 2px;
   font-size: 18px;
   font-weight: normal;
   font-family: ${globalTheme.fontFamilySansSerif};


### PR DESCRIPTION
Closes #2067. Updated the feedback page to accommodate the privacy statement, and updated the feedback bar to match the newest design as a result of the new privacy statement. 

This PR also fixes a bug in the feedback bar, where the "cancel" button onClick event wasn't updating the state of commentIsBug, which was causing "What went wrong?" to sometimes appear in the feedback bar when "no" was clicked. For the user scenario _Did something go wrong > cancel > No_, the text would ask "What went wrong?" but it should be "How can we provide information that is more useful?" 