### PR TITLE
Remove disabled cookies banner

### DIFF
--- a/components/BB.js
+++ b/components/BB.js
@@ -127,7 +127,7 @@ export class BB extends Component {
               <SelectionsEditor t={t} store={store} url={url} />
             </Grid>
             <Grid id="mainContent" item md={8} xs={12}>
-              <Grid container spacing={16}>
+              {/* <Grid container spacing={16}>
                 <Grid item xs={12}>
                   {this.state.showDisabledCookieBanner ? (
                     <DisabledCookiesBanner
@@ -138,7 +138,7 @@ export class BB extends Component {
                     />
                   ) : null}
                 </Grid>
-              </Grid>
+              </Grid> */}
               <BenefitsPane id="BenefitsPane" t={t} store={store} url={url} />
             </Grid>
             <Grid item xs={12}>

--- a/components/BB.js
+++ b/components/BB.js
@@ -8,7 +8,7 @@ import { withTheme } from "@material-ui/core/styles";
 import { css, jsx } from "@emotion/core";
 import Container from "../components/container";
 import { globalTheme } from "../theme";
-import { DisabledCookiesBanner } from "./disabled_cookies_banner";
+// import { DisabledCookiesBanner } from "./disabled_cookies_banner";
 import { areCookiesDisabled } from "../utils/common";
 import BenefitsPane from "./benefits_pane";
 import BreadCrumbs from "../components/breadcrumbs";

--- a/components/BB.js
+++ b/components/BB.js
@@ -127,18 +127,18 @@ export class BB extends Component {
               <SelectionsEditor t={t} store={store} url={url} />
             </Grid>
             <Grid id="mainContent" item md={8} xs={12}>
-              {/* <Grid container spacing={16}>
+              <Grid container spacing={16}>
                 <Grid item xs={12}>
-                  {this.state.showDisabledCookieBanner ? (
+                  {/* {this.state.showDisabledCookieBanner ? (
                     <DisabledCookiesBanner
                       t={t}
                       onClose={() =>
                         this.setState({ showDisabledCookieBanner: false })
                       }
                     />
-                  ) : null}
+                  ) : null} */}
                 </Grid>
-              </Grid> */}
+              </Grid>
               <BenefitsPane id="BenefitsPane" t={t} store={store} url={url} />
             </Grid>
             <Grid item xs={12}>


### PR DESCRIPTION
The _Cookies need to be enabled for this site to save benefits for later_ banner was removed from the benefits directory page on the front-end, but still exists on the back-end. I've added it to the technical debt of #2086, as this is part removing the saved list feature and replacing it. This should be the last part of  #2084.