### PR TITLE
Removed "Contact Us" button from "no results" message

### DIFF
--- a/__tests__/components/no_results_buttons_test.js
+++ b/__tests__/components/no_results_buttons_test.js
@@ -20,9 +20,9 @@ describe("NoResultsButtons", () => {
     expect(await axe(html)).toHaveNoViolations();
   });
 
-  it("contains 2 buttons", () => {
+  it("contains 1 button", () => {
     expect(
       mount(<NoResultsButtons {...props} />).find("Button").length
-    ).toEqual(2);
+    ).toEqual(1);
   });
 });

--- a/components/no_results_buttons.js
+++ b/components/no_results_buttons.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { css, jsx } from "@emotion/core";
 import Button from "./button";
 import { globalTheme } from "../theme";
-import Body from "./typography/body";
 
 const buttonBar = css`
   margin-top: 40px;

--- a/components/no_results_buttons.js
+++ b/components/no_results_buttons.js
@@ -14,17 +14,6 @@ const button = css`
     margin: 20px;
   }
 `;
-const orText = css`
-  display: inline-block;
-  padding: 0 20px;
-  font-family: ${globalTheme.fontFamilySansSerif};
-  font-weight: bold;
-  color: ${globalTheme.colour.greyishBrown};
-  margin-bottom: 0;
-  @media only screen and (max-width: ${globalTheme.max.sm}) {
-    display: none;
-  }
-`;
 
 const NoResultsButtons = props => {
   return (
@@ -35,12 +24,6 @@ const NoResultsButtons = props => {
         onClick={() => props.clearFilters()}
       >
         {props.t("BenefitsPane.reset_filters")}
-      </Button>
-
-      <Body styles={orText}>{props.t("BenefitsPane.or")}</Body>
-
-      <Button css={button} id="contact_us_button" secondary>
-        {props.t("BenefitsPane.contact_us")}
       </Button>
     </div>
   );


### PR DESCRIPTION
Conversation behind removing the contact us button:

<img width="445" alt="Screen Shot 2019-04-23 at 12 47 00 PM" src="https://user-images.githubusercontent.com/17673146/56595925-e7986e00-65c5-11e9-812c-190fc71878a5.png">

The PR removes the contact us button from the benefits directory page when there are no results. The no_results_button_test was adjusted so it would check for one button, no longer two.