### PR TITLE
Disabled summary page

### DIFF
--- a/cypress/integration/guided_experience_spec.js
+++ b/cypress/integration/guided_experience_spec.js
@@ -17,7 +17,7 @@ describe("Guided Experience", function() {
     cy.url().should("include", "benefits-directory");
   });
 
-  it("can choose some options and get to summary and benefits directory", () => {
+  it("can choose some options and get to benefits directory", () => {
     cy.contains(patronTypeVeteran).click();
     cy.get("#nextButton").click();
     cy.url().should("include", "serviceType?");
@@ -29,9 +29,9 @@ describe("Guided Experience", function() {
     cy.contains(patronTypeVeteran);
   });
 
-  it("can go back from summary and edit answer", () => {
-    cy.visit("summary");
-    cy.get("#edit-patronType").click();
-    cy.contains("Select who would be receiving the benefits.");
-  });
+  // it("can go back from summary and edit answer", () => {
+  //   cy.visit("summary");
+  //   cy.get("#edit-patronType").click();
+  //   cy.contains("Select who would be receiving the benefits.");
+  // });
 });

--- a/server.js
+++ b/server.js
@@ -139,6 +139,10 @@ Promise.resolve(getAllData()).then(allData => {
         res
           .status(404)
           .send("The Favourites page only exists on the staging app.");
+      } else if (req.url.includes("summary") && !staging) {
+        res
+          .status(404)
+          .send("The summary page only exists on the staging app.");
       } else {
         const favouriteBenefits = new Cookies(req.headers.cookie).get(
           "favouriteBenefits"


### PR DESCRIPTION
The summary page is accessible if the user sets the page to /summary in the url. This patch should disable that for prod.

I noticed the summary page was being hit -- most likely by bots accessing the site -- but it shouldn't be available in prod since the edit selections sidebar was added.

<img width="501" alt="Screenshot 2019-04-30 at 3 41 53 PM" src="https://user-images.githubusercontent.com/17673146/56985414-aa505500-6b5e-11e9-866b-4ffd521acb7a.png">
