### PR TITLE
Upgrade webpack-bundle-analyzer to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "react-test-renderer": "^16.8.6",
     "semantic-release": "^15.13.3",
     "start-server-and-test": "^1.7.13",
-    "webpack-bundle-analyzer": "^3.2.0"
+    "webpack-bundle-analyzer": "^3.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12921,10 +12921,10 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-bundle-analyzer@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.2.0.tgz#0630d298e88511d036d7c823705d7b852593d5c4"
-  integrity sha512-F6bwrg5TBb9HsHZCltH1L5F091ELQ+/i67MEH7jWkYRvVp53eONNneGaIXSdOQUiXUyd3RnkITWRfWvSVQGnZQ==
+webpack-bundle-analyzer@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.3.2.tgz#3da733a900f515914e729fcebcd4c40dde71fc6f"
+  integrity sha512-7qvJLPKB4rRWZGjVp5U1KEjwutbDHSKboAl0IfafnrdXMrgC0tOtZbQD6Rw0u4cmpgRN4O02Fc0t8eAT+FgGzA==
   dependencies:
     acorn "^6.0.7"
     acorn-walk "^6.1.1"


### PR DESCRIPTION
Upgrade webpack-bundle-analyzer to version 3.3.2 or later.

## Details
[WS-2019-0058](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/263)
moderate severity
__Vulnerable versions:__ < 3.3.2
__Patched version:__ 3.3.2

Versions of webpack-bundle-analyzer prior to 3.3.2 are vulnerable to Cross-Site Scripting. The package uses JSON.stringify() without properly escaping input which may lead to Cross-Site Scripting.

