### PR TITLE
Changed "skip to main content" translation to match VAC site

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -2995,7 +2995,7 @@
     {
       "key": "skipLink",
       "English": "Skip to Main Content",
-      "French": "Aller au contenu principal",
+      "French": "Passer au contenu principal",
       "id": "skipLink",
       "section": ""
     },


### PR DESCRIPTION
Closes #2149.

Updated the translation in AirTable and the data.json file.