### PR TITLE
No_results_buttons styling updates

### DIFF
--- a/components/button.js
+++ b/components/button.js
@@ -58,20 +58,17 @@ const StyledButton = styled("button")(
     padding: isSmall ? "6px 10px 4px 12px" : undefined
   }),
   ({ isSecondary }) => ({
-    backgroundColor: isSecondary ? globalTheme.colour.cerulean : undefined,
+    color: isSecondary ? globalTheme.colour.greyishBrown : undefined,
+    backgroundColor: isSecondary ? globalTheme.colour.darkPaleGrey : undefined,
     ":hover": {
-      backgroundColor: isSecondary ? globalTheme.colour.darkGreyBlue : undefined
+      backgroundColor: isSecondary ? globalTheme.colour.navy : undefined
     },
     ":focus": {
-      backgroundColor: isSecondary
-        ? globalTheme.colour.darkGreyBlue
-        : undefined,
+      backgroundColor: isSecondary ? globalTheme.colour.navy : undefined,
       outline: `3px solid ` + globalTheme.colour.focusColour
     },
     ":active": {
-      boxShadow: isSecondary
-        ? `0 0 0 ${globalTheme.colour.darkGreyBlue}`
-        : undefined
+      boxShadow: isSecondary ? `0 0 0 ${globalTheme.colour.navy}` : undefined
     }
   })
 );

--- a/components/no_results_buttons.js
+++ b/components/no_results_buttons.js
@@ -17,6 +17,9 @@ const button = css`
 const orText = css`
   display: inline-block;
   padding: 0 20px;
+  font-family: ${globalTheme.fontFamilySansSerif};
+  font-weight: bold;
+  color: ${globalTheme.colour.greyishBrown};
   margin-bottom: 0;
   @media only screen and (max-width: ${globalTheme.max.sm}) {
     display: none;


### PR DESCRIPTION
Closes #2044. This PR changed the secondary button colours to match the design and updated the "or" font style in no_results_buttons. 

https://app.zeplin.io/project/5acbd659dc553ec84805afd4/screen/5b574e7837337ec3be53302e