### PR TITLE
Upgraded jest-haste 

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "regenerator-runtime": "^0.13.2",
     "reselect": "^4.0.0",
     "universal-cookie": "^4.0.0",
-    "webpack": "^4.32.2"
+    "webpack": "^4.35.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "express": "^4.17.1",
     "helmet": "^3.18.0",
     "isomorphic-unfetch": "^3.0.0",
-    "jest-haste-map": "^24.8.0",
+    "jest-haste-map": "^24.8.1",
     "jest-resolve": "^24.8.0",
     "js-yaml": "3.13.1",
     "lunr": "^2.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7506,6 +7506,25 @@ jest-haste-map@^24.8.0:
   optionalDependencies:
     fsevents "^1.2.7"
 
+jest-haste-map@^24.8.1:
+  version "24.8.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.8.1.tgz#f39cc1d2b1d907e014165b4bd5a957afcb992982"
+  integrity sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==
+  dependencies:
+    "@jest/types" "^24.8.0"
+    anymatch "^2.0.0"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.15"
+    invariant "^2.2.4"
+    jest-serializer "^24.4.0"
+    jest-util "^24.8.0"
+    jest-worker "^24.6.0"
+    micromatch "^3.1.10"
+    sane "^4.0.3"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
 jest-jasmine2@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz#a9c7e14c83dd77d8b15e820549ce8987cc8cd898"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13795,10 +13795,10 @@ webpack@4.29.0:
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
 
-webpack@^4.32.2:
-  version "4.32.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.32.2.tgz#3639375364a617e84b914ddb2c770aed511e5bc8"
-  integrity sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==
+webpack@^4.35.0:
+  version "4.35.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.35.0.tgz#ad3f0f8190876328806ccb7a36f3ce6e764b8378"
+  integrity sha512-M5hL3qpVvtr8d4YaJANbAQBc4uT01G33eDpl/psRTBCfjxFTihdhin1NtAKB1ruDwzeVdcsHHV3NX+QsAgOosw==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"


### PR DESCRIPTION
Upgraded the jest-haste and webpack dependencies to resolve security vulnerability reported by snyk.
<img width="1129" alt="Screenshot 2019-06-21 at 2 24 34 PM" src="https://user-images.githubusercontent.com/17673146/59940161-552f1200-9430-11e9-9c58-2c5c83b7654f.png">
