### PR TITLE
Hot fixes - disabling summary page + styling fixes to fallback page

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -82,13 +82,15 @@ class Layout extends Component {
           <ErrorBoundary>
             <Content>
               <SkipToMainContent skipLink={skipLink} t={t} />
-              <div id="header_css" css={black_bg}>
-                {t("current-language-code") === "en" ? (
-                  <VacHeaderEn t={t} url={url} />
-                ) : (
-                  <VacHeaderFr t={t} url={url} />
-                )}
-              </div>
+              {!this.props.parentIsFallbackPage ? (
+                <div id="header_css" css={black_bg}>
+                  {t("current-language-code") === "en" ? (
+                    <VacHeaderEn t={t} url={url} />
+                  ) : (
+                    <VacHeaderFr t={t} url={url} />
+                  )}
+                </div>
+              ) : null}
               <main id="main">{this.props.children}</main>
             </Content>
             {!this.props.parentIsFallbackPage ? (
@@ -98,13 +100,15 @@ class Layout extends Component {
                 </Container>
               </div>
             ) : null}
-            <div id="footer_styles" css={fontStyle}>
-              {t("current-language-code") === "en" ? (
-                <VacFooterEn />
-              ) : (
-                <VacFooterFr />
-              )}
-            </div>
+            {!this.props.parentIsFallbackPage ? (
+              <div id="footer_styles" css={fontStyle}>
+                {t("current-language-code") === "en" ? (
+                  <VacFooterEn />
+                ) : (
+                  <VacFooterFr />
+                )}
+              </div>
+            ) : null}
           </ErrorBoundary>
           {noScriptTag}
         </div>

--- a/components/layout.js
+++ b/components/layout.js
@@ -91,11 +91,13 @@ class Layout extends Component {
               </div>
               <main id="main">{this.props.children}</main>
             </Content>
-            <div css={backgoundColour1}>
-              <Container>
-                <FeedbackBar t={t} />
-              </Container>
-            </div>
+            {!this.props.parentIsFallbackPage ? (
+              <div css={backgoundColour1}>
+                <Container>
+                  <FeedbackBar t={t} />
+                </Container>
+              </div>
+            ) : null}
             <div id="footer_styles" css={fontStyle}>
               {t("current-language-code") === "en" ? (
                 <VacFooterEn />
@@ -119,7 +121,8 @@ Layout.propTypes = {
   url: PropTypes.object.isRequired,
   skipLink: PropTypes.string.isRequired,
   title: PropTypes.string,
-  backgroundColor: PropTypes.string
+  backgroundColor: PropTypes.string,
+  parentIsFallbackPage: PropTypes.bool
 };
 
 Layout.defaultProps = {

--- a/cypress/integration/guided_experience_spec.js
+++ b/cypress/integration/guided_experience_spec.js
@@ -17,7 +17,7 @@ describe("Guided Experience", function() {
     cy.url().should("include", "benefits-directory");
   });
 
-  it("can choose some options and get to summary and benefits directory", () => {
+  it("can choose some options and get to benefits directory", () => {
     cy.contains(patronTypeVeteran).click();
     cy.get("#nextButton").click();
     cy.url().should("include", "serviceType?");
@@ -29,9 +29,9 @@ describe("Guided Experience", function() {
     cy.contains(patronTypeVeteran);
   });
 
-  it("can go back from summary and edit answer", () => {
-    cy.visit("summary");
-    cy.get("#edit-patronType").click();
-    cy.contains("Select who would be receiving the benefits.");
-  });
+  // it("can go back from summary and edit answer", () => {
+  //   cy.visit("summary");
+  //   cy.get("#edit-patronType").click();
+  //   cy.contains("Select who would be receiving the benefits.");
+  // });
 });

--- a/fallback-pages/browser-incompatible.html
+++ b/fallback-pages/browser-incompatible.html
@@ -1,46 +1,53 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Your browser is not supported | Ton navigateur n'est pas supporté</title>
-    <link href="//cdn.muicss.com/mui-0.9.39-rc1/css/mui.min.css" rel="stylesheet" type="text/css"/>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Your browser is not supported | Ton navigateur n'est pas supporté
+    </title>
+    <link
+      href="//cdn.muicss.com/mui-0.9.39-rc1/css/mui.min.css"
+      rel="stylesheet"
+      type="text/css"
+    />
     <style>
       /**
        * Body CSS
        */
-html,
-body {
-  height: 100%;
-}
-html,
-body
-{
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.004);
-}
-/**
+      html,
+      body {
+        height: 100%;
+      }
+      html,
+      body {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.004);
+      }
+      /**
  * Content CSS
  */
-#content-wrapper {
-  min-height: 100%;
-}
-</style>
-</head>
-<body>
-  <div id="content-wrapper" class="mui--text-center">
-    <br/>
-    <br/>
-    <p>
-      Your current version of this browser is not supported. Please update to the latest version.      
-      To see a list of all benefits click <a href='/all-benefits'>here</a>.
-    </p>
-    <p>
-      Votre version actuelle de ce navigateur n'est pas supportée. S'il vous plaît mettre à jour à la dernière version.
-      Pour voir la liste complète des avantages, cliquez <a href='/all-benefits'>ici</a>.
-    </p>
-  </div>
-</body>
+      #content-wrapper {
+        min-height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="content-wrapper" class="mui--text-center">
+      <br />
+      <br />
+      <p>
+        Your current version of this browser is not supported. Please update to
+        the latest version. To see a list of all benefits click
+        <a href="/all-benefits">here</a>.
+      </p>
+      <p>
+        Votre version actuelle de ce navigateur n'est pas supportée. S'il vous
+        plaît mettre à jour à la dernière version. Pour voir la liste complète
+        des avantages, cliquez <a href="/all-benefits?lng=fr">ici</a>.
+      </p>
+    </div>
+  </body>
 </html>

--- a/pages/all-benefits.js
+++ b/pages/all-benefits.js
@@ -9,6 +9,7 @@ import { connect } from "react-redux";
 import BenefitList from "../components/benefit_list";
 import Container from "../components/container";
 import Header from "../components/typography/header";
+import { globalTheme } from "../theme";
 
 const header = css`
   padding-bottom: 10px;
@@ -28,6 +29,8 @@ export class AllBenefits extends Component {
         title={t("titles.all_benefits")}
         skipLink="#mainContent"
         url={url}
+        backgroundColor={globalTheme.colour.paleGreyTwo}
+        parentIsFallbackPage={true}
       >
         <Container id="mainContent">
           <Header size="xl" headingLevel="h1" paddingTop="30" styles={header}>

--- a/server.js
+++ b/server.js
@@ -139,6 +139,10 @@ Promise.resolve(getAllData()).then(allData => {
         res
           .status(404)
           .send("The Favourites page only exists on the staging app.");
+      } else if (req.url.includes("summary") && !staging) {
+        res
+          .status(404)
+          .send("The summary page only exists on the staging app.");
       } else {
         const favouriteBenefits = new Cookies(req.headers.cookie).get(
           "favouriteBenefits"


### PR DESCRIPTION
This PR disables the summary page on production environment, which should never have been accessible to users at this time. Also closes #2132, addressing some small styling things and temporarily removes the header and footer from /all-benefits, so IE10 users don't see the header and footer without styling.